### PR TITLE
Relish 광고 배너 컴포넌트 추가 및 슬롯 정리

### DIFF
--- a/components/x/ads/RelishInvokeAd.jsx
+++ b/components/x/ads/RelishInvokeAd.jsx
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from "react";
+
+const SCRIPT_SRC = "//relishsubsequentlytank.com/4bad6f43b4d5435cfdaf9cb7c11142bc/invoke.js";
+const AD_OPTIONS = {
+  key: "4bad6f43b4d5435cfdaf9cb7c11142bc",
+  format: "iframe",
+  height: 250,
+  width: 300,
+  params: {},
+};
+
+export default function RelishInvokeAd({ className = "", style }) {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || typeof window === "undefined") {
+      return () => {};
+    }
+
+    container.innerHTML = "";
+
+    const optionsScript = document.createElement("script");
+    optionsScript.type = "text/javascript";
+    optionsScript.innerHTML = `window.atOptions = ${JSON.stringify(AD_OPTIONS)}; window.atOptions = window.atOptions || {}; var atOptions = window.atOptions;`;
+
+    const invokeScript = document.createElement("script");
+    invokeScript.type = "text/javascript";
+    invokeScript.src = SCRIPT_SRC;
+    invokeScript.async = true;
+
+    container.appendChild(optionsScript);
+    container.appendChild(invokeScript);
+
+    return () => {
+      container.innerHTML = "";
+    };
+  }, []);
+
+  return <div ref={containerRef} className={className} style={style} />;
+}

--- a/components/x/slug/ContentDetailPage.jsx
+++ b/components/x/slug/ContentDetailPage.jsx
@@ -10,23 +10,17 @@ import { loadFavorites, toggleFavoriteSlug } from "@/utils/storage";
 import VideoCard from "@/components/x/video/VideoCard";
 import TitleNameHead from "@/components/m/TitleNameHead";
 import LogoText from "@/components/LogoText";
-import RecommendedMemes from "@/components/m/RecommendedMemes";
-import dynamic from "next/dynamic";
 import CategoryNavigation from "./CategoryNavigation";
+import dynamic from "next/dynamic";
 
-const BannerRect = dynamic(() => import("@/components/ads/RelishAtOptionsFrame"), { ssr: false });
+const RelishInvokeAd = dynamic(() => import("@/components/x/ads/RelishInvokeAd"), { ssr: false });
 
 export default function ContentDetailPage({
   meme,
-  allMemes,
   disableVideo = false,
   hideBackToFeed = false,
   backSlot = null,
-  showRecommended = true,
-  recommendSlot = null,
   onPreviewClick,
-  belowVideoSlot = null,
-  afterArticleSlot = null,
   onCtaClick,
 }) {
   const { t, i18n } = useTranslation("common");
@@ -202,7 +196,7 @@ export default function ContentDetailPage({
           />
 
           <div className="mt-6 flex justify-center">
-            <BannerRect width={300} height={250} />
+            <RelishInvokeAd />
           </div>
 
           <article className="mt-6 space-y-7 rounded-3xl bg-slate-900/80 p-6 shadow-[0_30px_80px_-40px_rgba(15,23,42,0.9)] ring-1 ring-slate-800/70 sm:p-9">
@@ -240,7 +234,6 @@ export default function ContentDetailPage({
                   </a>
                 </div>
               )}
-              {belowVideoSlot}
             </div>
 
             <div className="flex flex-col gap-4">
@@ -268,14 +261,6 @@ export default function ContentDetailPage({
               </div>
             </div>
           </article>
-
-          {afterArticleSlot}
-
-          {showRecommended ? (
-            <RecommendedMemes t={t} locale={locale} allMemes={allMemes} meme={meme} />
-          ) : (
-            recommendSlot ?? null
-          )}
         </main>
       </div>
     </>

--- a/pages/x/[slug].js
+++ b/pages/x/[slug].js
@@ -1,16 +1,10 @@
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import { getAllContent, getContentBySlug } from '@/utils/contentSource';
 import ContentDetailPage from '@/components/x/slug/ContentDetailPage';
-import dynamic from 'next/dynamic';
-import QuadAdGrid from '@/components/ads/QuadAdGrid';
-const MonetagBanner = dynamic(() => import('@/components/x/ads/BannerAdsMonetag'), { ssr: false });
 import * as g from '@/lib/gtag';
 import { vaTrack } from '@/lib/va';
 import { useEffect, useRef, useCallback } from 'react';
 import usePageviewTracker from '@/hooks/usePageviewTracker';
-
-const BannerTop = dynamic(() => import('@/components/ads/RelishBannerInvoke'), { ssr: false });
-const BannerRect = dynamic(() => import('@/components/ads/RelishAtOptionsFrame'), { ssr: false });
 
 export default function ImageDetail(props) {
   if (typeof window !== "undefined" && props?.meme?.slug === "6fca6583443e837b") {
@@ -167,21 +161,6 @@ export default function ImageDetail(props) {
       disableVideo
       hideBackToFeed
       backSlot={null}
-      showRecommended={false}
-      recommendSlot={
-        <div className="mt-10 flex justify-center">
-        {/* todo: 여기에 만든 광고 배너 추가*/}
-        </div>
-      }
-      belowVideoSlot={null}
-      afterArticleSlot={
-        <div className="mt-6 flex w-full justify-center">
-          <MonetagBanner
-            containerId="container-423e3c0edc8f597be9c7991231d2dd57"
-            src="//relishsubsequentlytank.com/423e3c0edc8f597be9c7991231d2dd57/invoke.js"
-          />
-        </div>
-      }
       onPreviewClick={() => {
         const slug = props?.meme?.slug || '';
         const title = props?.meme?.title || '';


### PR DESCRIPTION
## 요약
- Relish 광고 스크립트를 별도 컴포넌트로 분리하고 x 상세 페이지에 삽입했습니다.
- ContentDetailPage의 추천 및 슬롯 관련 prop을 제거하고 레이아웃을 단순화했습니다.
- 불필요한 광고 슬롯 전달 코드를 정리했습니다.

## 테스트
- 테스트를 수행하지 않았습니다 (해당 사항 없음)


------
https://chatgpt.com/codex/tasks/task_e_68d686fff9f88323b0af65787bb7daeb