### PR TITLE
Fix share button payload and stabilize view tracking

### DIFF
--- a/components/button/ShareButton.jsx
+++ b/components/button/ShareButton.jsx
@@ -1,22 +1,45 @@
 import IconActionButton from "@/components/button/base/IconActionButton";
 import {ShareIcon} from "@/components/icons";
 
-export default function ShareButton({ t }) {
+function buildShareUrl(slug) {
+    if (typeof window === "undefined") return "";
+    if (!slug) return window.location.href;
+    try {
+        const base = window.location.origin;
+        return `${base}/m/${slug}`;
+    } catch {
+        return window.location.href;
+    }
+}
+
+export default function ShareButton({ t, title, slug }) {
     const handleShare = async () => {
-        if (typeof window === 'undefined') return;
-        const payload = { title: meme.title, url: window.location.href };
+        if (typeof window === "undefined") return;
+
+        const shareTitle = title || (typeof document !== "undefined" ? document.title : "");
+        const shareUrl = buildShareUrl(slug);
+        const payload = {
+            title: shareTitle,
+            url: shareUrl,
+        };
 
         if (navigator.share) {
             try {
                 await navigator.share(payload);
                 return;
-            } catch (err) {
-                if (err?.name === 'AbortError') return;
+            } catch (error) {
+                if (error?.name === "AbortError") return;
+                console.warn("Share dismissed", error);
             }
         }
-        const text = encodeURIComponent(meme.title);
-        const shareUrl = `https://twitter.com/intent/tweet?url=${encodeURIComponent(window.location.href)}&text=${text}`;
-        window.open(shareUrl, '_blank', 'noopener,noreferrer');
+
+        const text = encodeURIComponent(shareTitle);
+        const urlParam = encodeURIComponent(shareUrl);
+        const shareIntent = `https://twitter.com/intent/tweet?url=${urlParam}${text ? `&text=${text}` : ""}`;
+        const newWindow = window.open(shareIntent, "_blank", "noopener,noreferrer");
+        if (!newWindow) {
+            window.alert?.(t("shareFallback"));
+        }
     };
 
     return (


### PR DESCRIPTION
## Summary
- fix the mobile share button to use the current meme metadata and provide a fallback intent when native sharing is unavailable
- reset and refresh view metrics per slug while preventing duplicate increments caused by strict-mode effect replays

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2c434eb9c8323a2fdfc2558a6c616