### PR TITLE
Adsterra 통계 자동 로딩 및 환경 변수 연동

### DIFF
--- a/pages/api/adsterra/domains.js
+++ b/pages/api/adsterra/domains.js
@@ -1,0 +1,29 @@
+import { fetchAdsterraJson } from '@/utils/adsterraClient';
+
+const TARGET_DOMAIN_ID = (process.env.ADSTERRA_STATS_DOMAIN_ID || process.env.ADSTERRA_DOMAIN_ID || '5609169').trim();
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    const data = await fetchAdsterraJson('/domains.json');
+    const domains = Array.isArray(data?.items)
+      ? data.items
+          .filter((item) => String(item?.id ?? '') === TARGET_DOMAIN_ID)
+          .map((item) => ({
+            id: String(item?.id ?? ''),
+            title: item?.title || '',
+          }))
+      : [];
+    return res.status(200).json({ domains });
+  } catch (error) {
+    return res.status(error.status || 502).json({ error: error.message || 'Failed to load domains.' });
+  }
+}
+
+export const config = {
+  runtime: 'nodejs',
+};

--- a/pages/api/adsterra/placements.js
+++ b/pages/api/adsterra/placements.js
@@ -1,0 +1,38 @@
+import { fetchAdsterraJson } from '@/utils/adsterraClient';
+
+const TARGET_DOMAIN_ID = (process.env.ADSTERRA_STATS_DOMAIN_ID || process.env.ADSTERRA_DOMAIN_ID || '5609169').trim();
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const domainId = typeof req.body?.domainId === 'string' ? req.body.domainId.trim() : '';
+
+  if (!domainId) {
+    return res.status(400).json({ error: 'Missing domain id.' });
+  }
+  if (domainId !== TARGET_DOMAIN_ID) {
+    return res.status(403).json({ error: 'Unsupported domain id.' });
+  }
+
+  try {
+    const data = await fetchAdsterraJson(`/domain/${domainId}/placements.json`);
+    const placements = Array.isArray(data?.items)
+      ? data.items.map((item) => ({
+          id: String(item?.id ?? ''),
+          title: item?.title || '',
+          alias: item?.alias || '',
+          directUrl: item?.direct_url || '',
+        }))
+      : [];
+    return res.status(200).json({ placements });
+  } catch (error) {
+    return res.status(error.status || 502).json({ error: error.message || 'Failed to load placements.' });
+  }
+}
+
+export const config = {
+  runtime: 'nodejs',
+};

--- a/pages/api/adsterra/stats.js
+++ b/pages/api/adsterra/stats.js
@@ -1,0 +1,88 @@
+import { fetchAdsterraJson } from '@/utils/adsterraClient';
+
+const TARGET_DOMAIN_ID = (process.env.ADSTERRA_STATS_DOMAIN_ID || process.env.ADSTERRA_DOMAIN_ID || '5609169').trim();
+
+function buildStatsEndpoint({ domainId, placementId, startDate, endDate, groupBy = ['date'] }) {
+  const params = new URLSearchParams();
+  if (startDate) params.append('start_date', startDate);
+  if (endDate) params.append('finish_date', endDate);
+  if (domainId) params.append('domain', domainId);
+
+  const groupValues = Array.isArray(groupBy) && groupBy.length ? groupBy : ['date'];
+  groupValues.forEach((value) => {
+    if (value) params.append('group_by[]', value);
+  });
+
+  if (placementId) {
+    params.append('placement_ids[]', placementId);
+  }
+
+  const query = params.toString();
+  return `/stats.json${query ? `?${query}` : ''}`;
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const domainId = typeof req.body?.domainId === 'string' ? req.body.domainId.trim() : '';
+  const placementId = typeof req.body?.placementId === 'string' ? req.body.placementId.trim() : '';
+  const startDate = typeof req.body?.startDate === 'string' ? req.body.startDate.trim() : '';
+  const endDate = typeof req.body?.endDate === 'string' ? req.body.endDate.trim() : '';
+  const groupBy = Array.isArray(req.body?.groupBy) ? req.body.groupBy : undefined;
+
+  if (!domainId) {
+    return res.status(400).json({ error: 'Missing domain id.' });
+  }
+  if (domainId !== TARGET_DOMAIN_ID) {
+    return res.status(403).json({ error: 'Unsupported domain id.' });
+  }
+  if (!placementId) {
+    return res.status(400).json({ error: 'Missing placement id.' });
+  }
+  if (!startDate || !endDate) {
+    return res.status(400).json({ error: 'Both start and end dates are required.' });
+  }
+
+  try {
+    const endpoint = buildStatsEndpoint({ domainId, placementId, startDate, endDate, groupBy });
+    const data = await fetchAdsterraJson(endpoint);
+    const items = Array.isArray(data?.items) ? data.items : [];
+    const normalizedItems = [];
+
+    items.forEach((entry) => {
+      if (!entry || typeof entry !== 'object') {
+        return;
+      }
+
+      if (Array.isArray(entry?.items)) {
+        normalizedItems.push(...entry.items);
+        return;
+      }
+
+      if (entry?.value && Array.isArray(entry.value.items)) {
+        normalizedItems.push(...entry.value.items);
+        return;
+      }
+
+      normalizedItems.push(entry);
+    });
+
+    const itemCount = Number.isFinite(Number(data?.itemCount))
+      ? Number(data.itemCount)
+      : normalizedItems.length || items.length;
+    return res.status(200).json({
+      items: normalizedItems.length ? normalizedItems : items,
+      itemCount,
+      raw: data,
+    });
+  } catch (error) {
+    return res.status(error.status || 502).json({ error: error.message || 'Failed to load statistics.' });
+  }
+}
+
+export const config = {
+  runtime: 'nodejs',
+};

--- a/utils/adsterraClient.js
+++ b/utils/adsterraClient.js
@@ -1,0 +1,62 @@
+const API_BASE_URL = 'https://api3.adsterratools.com/publisher';
+
+function resolveEnvToken() {
+  const primary = typeof process.env.ADSTERRA_STATS_API_TOKEN === 'string' ? process.env.ADSTERRA_STATS_API_TOKEN.trim() : '';
+  if (primary) return primary;
+  const fallback = typeof process.env.ADSTERRA_API_TOKEN === 'string' ? process.env.ADSTERRA_API_TOKEN.trim() : '';
+  if (fallback) return fallback;
+  return '';
+}
+
+export function getAdsterraApiToken() {
+  return resolveEnvToken();
+}
+
+function buildUrl(endpoint) {
+  const trimmed = typeof endpoint === 'string' ? endpoint.trim() : '';
+  if (!trimmed) {
+    throw new Error('Endpoint is required');
+  }
+  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+    return trimmed;
+  }
+  const normalized = trimmed.startsWith('/') ? trimmed.slice(1) : trimmed;
+  return `${API_BASE_URL}/${normalized}`;
+}
+
+export async function fetchAdsterraJson(endpoint, token) {
+  const providedToken = typeof token === 'string' ? token.trim() : '';
+  const apiToken = providedToken || resolveEnvToken();
+  if (!apiToken) {
+    throw new Error('Missing Adsterra API token.');
+  }
+
+  const url = buildUrl(endpoint);
+  const response = await fetch(url, {
+    headers: {
+      'X-API-Key': apiToken,
+    },
+  });
+
+  const text = await response.text();
+  let data = null;
+  if (text) {
+    try {
+      data = JSON.parse(text);
+    } catch (error) {
+      data = null;
+    }
+  }
+
+  if (!response.ok) {
+    const message = data?.message || `Adsterra request failed with status ${response.status}`;
+    const err = new Error(message);
+    err.status = response.status;
+    err.data = data;
+    throw err;
+  }
+
+  return data;
+}
+
+export const ADSTERRA_API_BASE_URL = API_BASE_URL;


### PR DESCRIPTION
## Summary
- Vercel 환경 변수로 통계 API 토큰과 도메인 정보를 불러오도록 관리자 통계 탭을 개편했습니다.
- 통계 탭 진입 시 자동으로 laffy.org(5609169) 플레이스먼트와 통계를 새로고침하고, 새로고침/기간 초기화 UX를 정리했습니다.
- Adsterra 프록시 API가 고정 도메인만 허용하고 서버 환경 변수를 기본 토큰으로 사용하도록 업데이트했습니다.

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d65bcecf288323809d7fecb141276d