### PR TITLE
Support image uploads and display

### DIFF
--- a/components/m/RecommendedMemes.jsx
+++ b/components/m/RecommendedMemes.jsx
@@ -49,7 +49,11 @@ export default function RecommendedMemes({t, locale, allMemes, meme }) {
                             )}
                             <span className="absolute left-3 top-3 inline-flex items-center gap-2 rounded-full bg-slate-950/70 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-slate-100">
                 <CompassIcon className="h-3.5 w-3.5" />
-                                {item.type === "video" ? t("meta.video") : t("meta.thread")}
+                                {item.type === "image"
+                                    ? t("meta.image")
+                                    : item.type === "video"
+                                      ? t("meta.video")
+                                      : t("meta.thread")}
               </span>
                         </div>
                         <div className="flex flex-1 flex-col gap-3 p-4">

--- a/components/m/video/VideoCard.jsx
+++ b/components/m/video/VideoCard.jsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import clsx from "clsx";
 
 export default function VideoCard({
@@ -7,12 +7,19 @@ export default function VideoCard({
                                       title,
                                       aspect,
                                       disablePlay = false,
+                                      mediaType = "video",
                                   }) {
     const vRef = useRef(null);
     const [overlay, setOverlay] = useState(true);
 
+    const isImage = mediaType === "image";
+
+    useEffect(() => {
+        setOverlay(true);
+    }, [mediaType, src]);
+
     const play = async () => {
-        if (disablePlay) return; // true면 무시
+        if (disablePlay || isImage) return; // true면 무시
         try {
             await vRef.current?.play();
             setOverlay(false);
@@ -21,8 +28,10 @@ export default function VideoCard({
         }
     };
 
-    const resolvedPoster =
-        typeof poster === "string" && poster.trim().length > 0 ? poster : null;
+    const cleanedPoster = typeof poster === "string" && poster.trim().length > 0 ? poster : null;
+    const cleanedSrc = typeof src === "string" && src.trim().length > 0 ? src : null;
+    const resolvedPoster = cleanedPoster || (isImage ? cleanedSrc : null);
+    const imageSource = isImage ? resolvedPoster || cleanedSrc : null;
 
     return (
         <div
@@ -31,7 +40,20 @@ export default function VideoCard({
                 aspect
             )}
         >
-            {disablePlay ? (
+            {isImage ? (
+                imageSource ? (
+                    <img
+                        src={imageSource}
+                        alt={title || "Uploaded media"}
+                        className="h-full w-full object-cover"
+                        loading="lazy"
+                    />
+                ) : (
+                    <div className="flex h-full w-full items-center justify-center bg-[radial-gradient(circle_at_center,_#6366f1_0%,_#0f172a_70%)] text-sm font-semibold text-slate-100">
+                        이미지 미리보기를 불러오지 못했어요
+                    </div>
+                )
+            ) : disablePlay ? (
                 // 썸네일 + 비디오 느낌 (재생 안 됨)
                 <video
                     className="h-full w-full object-cover pointer-events-none"
@@ -58,24 +80,39 @@ export default function VideoCard({
             {/* 오버레이 아이콘 */}
             {overlay && (
                 <div
-                    onClick={disablePlay ? undefined : play}
+                    onClick={disablePlay || isImage ? undefined : play}
                     className={clsx(
                         "absolute inset-0 grid place-items-center transition",
-                        disablePlay
+                        disablePlay || isImage
                             ? "cursor-default bg-black/20"
                             : "hover:bg-black/10 cursor-pointer"
                     )}
                 >
                     <div className="flex flex-col items-center gap-2 pointer-events-none">
                         <div className="h-20 w-20 rounded-full bg-white/20 backdrop-blur-sm grid place-items-center">
-                            <svg
-                                xmlns="http://www.w3.org/2000/svg"
-                                className="h-12 w-12 text-white drop-shadow-lg"
-                                fill="currentColor"
-                                viewBox="0 0 24 24"
-                            >
-                                <path d="M8 5v14l11-7z" />
-                            </svg>
+                            {isImage ? (
+                                <svg
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    className="h-12 w-12 text-white drop-shadow-lg"
+                                    fill="none"
+                                    viewBox="0 0 24 24"
+                                    stroke="currentColor"
+                                    strokeWidth="1.8"
+                                >
+                                    <rect x="4" y="5" width="16" height="14" rx="2" ry="2" />
+                                    <path d="M8.5 11.5l3 3 2.5-2.5 3.5 3.5" />
+                                    <circle cx="9" cy="9" r="1.5" fill="currentColor" />
+                                </svg>
+                            ) : (
+                                <svg
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    className="h-12 w-12 text-white drop-shadow-lg"
+                                    fill="currentColor"
+                                    viewBox="0 0 24 24"
+                                >
+                                    <path d="M8 5v14l11-7z" />
+                                </svg>
+                            )}
                         </div>
                         {title && (
                             <span className="text-white/90 text-sm font-semibold">

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -7,9 +7,10 @@ const ORIENTATION_MAP = {
 export const getOrientationClass = (orientation) => ORIENTATION_MAP[orientation] || 'aspect-video';
 
 export const formatDuration = (seconds) => {
-  if (!Number.isFinite(seconds)) return null;
-  const mins = Math.floor(seconds / 60);
-  const secs = Math.floor(seconds % 60);
+  const totalSeconds = Number(seconds);
+  if (!Number.isFinite(totalSeconds) || totalSeconds <= 0) return null;
+  const mins = Math.floor(totalSeconds / 60);
+  const secs = Math.floor(totalSeconds % 60);
   return `${mins}:${secs.toString().padStart(2, '0')}`;
 };
 

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -55,6 +55,15 @@ export default function Admin() {
 
   async function registerMeta(blob) {
     const slug = await generateSlug(blob);
+    const contentType = typeof blob?.contentType === 'string' ? blob.contentType : '';
+    const pathname = typeof blob?.pathname === 'string' ? blob.pathname : '';
+    const lowerPathname = pathname.toLowerCase();
+    const lowerUrl = typeof blob?.url === 'string' ? blob.url.toLowerCase() : '';
+    const imageExtPattern = /(\.jpe?g|\.png|\.webp)$/;
+    const hasImageExtension = imageExtPattern.test(lowerPathname) || imageExtPattern.test(lowerUrl);
+    const isImage = contentType.startsWith('image/') || hasImageExtension;
+    const normalizedType = isImage ? 'image' : 'video';
+
     const res = await fetch(`/api/admin/register${qs}`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -63,8 +72,11 @@ export default function Admin() {
         title,
         description,
         url: blob.url,
-        durationSeconds: Number(duration) || 0,
-        orientation
+        durationSeconds: isImage ? 0 : Number(duration) || 0,
+        orientation,
+        type: normalizedType,
+        poster: isImage ? blob.url : null,
+        thumbnail: isImage ? blob.url : null
       })
     });
     if (!res.ok) {

--- a/pages/m/[slug].js
+++ b/pages/m/[slug].js
@@ -111,6 +111,7 @@ export default function MemeDetail({ meme, allMemes }) {
                         src={meme.src}
                         title={meme.title}
                         aspect={mediaAspect}
+                        mediaType={meme.type}
                         disablePlay={true}   // ← true면 썸네일+재생아이콘만
                     />
               </div>

--- a/pages/m/index.js
+++ b/pages/m/index.js
@@ -52,13 +52,19 @@ export default function Home({ memes: memeList }) {
       const relativeTime = publishedDate ? formatRelativeTime(publishedDate, locale) : null;
       const liked = isLiked(meme.slug);
       const likesValue = meme.likes + (liked ? 1 : 0);
+      const typeKey =
+        meme.type === 'image'
+          ? 'image'
+          : meme.type === 'video'
+            ? 'video'
+            : 'thread';
       return {
         ...meme,
         mediaAspect,
-        durationLabel: formatDuration(meme.durationSeconds),
+        durationLabel: typeKey === 'video' ? formatDuration(meme.durationSeconds) : null,
         publishedDate,
         relativeTime,
-        typeLabel: t(`meta.${meme.type === 'video' ? 'video' : 'thread'}`),
+        typeLabel: t(`meta.${typeKey}`),
         likesValue,
         likesDisplay: formatCount(likesValue, locale),
         viewsDisplay: formatCount(meme.views, locale)

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -7,6 +7,7 @@
   "footerText": "Laffy Orbit · crafted for curious moderators and meme scouts.",
   "meta": {
     "video": "Video",
+    "image": "Photo",
     "thread": "Thread",
     "durationLabel": "Duration",
     "sourceLabel": "Source",

--- a/public/locales/ko/common.json
+++ b/public/locales/ko/common.json
@@ -7,6 +7,7 @@
   "footerText": "Laffy Orbit · 크리에이터와 모더레이터를 위한 차세대 밈 허브.",
   "meta": {
     "video": "영상",
+    "image": "사진",
     "thread": "트윗 스레드",
     "durationLabel": "재생 시간",
     "sourceLabel": "출처",


### PR DESCRIPTION
## Summary
- detect image uploads in the admin panel and register metadata with the correct type and preview assets
- update API metadata handling and front-end media card to render uploaded photos alongside videos
- adjust feed labeling, hide zero-length durations, and add translation keys for the new image content type

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2c4b04e848323bafc2beaafeee6e9