### PR TITLE
Ensure video thumbnails render correctly

### DIFF
--- a/components/m/video/VideoCard.jsx
+++ b/components/m/video/VideoCard.jsx
@@ -1,6 +1,8 @@
 import clsx from 'clsx';
 
 export default function VideoCard({ poster, src, title, aspect, disablePlay = false }) {
+    const resolvedPoster = typeof poster === 'string' && poster.trim().length > 0 ? poster : null;
+
     return (
         <div
             className={clsx(
@@ -11,12 +13,19 @@ export default function VideoCard({ poster, src, title, aspect, disablePlay = fa
             {disablePlay ? (
                 // 단순 썸네일 카드
                 <div className="relative">
-                    <img
-                        src={poster}
-                        alt={title}
-                        className="h-full w-full object-cover select-none pointer-events-none"
-                    />
-                    <div className="absolute inset-0 flex items-center justify-center">
+                    {resolvedPoster ? (
+                        <img
+                            src={resolvedPoster}
+                            alt={title}
+                            className="h-full w-full select-none object-cover pointer-events-none"
+                            loading="lazy"
+                        />
+                    ) : (
+                        <div className="flex h-full w-full items-center justify-center bg-slate-900/80 text-sm text-slate-200">
+                            미리보기가 준비되지 않았어요
+                        </div>
+                    )}
+                    <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
                         <svg
                             xmlns="http://www.w3.org/2000/svg"
                             className="h-16 w-16 text-white/80 drop-shadow-lg"
@@ -34,7 +43,7 @@ export default function VideoCard({ poster, src, title, aspect, disablePlay = fa
                     controls
                     preload="metadata"
                     playsInline
-                    poster={poster}
+                    poster={resolvedPoster || undefined}
                 >
                     <source src={src} type="video/mp4" />
                 </video>

--- a/pages/api/admin/list.js
+++ b/pages/api/admin/list.js
@@ -1,11 +1,16 @@
 import { assertAdmin } from './_auth';
 import { list } from '@vercel/blob';
+import { getBlobReadToken } from '@/utils/blobTokens';
 
 export default async function handler(req, res) {
   if (req.method !== 'GET') return res.status(405).end();
   if (!assertAdmin(req, res)) return;
   try {
-    const { blobs } = await list({ prefix: 'content/' });
+    const token = getBlobReadToken();
+    if (!token) {
+      return res.status(503).json({ error: 'Blob access token unavailable' });
+    }
+    const { blobs } = await list({ prefix: 'content/', token });
     // Return only json meta files
     const items = blobs
       .filter((b) => b.pathname.endsWith('.json'))

--- a/utils/blobTokens.js
+++ b/utils/blobTokens.js
@@ -1,0 +1,7 @@
+export function getBlobReadToken() {
+  return process.env.BLOB_READ_WRITE_TOKEN || process.env.BLOB_READ_TOKEN || null;
+}
+
+export function getBlobWriteToken() {
+  return process.env.BLOB_READ_WRITE_TOKEN || null;
+}

--- a/utils/contentSource.js
+++ b/utils/contentSource.js
@@ -1,9 +1,11 @@
 import { list } from '@vercel/blob';
+import { getBlobReadToken } from './blobTokens';
 
 export async function listBlobContent() {
-  if (!process.env.BLOB_READ_WRITE_TOKEN) return [];
+  const token = getBlobReadToken();
+  if (!token) return [];
   try {
-    const { blobs } = await list({ prefix: 'content/' });
+    const { blobs } = await list({ prefix: 'content/', token });
     const metas = blobs.filter((b) => b.pathname.endsWith('.json'));
     const items = await Promise.all(
       metas.map(async (b) => {
@@ -35,14 +37,17 @@ export async function getContentBySlug(slug) {
 }
 
 function normalize(meta) {
+  const normalizedPoster = meta.poster || meta.thumbnail || null;
+  const normalizedThumbnail = meta.thumbnail || normalizedPoster || '';
+
   return {
     slug: meta.slug,
     type: meta.type || 'video',
     src: meta.src || meta.url,
-    poster: meta.poster || null,
+    poster: normalizedPoster,
     title: meta.title || '',
     description: meta.description || '',
-    thumbnail: meta.thumbnail || meta.poster || '',
+    thumbnail: normalizedThumbnail,
     orientation: meta.orientation || 'landscape',
     durationSeconds: Number(meta.durationSeconds) || 0,
     source: meta.source || 'Blob',


### PR DESCRIPTION
## Summary
- normalize meme content so that video posters fall back to available thumbnails
- update the mobile VideoCard to ignore empty poster values and provide a graceful fallback UI
- allow blob-backed content listing to use read-only tokens so local environments can fetch remote data

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2b7c3feb88323953345f046c2f40f