### PR TITLE
x 상세 페이지 헤더 및 광고 동작 개선

### DIFF
--- a/components/ads/RelishAtOptionsFrame.jsx
+++ b/components/ads/RelishAtOptionsFrame.jsx
@@ -10,9 +10,28 @@ export default function RelishAtOptionsFrame({
 }) {
   const slotRef = useRef(null);
   useEffect(() => {
+    const slotEl = slotRef.current;
+    if (slotEl) {
+      slotEl.innerHTML = '';
+    }
+
+    let previousAtOptions;
+    let restored = false;
+    const restoreAtOptions = () => {
+      if (restored) return;
+      restored = true;
+      try {
+        if (typeof previousAtOptions === 'undefined') {
+          delete window.atOptions;
+        } else {
+          window.atOptions = previousAtOptions;
+        }
+      } catch {}
+    };
+
     // Set global atOptions required by the network
     try {
-      // eslint-disable-next-line no-undef
+      previousAtOptions = window.atOptions;
       window.atOptions = {
         key: keyId,
         format: 'iframe',
@@ -25,9 +44,12 @@ export default function RelishAtOptionsFrame({
     const s = document.createElement('script');
     s.type = 'text/javascript';
     s.src = `${srcBase}/${keyId}/invoke.js`;
+    s.onload = restoreAtOptions;
+    s.onerror = restoreAtOptions;
     const parent = slotRef.current || document.body;
     parent.appendChild(s);
     return () => {
+      restoreAtOptions();
       try { parent.removeChild(s); } catch {}
     };
   }, [height, keyId, params, srcBase, width]);

--- a/components/m/MemeDetailPage.jsx
+++ b/components/m/MemeDetailPage.jsx
@@ -12,7 +12,9 @@ import VideoCard from "@/components/x/video/VideoCard";
 import TitleNameHead from "@/components/m/TitleNameHead";
 import LogoText from "@/components/LogoText";
 import RecommendedMemes from "@/components/m/RecommendedMemes";
-import BannerAdsMonetag from "@/components/ads/BannerAdsMonetag";
+import dynamic from "next/dynamic";
+
+const BannerRect = dynamic(() => import("@/components/ads/RelishAtOptionsFrame"), { ssr: false });
 
 export default function MemeDetailPage({
   meme,
@@ -188,8 +190,8 @@ export default function MemeDetailPage({
           {/*  <LocaleSwitchButton locale={locale} />*/}
           {/*</div>*/}
 
-          <div className="mt-6 mb-3 text-center">
-            <LogoText size={'3xl'} />
+          <div className="mt-6 mb-6 text-center">
+            <LogoText size={'5xl'} className="tracking-[0.4em]" />
           </div>
 
           {navItems.length > 0 && (
@@ -233,7 +235,9 @@ export default function MemeDetailPage({
              </nav>
           )}
 
-          <BannerAdsMonetag />
+          <div className="mt-6 flex justify-center">
+            <BannerRect width={300} height={250} />
+          </div>
 
           {hideBackToFeed ? (backSlot ?? null) : (
             <BackToFeedLink href="/x" label={t("backToFeed")} />


### PR DESCRIPTION
## 요약
- x 상세 페이지 상단 로고 영역을 확대하고 여백을 조정했습니다.
- 카테고리 바로 아래에 300x250 배너가 노출되도록 하고, 기존 배너 스크립트 충돌을 방지하도록 광고 컨테이너 정리를 추가했습니다.

## 테스트
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d67899d8908323a8aeba6607c2d554