### PR TITLE
메타 JSON 스키마 마이그레이션 지원

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "migrate:meta": "node scripts/migrate-meta.js"
   },
   "keywords": [],
   "author": "",

--- a/pages/api/admin/register.js
+++ b/pages/api/admin/register.js
@@ -1,5 +1,6 @@
 import { assertAdmin } from './_auth';
 import { put } from '@vercel/blob';
+import { buildLatestMeta, normalizeMeta } from '@/utils/metaNormalizer';
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') return res.status(405).end();
@@ -33,31 +34,41 @@ export default async function handler(req, res) {
       }
     })();
 
-    const resolvedSlug = (slug || existingMeta?.slug || '').trim();
+    const existingNormalized = existingMeta ? normalizeMeta(existingMeta) : null;
+
+    const resolvedSlug = (slug || existingNormalized?.slug || existingMeta?.slug || '').trim();
     if (!resolvedSlug) return res.status(400).json({ error: 'Missing slug' });
 
     const trimmedTitle = typeof title === 'string' && title.trim().length > 0
       ? title.trim()
-      : existingMeta?.title || '';
+      : existingNormalized?.title || existingMeta?.title || '';
     if (!trimmedTitle) return res.status(400).json({ error: 'Missing title' });
 
     const trimmedDescription = typeof description === 'string'
       ? description
-      : typeof existingMeta?.description === 'string'
-        ? existingMeta.description
-        : '';
+      : typeof existingNormalized?.description === 'string' && existingNormalized.description.length > 0
+        ? existingNormalized.description
+        : typeof existingMeta?.description === 'string'
+          ? existingMeta.description
+          : '';
 
     const trimmedUrl = typeof url === 'string' && url.trim().length > 0 ? url.trim() : '';
-    const existingSrc = typeof existingMeta?.src === 'string' ? existingMeta.src : '';
+    const existingSrc = typeof existingNormalized?.src === 'string' && existingNormalized.src.length > 0
+      ? existingNormalized.src
+      : typeof existingMeta?.src === 'string'
+        ? existingMeta.src
+        : '';
     const existingUrlFallback = typeof existingMeta?.url === 'string' ? existingMeta.url : '';
     const resolvedSrc = trimmedUrl || existingSrc || existingUrlFallback;
     if (!resolvedSrc) return res.status(400).json({ error: 'Missing source URL' });
 
     const baseType = typeof rawType === 'string' && rawType.trim().length > 0
       ? rawType.trim()
-      : typeof existingMeta?.type === 'string'
-        ? existingMeta.type
-        : '';
+      : typeof existingNormalized?.type === 'string' && existingNormalized.type.length > 0
+        ? existingNormalized.type
+        : typeof existingMeta?.type === 'string'
+          ? existingMeta.type
+          : '';
 
     const normalizedType = baseType.toLowerCase() === 'image' ? 'image' : 'video';
 
@@ -68,8 +79,16 @@ export default async function handler(req, res) {
 
     const posterInput = typeof rawPoster === 'string' && rawPoster.trim().length > 0 ? rawPoster.trim() : '';
     const thumbnailInput = typeof rawThumbnail === 'string' && rawThumbnail.trim().length > 0 ? rawThumbnail.trim() : '';
-    const posterExisting = typeof existingMeta?.poster === 'string' ? existingMeta.poster : '';
-    const thumbnailExisting = typeof existingMeta?.thumbnail === 'string' ? existingMeta.thumbnail : '';
+    const posterExisting = typeof existingNormalized?.poster === 'string' && existingNormalized.poster.length > 0
+      ? existingNormalized.poster
+      : typeof existingMeta?.poster === 'string'
+        ? existingMeta.poster
+        : '';
+    const thumbnailExisting = typeof existingNormalized?.thumbnail === 'string' && existingNormalized.thumbnail.length > 0
+      ? existingNormalized.thumbnail
+      : typeof existingMeta?.thumbnail === 'string'
+        ? existingMeta.thumbnail
+        : '';
 
     const resolvedPoster =
       effectiveType === 'image'
@@ -83,13 +102,16 @@ export default async function handler(req, res) {
 
     const resolvedDuration = (() => {
       if (durationSeconds !== undefined && durationSeconds !== null && durationSeconds !== '') {
-        if (typeof durationSeconds === 'number') return durationSeconds;
+        if (typeof durationSeconds === 'number') return Math.max(0, Math.round(durationSeconds));
         const parsed = Number(durationSeconds);
-        if (Number.isFinite(parsed)) return parsed;
-        return durationSeconds;
+        if (Number.isFinite(parsed)) return Math.max(0, Math.round(parsed));
+      }
+      if (existingNormalized && typeof existingNormalized.durationSeconds === 'number') {
+        return Math.max(0, Math.round(existingNormalized.durationSeconds));
       }
       if (existingMeta && Object.prototype.hasOwnProperty.call(existingMeta, 'durationSeconds')) {
-        return existingMeta.durationSeconds;
+        const parsed = Number(existingMeta.durationSeconds);
+        if (Number.isFinite(parsed)) return Math.max(0, Math.round(parsed));
       }
       return 0;
     })();
@@ -98,42 +120,69 @@ export default async function handler(req, res) {
     const viewsNumber = Number(views);
     const resolvedLikes = Number.isFinite(likesNumber)
       ? Math.max(0, Math.round(likesNumber))
-      : Number.isFinite(Number(existingMeta?.likes))
-        ? Math.max(0, Math.round(Number(existingMeta.likes)))
-        : 0;
+      : Number.isFinite(Number(existingNormalized?.likes))
+        ? Math.max(0, Math.round(Number(existingNormalized.likes)))
+        : Number.isFinite(Number(existingMeta?.likes))
+          ? Math.max(0, Math.round(Number(existingMeta.likes)))
+          : 0;
     const resolvedViews = Number.isFinite(viewsNumber)
       ? Math.max(0, Math.round(viewsNumber))
-      : Number.isFinite(Number(existingMeta?.views))
-        ? Math.max(0, Math.round(Number(existingMeta.views)))
-        : 0;
+      : Number.isFinite(Number(existingNormalized?.views))
+        ? Math.max(0, Math.round(Number(existingNormalized.views)))
+        : Number.isFinite(Number(existingMeta?.views))
+          ? Math.max(0, Math.round(Number(existingMeta.views)))
+          : 0;
     const resolvedPublishedAt = typeof publishedAt === 'string' && publishedAt.trim().length > 0
       ? publishedAt
-      : typeof existingMeta?.publishedAt === 'string' && existingMeta.publishedAt.trim().length > 0
-        ? existingMeta.publishedAt
-        : new Date().toISOString();
+      : typeof existingNormalized?.publishedAt === 'string' && existingNormalized.publishedAt.trim().length > 0
+        ? existingNormalized.publishedAt
+        : typeof existingMeta?.publishedAt === 'string' && existingMeta.publishedAt.trim().length > 0
+          ? existingMeta.publishedAt
+          : new Date().toISOString();
 
     const resolvedOrientation = typeof orientation === 'string' && orientation.trim().length > 0
       ? orientation.trim()
-      : typeof existingMeta?.orientation === 'string' && existingMeta.orientation.trim().length > 0
-        ? existingMeta.orientation
-        : 'landscape';
+      : typeof existingNormalized?.orientation === 'string' && existingNormalized.orientation.trim().length > 0
+        ? existingNormalized.orientation
+        : typeof existingMeta?.orientation === 'string' && existingMeta.orientation.trim().length > 0
+          ? existingMeta.orientation
+          : 'landscape';
 
-    const meta = {
-      ...existingMeta,
+    const normalizedForSave = {
       slug: resolvedSlug,
       type: effectiveType,
       src: resolvedSrc,
       poster: resolvedPoster || null,
-      title: trimmedTitle,
-      description: trimmedDescription,
       thumbnail: resolvedThumbnail || null,
       orientation: resolvedOrientation,
       durationSeconds: resolvedDuration,
-      source: existingMeta?.source || 'Blob',
       publishedAt: resolvedPublishedAt,
       likes: resolvedLikes,
-      views: resolvedViews
+      views: resolvedViews,
+      title: trimmedTitle,
+      description: trimmedDescription,
+      summary: trimmedDescription,
+      source: existingNormalized?.source || existingMeta?.source || 'Blob',
+      updatedAt: existingNormalized?.updatedAt || null,
+      schemaVersion: existingNormalized?.schemaVersion || null,
     };
+
+    const meta = buildLatestMeta(normalizedForSave, {
+      cardTitle: trimmedDescription,
+      socialTitle: trimmedTitle,
+      summary: trimmedDescription,
+      runtimeSec: resolvedDuration,
+      publishedAt: resolvedPublishedAt,
+      updatedAt: existingNormalized ? new Date().toISOString() : undefined,
+      previewUrl: resolvedPoster,
+      thumbUrl: resolvedThumbnail,
+      sourceOrigin: typeof normalizedForSave.source === 'string' ? normalizedForSave.source : 'Blob',
+      likes: resolvedLikes,
+      views: resolvedViews,
+      type: effectiveType,
+      assetUrl: resolvedSrc,
+      orientation: resolvedOrientation,
+    });
     const folder = effectiveType === 'image' ? 'images' : 'videos';
 
     let keyFromMetaUrl = null;
@@ -151,7 +200,7 @@ export default async function handler(req, res) {
 
     const key = keyFromMetaUrl || `content/${folder}/${resolvedSlug}.json`;
 
-    await put(key, JSON.stringify(meta), {
+    await put(key, JSON.stringify(meta, null, 2), {
       token: process.env.BLOB_READ_WRITE_TOKEN,
       access: 'public',
       contentType: 'application/json',

--- a/scripts/migrate-meta.js
+++ b/scripts/migrate-meta.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+const { list, put } = require('@vercel/blob');
+const { buildLatestMeta, normalizeMeta, LATEST_SCHEMA_VERSION } = require('../utils/metaNormalizer');
+
+async function main() {
+  const token = process.env.BLOB_READ_WRITE_TOKEN;
+  if (!token) {
+    console.error('[migrate-meta] BLOB_READ_WRITE_TOKEN is required to run this script.');
+    process.exit(1);
+  }
+
+  const { blobs } = await list({ prefix: 'content/', token });
+  const metaFiles = blobs.filter((blob) => blob.pathname.endsWith('.json'));
+
+  let updatedCount = 0;
+  let skippedCount = 0;
+  let failedCount = 0;
+
+  for (const blob of metaFiles) {
+    try {
+      const res = await fetch(blob.url, { cache: 'no-store' });
+      if (!res.ok) {
+        failedCount += 1;
+        console.warn(`[migrate-meta] Failed to fetch ${blob.pathname}: ${res.status}`);
+        continue;
+      }
+
+      const meta = await res.json();
+      const normalized = normalizeMeta(meta);
+      if (!normalized) {
+        failedCount += 1;
+        console.warn(`[migrate-meta] Skipping ${blob.pathname}: unable to normalize`);
+        continue;
+      }
+
+      if (meta && meta.schemaVersion === LATEST_SCHEMA_VERSION) {
+        skippedCount += 1;
+        continue;
+      }
+
+      const latest = buildLatestMeta({
+        ...normalized,
+        summary: normalized.summary || normalized.description,
+      });
+
+      await put(blob.pathname, JSON.stringify(latest, null, 2), {
+        token,
+        access: 'public',
+        contentType: 'application/json',
+        addRandomSuffix: false,
+        allowOverwrite: true,
+      });
+
+      updatedCount += 1;
+    } catch (error) {
+      failedCount += 1;
+      console.error(`[migrate-meta] Failed to migrate ${blob.pathname}:`, error);
+    }
+  }
+
+  console.log(`[migrate-meta] Completed. updated=${updatedCount}, skipped=${skippedCount}, failed=${failedCount}`);
+}
+
+main().catch((error) => {
+  console.error('[migrate-meta] Unexpected error:', error);
+  process.exit(1);
+});

--- a/utils/contentSource.js
+++ b/utils/contentSource.js
@@ -1,6 +1,7 @@
 import { list } from '@vercel/blob';
 import { getBlobReadToken } from './blobTokens';
 import localMemes from './localMemes';
+import { normalizeMeta } from './metaNormalizer';
 
 const isProduction = process.env.NODE_ENV === 'production';
 
@@ -19,7 +20,7 @@ export async function listBlobContent() {
           const res = await fetch(b.url);
           if (!res.ok) return null;
           const m = await res.json();
-          return normalize(m);
+          return normalizeMeta(m);
         } catch {
           return null;
         }
@@ -48,29 +49,10 @@ export async function getContentBySlug(slug) {
 
 function getLocalFallback() {
   return {
-    items: localMemes.map((item) => ({ ...item })),
+    items: localMemes
+      .map((item) => normalizeMeta(item))
+      .filter(Boolean),
     source: 'local'
-  };
-}
-
-function normalize(meta) {
-  const normalizedPoster = meta.poster || meta.thumbnail || null;
-  const normalizedThumbnail = meta.thumbnail || normalizedPoster || '';
-
-  return {
-    slug: meta.slug,
-    type: meta.type || 'video',
-    src: meta.src || meta.url,
-    poster: normalizedPoster,
-    title: meta.title || '',
-    description: meta.description || '',
-    thumbnail: normalizedThumbnail,
-    orientation: meta.orientation || 'landscape',
-    durationSeconds: Number(meta.durationSeconds) || 0,
-    source: meta.source || 'Blob',
-    publishedAt: meta.publishedAt || new Date().toISOString(),
-    likes: Number(meta.likes) || 0,
-    views: Number(meta.views) || 0
   };
 }
 

--- a/utils/metaNormalizer.js
+++ b/utils/metaNormalizer.js
@@ -1,0 +1,235 @@
+const LATEST_SCHEMA_VERSION = '2024-05';
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function pickFirstString(...candidates) {
+  for (const candidate of candidates) {
+    if (isNonEmptyString(candidate)) {
+      return candidate.trim();
+    }
+  }
+  return '';
+}
+
+function toFiniteNumber(value) {
+  if (value === null || value === undefined || value === '') return null;
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function toPositiveInt(value, fallback = 0) {
+  const num = toFiniteNumber(value);
+  if (num === null) return Math.max(0, Math.round(fallback));
+  return Math.max(0, Math.round(num));
+}
+
+function toOptionalPositiveInt(value) {
+  const num = toFiniteNumber(value);
+  if (num === null) return null;
+  return Math.max(0, Math.round(num));
+}
+
+function normalizeType(value) {
+  if (!isNonEmptyString(value)) return 'video';
+  const lower = value.trim().toLowerCase();
+  if (lower === 'image') return 'image';
+  if (lower === 'video') return 'video';
+  return lower || 'video';
+}
+
+function normalizeMeta(meta) {
+  if (!meta || typeof meta !== 'object') {
+    return null;
+  }
+
+  const schemaVersion = isNonEmptyString(meta.schemaVersion) ? meta.schemaVersion.trim() : null;
+  if (schemaVersion) {
+    return normalizeV2(meta, schemaVersion);
+  }
+  return normalizeV1(meta);
+}
+
+function normalizeV1(meta) {
+  const slug = pickFirstString(meta.slug);
+  if (!slug) return null;
+
+  const type = normalizeType(meta.type);
+  const src = pickFirstString(meta.src, meta.url, meta.assetUrl);
+  if (!src) return null;
+
+  const poster = pickFirstString(meta.poster, meta.thumbnail);
+  const thumbnail = pickFirstString(meta.thumbnail, poster, src);
+  const orientation = pickFirstString(meta.orientation, 'landscape');
+  const durationSeconds = toPositiveInt(meta.durationSeconds, 0);
+  const publishedAt = pickFirstString(meta.publishedAt);
+  const likes = toPositiveInt(meta.likes, 0);
+  const views = toPositiveInt(meta.views, 0);
+  const source = pickFirstString(meta.source, 'Blob');
+
+  return {
+    slug,
+    type,
+    src,
+    poster: poster || null,
+    thumbnail: thumbnail || null,
+    orientation: orientation || 'landscape',
+    durationSeconds,
+    source,
+    publishedAt: publishedAt || new Date().toISOString(),
+    likes,
+    views,
+    schemaVersion: null,
+    updatedAt: null,
+    title: pickFirstString(meta.title, slug),
+    description: pickFirstString(meta.description, ''),
+    summary: pickFirstString(meta.summary, meta.description, ''),
+  };
+}
+
+function normalizeV2(meta, schemaVersion) {
+  const display = meta.display && typeof meta.display === 'object' ? meta.display : {};
+  const media = meta.media && typeof meta.media === 'object' ? meta.media : {};
+  const timestamps = meta.timestamps && typeof meta.timestamps === 'object' ? meta.timestamps : {};
+  const metrics = meta.metrics && typeof meta.metrics === 'object' ? meta.metrics : {};
+
+  const slug = pickFirstString(meta.slug);
+  if (!slug) return null;
+
+  const type = normalizeType(meta.type);
+  const assetUrl = pickFirstString(media.assetUrl, meta.src, meta.url, meta.asset);
+  if (!assetUrl) return null;
+
+  const previewUrl = pickFirstString(media.previewUrl, media.poster, meta.poster);
+  const thumbUrl = pickFirstString(media.thumbUrl, media.thumbnail, meta.thumbnail, previewUrl, assetUrl);
+
+  const orientation = pickFirstString(media.orientation, meta.orientation, 'landscape');
+  const runtime = toPositiveInt(display.runtimeSec, toPositiveInt(meta.durationSeconds, 0));
+  const publishedAt = pickFirstString(timestamps.publishedAt, meta.publishedAt);
+  const updatedAt = pickFirstString(timestamps.updatedAt, meta.updatedAt);
+  const likes = metrics.likes !== undefined ? toPositiveInt(metrics.likes, 0) : toPositiveInt(meta.likes, 0);
+  const views = metrics.views !== undefined ? toPositiveInt(metrics.views, 0) : toPositiveInt(meta.views, 0);
+  const sourceOrigin = pickFirstString(
+    typeof meta.source === 'object' && meta.source ? meta.source.origin : '',
+    typeof meta.source === 'string' ? meta.source : '',
+    'Blob'
+  );
+
+  const socialTitle = pickFirstString(display.socialTitle, meta.title, slug);
+  const cardTitle = pickFirstString(display.cardTitle, meta.description, socialTitle);
+  const summary = pickFirstString(display.summary, cardTitle);
+
+  return {
+    slug,
+    type,
+    src: assetUrl,
+    poster: previewUrl || null,
+    thumbnail: thumbUrl || null,
+    orientation: orientation || 'landscape',
+    durationSeconds: runtime,
+    source: sourceOrigin,
+    publishedAt: publishedAt || new Date().toISOString(),
+    likes,
+    views,
+    schemaVersion,
+    updatedAt: updatedAt || null,
+    title: socialTitle || cardTitle || slug,
+    description: cardTitle || summary || '',
+    summary,
+  };
+}
+
+function buildLatestMeta(normalizedInput, overrides = {}) {
+  const normalized = normalizeMeta(normalizedInput) || normalizedInput;
+  if (!normalized || typeof normalized !== 'object') {
+    throw new Error('Cannot build schema: invalid normalized meta');
+  }
+
+  const slug = pickFirstString(overrides.slug, normalized.slug);
+  if (!slug) {
+    throw new Error('Cannot build schema: missing slug');
+  }
+
+  const type = normalizeType(overrides.type || normalized.type);
+  const assetUrl = pickFirstString(overrides.assetUrl, normalized.src);
+  if (!assetUrl) {
+    throw new Error('Cannot build schema: missing assetUrl');
+  }
+
+  const orientation = pickFirstString(overrides.orientation, normalized.orientation, 'landscape');
+  const runtime = toPositiveInt(overrides.runtimeSec, normalized.durationSeconds || 0);
+  const publishedAt = pickFirstString(overrides.publishedAt, normalized.publishedAt, new Date().toISOString());
+  const updatedAt = pickFirstString(overrides.updatedAt, normalized.updatedAt || '');
+  const cardTitle = pickFirstString(overrides.cardTitle, normalized.description, normalized.title, slug);
+  const socialTitle = pickFirstString(overrides.socialTitle, normalized.title, cardTitle, slug);
+  const summary = pickFirstString(overrides.summary, normalized.summary, cardTitle);
+  const previewUrl = pickFirstString(overrides.previewUrl, normalized.poster, type === 'image' ? assetUrl : '');
+  const thumbUrl = pickFirstString(overrides.thumbUrl, normalized.thumbnail, previewUrl, assetUrl);
+  const likes = overrides.likes !== undefined ? overrides.likes : normalized.likes;
+  const views = overrides.views !== undefined ? overrides.views : normalized.views;
+  const sourceOrigin = pickFirstString(
+    overrides.sourceOrigin,
+    typeof normalized.source === 'string' ? normalized.source : '',
+    'Blob'
+  );
+
+  const schemaVersion = pickFirstString(overrides.schemaVersion, normalized.schemaVersion, LATEST_SCHEMA_VERSION);
+
+  const result = {
+    schemaVersion,
+    slug,
+    type,
+    display: {
+      cardTitle: cardTitle || slug,
+      socialTitle: socialTitle || cardTitle || slug,
+      summary: summary || cardTitle || '',
+      runtimeSec: runtime,
+    },
+    media: {
+      assetUrl,
+      orientation: orientation || 'landscape',
+    },
+    timestamps: {
+      publishedAt,
+    },
+    source: {
+      origin: sourceOrigin || 'Blob',
+    },
+  };
+
+  if (updatedAt) {
+    result.timestamps.updatedAt = updatedAt;
+  }
+
+  if (previewUrl && previewUrl !== assetUrl) {
+    result.media.previewUrl = previewUrl;
+  }
+
+  const effectiveThumb = thumbUrl && thumbUrl !== (result.media.previewUrl || assetUrl)
+    ? thumbUrl
+    : null;
+  if (effectiveThumb) {
+    result.media.thumbUrl = effectiveThumb;
+  }
+
+  const likesNumber = toOptionalPositiveInt(likes);
+  const viewsNumber = toOptionalPositiveInt(views);
+  const metrics = {};
+  if (likesNumber !== null) metrics.likes = likesNumber;
+  if (viewsNumber !== null) metrics.views = viewsNumber;
+  if (Object.keys(metrics).length > 0) {
+    result.metrics = metrics;
+  }
+
+  return result;
+}
+
+module.exports = {
+  LATEST_SCHEMA_VERSION,
+  normalizeMeta,
+  buildLatestMeta,
+};


### PR DESCRIPTION
## 요약
- 신규 `metaNormalizer` 유틸을 도입해 구·신 스키마를 모두 평탄화하도록 정리했습니다.
- 관리자 업로드 및 콘텐츠 로딩 로직을 최신 스키마에 맞춰 갱신하고 업데이트 시점을 기록합니다.
- Blob에 저장된 메타 파일을 일괄 변환할 수 있도록 마이그레이션 스크립트를 추가했습니다.

## 테스트
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d65e3cccbc8323b8c6aecabe7ea8d1