### PR TITLE
관리자 메타 데이터 정규화 및 라우트 보정

### DIFF
--- a/pages/admin.js
+++ b/pages/admin.js
@@ -25,6 +25,118 @@ function getDefaultAdsterraDateRange() {
   };
 }
 
+function normalizeMeta(meta) {
+  if (!meta || typeof meta !== 'object') {
+    return {
+      slug: '',
+      type: '',
+      title: '',
+      summary: '',
+      description: '',
+      orientation: 'landscape',
+      durationSeconds: 0,
+      timestamps: [],
+      preview: '',
+      poster: '',
+      thumbnail: '',
+      src: '',
+      publishedAt: '',
+      likes: 0,
+      views: 0,
+    };
+  }
+
+  const rawSlug = typeof meta.slug === 'string' ? meta.slug.trim() : '';
+  const rawType = typeof meta.type === 'string' ? meta.type.trim().toLowerCase() : '';
+  const rawTitle = typeof meta.title === 'string' ? meta.title.trim() : '';
+  const rawSummary = typeof meta.summary === 'string' ? meta.summary.trim() : '';
+  const rawDescription = typeof meta.description === 'string' ? meta.description.trim() : '';
+  const orientation = meta.orientation === 'portrait' ? 'portrait' : 'landscape';
+
+  const parseDuration = (value) => {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric) || numeric < 0) return 0;
+    return Math.round(numeric);
+  };
+
+  const durationSeconds = parseDuration(
+    meta.durationSeconds ?? meta.duration ?? meta.length ?? meta.seconds
+  );
+
+  const normalizeTimestamp = (stamp) => {
+    if (!stamp || typeof stamp !== 'object') return null;
+    const numericSeconds = Number(
+      stamp.seconds ?? stamp.time ?? stamp.at ?? stamp.offset ?? stamp.position
+    );
+    if (!Number.isFinite(numericSeconds) || numericSeconds < 0) {
+      return null;
+    }
+
+    const label =
+      typeof stamp.label === 'string'
+        ? stamp.label.trim()
+        : typeof stamp.title === 'string'
+          ? stamp.title.trim()
+          : '';
+    const descriptionValue =
+      typeof stamp.description === 'string' ? stamp.description.trim() : '';
+    const slugValue = typeof stamp.slug === 'string' ? stamp.slug.trim() : '';
+    const urlValue = typeof stamp.url === 'string' ? stamp.url.trim() : '';
+
+    const normalizedStamp = {
+      seconds: numericSeconds,
+    };
+
+    if (label) normalizedStamp.label = label;
+    if (descriptionValue) normalizedStamp.description = descriptionValue;
+    if (slugValue) normalizedStamp.slug = slugValue;
+    if (urlValue) normalizedStamp.url = urlValue;
+
+    return normalizedStamp;
+  };
+
+  const timestamps = Array.isArray(meta.timestamps)
+    ? meta.timestamps
+        .map((stamp) => normalizeTimestamp(stamp))
+        .filter(Boolean)
+    : [];
+
+  const preview =
+    (typeof meta.preview === 'string' && meta.preview.trim()) ||
+    (typeof meta.thumbnail === 'string' && meta.thumbnail.trim()) ||
+    (typeof meta.poster === 'string' && meta.poster.trim()) ||
+    '';
+  const poster = typeof meta.poster === 'string' ? meta.poster.trim() : '';
+  const thumbnail =
+    (typeof meta.thumbnail === 'string' && meta.thumbnail.trim()) || poster || '';
+  const src =
+    (typeof meta.src === 'string' && meta.src.trim()) ||
+    (typeof meta.url === 'string' && meta.url.trim()) ||
+    '';
+
+  const publishedAt = typeof meta.publishedAt === 'string' ? meta.publishedAt : '';
+  const likesNumeric = Number(meta.likes);
+  const viewsNumeric = Number(meta.views);
+
+  return {
+    slug: rawSlug,
+    type: rawType,
+    title: rawTitle,
+    summary: rawSummary,
+    description: rawDescription,
+    orientation,
+    durationSeconds,
+    timestamps,
+    preview,
+    poster,
+    thumbnail,
+    src,
+    publishedAt,
+    likes: Number.isFinite(likesNumeric) && likesNumeric >= 0 ? likesNumeric : 0,
+    views: Number.isFinite(viewsNumeric) && viewsNumeric >= 0 ? viewsNumeric : 0,
+  };
+}
+
 export default function Admin() {
   const router = useRouter();
   const token = typeof router.query.token === 'string' ? router.query.token : '';
@@ -132,24 +244,41 @@ export default function Admin() {
       const enriched = await Promise.all(
         baseItems.map(async (it) => {
           try {
-            const metaFetchUrl = it.url ? `${it.url}${it.url.includes('?') ? '&' : '?'}_=${Date.now()}` : it.url;
+            const metaFetchUrl = it.url
+              ? `${it.url}${it.url.includes('?') ? '&' : '?'}_=${Date.now()}`
+              : it.url;
             const metaRes = await fetch(metaFetchUrl, { cache: 'no-store' });
             if (!metaRes.ok) return { ...it, _error: true };
             const meta = await metaRes.json();
-            const slug = meta?.slug || it.pathname?.replace(/^content\//, '').replace(/\.json$/, '');
-            const type = (meta?.type || '').toLowerCase();
-            const preview = meta?.thumbnail || meta?.poster || '';
-            const routePath = `/x/${slug}`;
-            const titleValue = meta?.title || slug;
-            const descriptionValue = meta?.description || '';
-            const sourceUrl = meta?.src || meta?.url || meta?.sourceUrl || '';
-            const poster = meta?.poster || '';
-            const thumbnail = meta?.thumbnail || '';
-            const orientationValue = meta?.orientation || 'landscape';
-            const durationSeconds = Number(meta?.durationSeconds) || 0;
-            const likes = Number(meta?.likes) || 0;
-            const views = Number(meta?.views) || 0;
-            const publishedAt = meta?.publishedAt || '';
+            const normalized = normalizeMeta(meta);
+            const fallbackSlug = it.pathname
+              ?.replace(/^content\//, '')
+              .replace(/\.json$/, '');
+            const slug = normalized.slug || fallbackSlug || '';
+            const type = normalized.type || 'video';
+            const preview = normalized.preview || normalized.thumbnail || normalized.poster || '';
+            const routePath = slug
+              ? type === 'image'
+                ? `/x/${slug}`
+                : `/m/${slug}`
+              : '';
+            const titleValue = normalized.title || slug;
+            const summaryValue = normalized.summary || normalized.description || '';
+            const descriptionValue = normalized.description || summaryValue;
+            const sourceUrl = normalized.src || meta?.sourceUrl || '';
+            const poster = normalized.poster || '';
+            const thumbnail = normalized.thumbnail || poster || '';
+            const orientationValue = normalized.orientation || 'landscape';
+            const durationSeconds = Number.isFinite(normalized.durationSeconds)
+              ? normalized.durationSeconds
+              : 0;
+            const timestamps = Array.isArray(normalized.timestamps)
+              ? normalized.timestamps
+              : [];
+            const likes = Number.isFinite(normalized.likes) ? normalized.likes : 0;
+            const views = Number.isFinite(normalized.views) ? normalized.views : 0;
+            const publishedAt = normalized.publishedAt || '';
+
             return {
               ...it,
               slug,
@@ -157,15 +286,18 @@ export default function Admin() {
               preview,
               routePath,
               title: titleValue,
+              summary: summaryValue,
               description: descriptionValue,
               src: sourceUrl,
               poster,
               thumbnail,
               orientation: orientationValue,
               durationSeconds,
+              timestamps,
               likes,
               views,
               publishedAt,
+              rawMeta: meta,
             };
           } catch {
             const slug = it.pathname?.replace(/^content\//, '').replace(/\.json$/, '');


### PR DESCRIPTION
## 요약
- 관리자 목록에서 메타 데이터를 normalizeMeta로 정규화하여 제목, 요약, 타임스탬프 등 세부 정보를 보강했습니다.
- 타입에 따라 /x 또는 /m 라우트를 선택하고 원본 메타 JSON을 rawMeta로 보존하도록 조정했습니다.

## 테스트
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d67763cac083238ac98ed31473cd38