### PR TITLE
admin 페이지 구조 분리 및 기능 리팩터링

### DIFF
--- a/components/admin/adsterra/AdsterraChartPanel.jsx
+++ b/components/admin/adsterra/AdsterraChartPanel.jsx
@@ -1,0 +1,75 @@
+import { useMemo } from 'react';
+
+function buildSeries(rows) {
+  const map = new Map();
+  rows.forEach((row) => {
+    const dateLabel = row?.date || row?.day || row?.Day || row?.group;
+    if (!dateLabel) return;
+    const impressions = Number(row?.impression ?? row?.impressions ?? 0) || 0;
+    const clicks = Number(row?.clicks ?? row?.click ?? 0) || 0;
+    const revenue = Number(row?.revenue ?? 0) || 0;
+    const current = map.get(dateLabel) || { impressions: 0, clicks: 0, revenue: 0 };
+    current.impressions += impressions;
+    current.clicks += clicks;
+    current.revenue += revenue;
+    map.set(dateLabel, current);
+  });
+  return Array.from(map.entries()).sort((a, b) => new Date(a[0]) - new Date(b[0]));
+}
+
+export default function AdsterraChartPanel({ rows, formatNumber }) {
+  const series = useMemo(() => buildSeries(rows), [rows]);
+  if (!series.length) {
+    return (
+      <div className="rounded-2xl border border-slate-800/70 bg-slate-900/80 p-6 text-sm text-slate-400">
+        통계를 불러오면 추세 그래프가 표시됩니다.
+      </div>
+    );
+  }
+
+  const maxImpressions = Math.max(...series.map(([, value]) => value.impressions), 1);
+  const width = 600;
+  const height = 160;
+  const stepX = width / Math.max(series.length - 1, 1);
+
+  const linePath = series
+    .map(([, value], index) => {
+      const x = index * stepX;
+      const y = height - (value.impressions / maxImpressions) * height;
+      return `${index === 0 ? 'M' : 'L'}${x},${y}`;
+    })
+    .join(' ');
+
+  return (
+    <div className="rounded-2xl border border-slate-800/70 bg-slate-900/80 p-6">
+      <div className="flex items-center justify-between text-sm">
+        <div>
+          <p className="text-xs uppercase tracking-widest text-slate-500">노출 추세</p>
+          <p className="text-lg font-semibold text-white">최근 {series.length}일</p>
+        </div>
+        <div className="text-xs text-slate-400">
+          최고 노출 {formatNumber(maxImpressions)}
+        </div>
+      </div>
+      <svg viewBox={`0 0 ${width} ${height}`} className="mt-4 h-40 w-full">
+        <defs>
+          <linearGradient id="adsterra-impressions" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stopColor="#34d399" stopOpacity="0.8" />
+            <stop offset="100%" stopColor="#34d399" stopOpacity="0" />
+          </linearGradient>
+        </defs>
+        <path d={`${linePath} L${width},${height} L0,${height} Z`} fill="url(#adsterra-impressions)" />
+        <path d={linePath} stroke="#34d399" strokeWidth="3" fill="none" strokeLinecap="round" />
+      </svg>
+      <div className="mt-3 grid grid-cols-2 gap-2 text-[11px] text-slate-400 sm:grid-cols-4">
+        {series.map(([date, value]) => (
+          <div key={date} className="rounded-lg bg-slate-900/60 px-3 py-2">
+            <p className="font-semibold text-slate-200">{date}</p>
+            <p>노출 {formatNumber(value.impressions)}</p>
+            <p>클릭 {formatNumber(value.clicks)}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/admin/adsterra/AdsterraControls.jsx
+++ b/components/admin/adsterra/AdsterraControls.jsx
@@ -1,0 +1,235 @@
+import { ADSTERRA_ALL_PLACEMENTS_VALUE } from '../../../hooks/admin/useAdsterraStats';
+import AdsterraFilterChips from './filters/AdsterraFilterChips';
+import AdsterraPresetControls from './AdsterraPresetControls';
+
+export default function AdsterraControls({
+  domainName,
+  domainId,
+  loadingPlacements,
+  loadingStats,
+  status,
+  error,
+  placements,
+  placementId,
+  onPlacementChange,
+  startDate,
+  endDate,
+  onStartDateChange,
+  onEndDateChange,
+  onRefreshPlacements,
+  onFetchStats,
+  onResetDates,
+  canFetchStats,
+  countryFilter,
+  onCountryFilterChange,
+  countryOptions,
+  osFilter,
+  onOsFilterChange,
+  osOptions,
+  deviceFilter,
+  onDeviceFilterChange,
+  deviceOptions,
+  deviceFormatFilter,
+  onDeviceFormatFilterChange,
+  deviceFormatOptions,
+  placementLabel,
+  onApplyPreset,
+  onSavePreset,
+  presets,
+}) {
+  return (
+    <div className="space-y-4 rounded-2xl bg-slate-900/80 p-5 ring-1 ring-slate-800/70">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-widest text-slate-400">연결된 도메인</p>
+          <p className="text-sm font-semibold text-white">
+            {domainName}
+            <span className="ml-2 text-xs font-normal text-slate-400">{domainId ? `#${domainId}` : '—'}</span>
+          </p>
+          <p className="mt-1 text-[11px] text-slate-500">환경 변수에 저장된 토큰으로 자동 연결돼요.</p>
+        </div>
+        <div className="flex flex-col gap-1 text-xs text-slate-400 md:items-end">
+          <button
+            type="button"
+            onClick={onRefreshPlacements}
+            disabled={loadingPlacements}
+            className="inline-flex items-center justify-center rounded-full border border-slate-600/60 px-3 py-1 text-[11px] font-semibold text-slate-200 transition hover:bg-slate-800/60 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            플레이스먼트 새로고침
+          </button>
+          {loadingPlacements && <span>플레이스먼트를 불러오는 중입니다…</span>}
+        </div>
+      </div>
+
+      <AdsterraPresetControls
+        placementId={placementId}
+        startDate={startDate}
+        endDate={endDate}
+        countryFilter={countryFilter}
+        osFilter={osFilter}
+        deviceFilter={deviceFilter}
+        deviceFormatFilter={deviceFormatFilter}
+        placementLabel={placementLabel}
+        onApplyPreset={onApplyPreset}
+        onSavePreset={onSavePreset}
+        presets={presets}
+      />
+
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        <div className="md:col-span-2 xl:col-span-1">
+          <label className="mb-1 block text-xs uppercase tracking-widest text-slate-400">광고 포맷 (플레이스먼트)</label>
+          <select
+            value={placementId}
+            onChange={(event) => onPlacementChange(event.target.value)}
+            disabled={loadingPlacements}
+            className="w-full rounded-lg bg-slate-800 px-3 py-2 text-sm text-slate-100 disabled:opacity-40"
+          >
+            <option value={ADSTERRA_ALL_PLACEMENTS_VALUE}>전체 보기 (도메인 전체)</option>
+            <option value="">플레이스먼트를 선택해 주세요</option>
+            {placements.map((placement) => {
+              const rawId =
+                placement?.id ??
+                placement?.ID ??
+                placement?.placement_id ??
+                placement?.placementId ??
+                placement?.value;
+              const optionValue = rawId !== undefined && rawId !== null ? String(rawId) : '';
+              if (!optionValue) return null;
+              const label =
+                placement?.title ||
+                placement?.alias ||
+                placement?.placement ||
+                placement?.name ||
+                placement?.ad_format ||
+                `#${optionValue}`;
+              return (
+                <option key={optionValue} value={optionValue}>
+                  {label}
+                </option>
+              );
+            })}
+          </select>
+        </div>
+        <div>
+          <label className="mb-1 block text-xs uppercase tracking-widest text-slate-400">시작일</label>
+          <input
+            type="date"
+            value={startDate}
+            onChange={(event) => onStartDateChange(event.target.value)}
+            max={endDate || undefined}
+            className="w-full rounded-lg bg-slate-800 px-3 py-2 text-sm text-slate-100"
+          />
+        </div>
+        <div>
+          <label className="mb-1 block text-xs uppercase tracking-widest text-slate-400">종료일</label>
+          <input
+            type="date"
+            value={endDate}
+            onChange={(event) => onEndDateChange(event.target.value)}
+            min={startDate || undefined}
+            className="w-full rounded-lg bg-slate-800 px-3 py-2 text-sm text-slate-100"
+          />
+        </div>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+        <div>
+          <label className="mb-1 block text-xs uppercase tracking-widest text-slate-400">국가 필터</label>
+          <select
+            value={countryFilter}
+            onChange={(event) => onCountryFilterChange(event.target.value)}
+            className="w-full rounded-lg bg-slate-800 px-3 py-2 text-sm text-slate-100"
+          >
+            <option value="">전체</option>
+            {countryOptions.map((country) => (
+              <option key={country} value={country}>
+                {country}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="mb-1 block text-xs uppercase tracking-widest text-slate-400">OS 필터</label>
+          <select
+            value={osFilter}
+            onChange={(event) => onOsFilterChange(event.target.value)}
+            className="w-full rounded-lg bg-slate-800 px-3 py-2 text-sm text-slate-100"
+          >
+            <option value="">전체</option>
+            {osOptions.map((os) => (
+              <option key={os} value={os}>
+                {os}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="mb-1 block text-xs uppercase tracking-widest text-slate-400">디바이스 필터</label>
+          <select
+            value={deviceFilter}
+            onChange={(event) => onDeviceFilterChange(event.target.value)}
+            className="w-full rounded-lg bg-slate-800 px-3 py-2 text-sm text-slate-100"
+          >
+            <option value="">전체</option>
+            {deviceOptions.map((device) => (
+              <option key={device} value={device}>
+                {device}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="mb-1 block text-xs uppercase tracking-widest text-slate-400">디바이스 포맷</label>
+          <select
+            value={deviceFormatFilter}
+            onChange={(event) => onDeviceFormatFilterChange(event.target.value)}
+            className="w-full rounded-lg bg-slate-800 px-3 py-2 text-sm text-slate-100"
+          >
+            <option value="">전체</option>
+            {deviceFormatOptions.map((format) => (
+              <option key={format} value={format}>
+                {format}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <AdsterraFilterChips
+        countryFilter={countryFilter}
+        osFilter={osFilter}
+        deviceFilter={deviceFilter}
+        deviceFormatFilter={deviceFormatFilter}
+        onCountryFilterChange={onCountryFilterChange}
+        onOsFilterChange={onOsFilterChange}
+        onDeviceFilterChange={onDeviceFilterChange}
+        onDeviceFormatFilterChange={onDeviceFormatFilterChange}
+      />
+
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={onFetchStats}
+          disabled={!canFetchStats || loadingStats}
+          className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-emerald-400 via-teal-400 to-cyan-400 px-4 py-2 text-sm font-semibold text-slate-950 shadow-lg shadow-emerald-500/30 transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {loadingStats ? '통계 불러오는 중…' : '통계 다시 불러오기'}
+        </button>
+        <button
+          type="button"
+          onClick={onResetDates}
+          className="inline-flex items-center justify-center rounded-full border border-slate-600/60 px-3 py-2 text-xs font-semibold text-slate-200 transition hover:bg-slate-800/60"
+        >
+          기간 초기화
+        </button>
+      </div>
+
+      {status && (
+        <div className="rounded-xl border border-emerald-500/40 bg-emerald-500/10 p-3 text-xs text-emerald-100">{status}</div>
+      )}
+      {error && (
+        <div className="rounded-xl border border-rose-500/40 bg-rose-500/10 p-3 text-sm text-rose-100">{error}</div>
+      )}
+    </div>
+  );
+}

--- a/components/admin/adsterra/AdsterraPresetControls.jsx
+++ b/components/admin/adsterra/AdsterraPresetControls.jsx
@@ -1,0 +1,92 @@
+import { useMemo, useState } from 'react';
+
+export default function AdsterraPresetControls({
+  placementId,
+  startDate,
+  endDate,
+  countryFilter,
+  osFilter,
+  deviceFilter,
+  deviceFormatFilter,
+  placementLabel,
+  presets,
+  onSavePreset,
+  onApplyPreset,
+}) {
+  const [selectedPresetId, setSelectedPresetId] = useState('');
+  const [presetName, setPresetName] = useState('');
+
+  const canSave = useMemo(() => {
+    return Boolean(startDate && endDate);
+  }, [startDate, endDate]);
+
+  const handleSave = () => {
+    if (!canSave) return;
+    const name = presetName.trim() || `${startDate} ~ ${endDate}`;
+    onSavePreset({
+      id: Date.now().toString(),
+      name,
+      placementId,
+      startDate,
+      endDate,
+      countryFilter,
+      osFilter,
+      deviceFilter,
+      deviceFormatFilter,
+    });
+    setPresetName('');
+  };
+
+  const handleApply = () => {
+    if (!selectedPresetId) return;
+    const preset = presets.find((item) => item.id === selectedPresetId);
+    if (preset) {
+      onApplyPreset(preset);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3 rounded-2xl bg-slate-900/70 p-4 text-xs text-slate-300">
+      <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <div className="flex flex-1 flex-wrap items-center gap-2">
+          <input
+            value={presetName}
+            onChange={(event) => setPresetName(event.target.value)}
+            placeholder="프리셋 이름"
+            className="min-w-[10rem] flex-1 rounded-full bg-slate-950/50 px-4 py-2 text-sm text-slate-200 outline-none"
+          />
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={!canSave}
+            className="rounded-full bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 px-4 py-2 text-xs font-semibold text-white shadow-[0_12px_35px_rgba(99,102,241,0.4)] transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            현재 조건 저장
+          </button>
+        </div>
+        <div className="flex flex-1 flex-wrap items-center gap-2">
+          <select
+            value={selectedPresetId}
+            onChange={(event) => setSelectedPresetId(event.target.value)}
+            className="min-w-[10rem] flex-1 rounded-full bg-slate-950/50 px-4 py-2 text-sm text-slate-200 outline-none"
+          >
+            <option value="">프리셋 선택</option>
+            {presets.map((preset) => (
+              <option key={preset.id} value={preset.id}>
+                {preset.name} · {preset.startDate} ~ {preset.endDate} · {placementLabel(preset.placementId) || '전체'}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            onClick={handleApply}
+            disabled={!selectedPresetId}
+            className="rounded-full border border-slate-600/60 px-4 py-2 text-xs font-semibold text-slate-200 transition hover:bg-slate-800/60 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            불러오기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/admin/adsterra/AdsterraStatsTable.jsx
+++ b/components/admin/adsterra/AdsterraStatsTable.jsx
@@ -1,0 +1,103 @@
+import { ADSTERRA_ALL_PLACEMENTS_VALUE } from '../../../hooks/admin/useAdsterraStats';
+
+export default function AdsterraStatsTable({
+  rows,
+  loading,
+  formatNumber,
+  formatDecimal,
+  placementLabelMap,
+  selectedPlacementId,
+}) {
+  const allSelected = selectedPlacementId === ADSTERRA_ALL_PLACEMENTS_VALUE;
+
+  return (
+    <div className="overflow-hidden rounded-2xl bg-slate-900/80 ring-1 ring-slate-800/70">
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-slate-800/70 text-sm">
+          <thead className="bg-slate-900/60 text-left text-xs uppercase tracking-widest text-slate-400">
+            <tr>
+              <th className="px-4 py-3 font-semibold">날짜</th>
+              <th className="px-4 py-3 font-semibold">국가</th>
+              <th className="px-4 py-3 font-semibold">광고 포맷</th>
+              <th className="px-4 py-3 font-semibold">OS</th>
+              <th className="px-4 py-3 font-semibold">디바이스</th>
+              <th className="px-4 py-3 font-semibold">디바이스 포맷</th>
+              <th className="px-4 py-3 text-right font-semibold">노출수</th>
+              <th className="px-4 py-3 text-right font-semibold">클릭수</th>
+              <th className="px-4 py-3 text-right font-semibold">CTR</th>
+              <th className="px-4 py-3 text-right font-semibold">CPM (USD)</th>
+              <th className="px-4 py-3 text-right font-semibold">수익 (USD)</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-800/60">
+            {rows.map((row, index) => {
+              const impressions = Number(row?.impression ?? row?.impressions ?? 0) || 0;
+              const clicks = Number(row?.clicks ?? row?.click ?? 0) || 0;
+              const revenue = Number(row?.revenue ?? 0) || 0;
+              const ctrRaw =
+                Number(
+                  row?.ctr ??
+                    (impressions > 0 && clicks >= 0 ? (clicks / impressions) * 100 : 0)
+                ) || 0;
+              const cpmRaw =
+                Number(
+                  row?.cpm ??
+                    (impressions > 0 && revenue >= 0 ? (revenue / impressions) * 1000 : 0)
+                ) || 0;
+              const dateLabel = row?.date || row?.day || row?.Day || row?.group || `#${index + 1}`;
+              const countryLabel = row?.country ?? row?.Country ?? row?.geo ?? row?.Geo ?? '—';
+              const osLabel = row?.os ?? row?.OS ?? row?.platform ?? row?.Platform ?? '—';
+              const deviceLabel = row?.device ?? row?.Device ?? row?.device_type ?? row?.deviceType ?? '—';
+              const deviceFormatLabel =
+                row?.device_format ?? row?.deviceFormat ?? row?.DeviceFormat ?? '—';
+              const placementId =
+                row?.placement_id ?? row?.placementId ?? row?.placementID ?? row?.placementid;
+              const placementName =
+                row?.placement_name ??
+                row?.placement ??
+                row?.placementName ??
+                row?.ad_format ??
+                '';
+              const placementDisplay =
+                placementName ||
+                (placementId !== undefined && placementId !== null
+                  ? placementLabelMap.get(String(placementId)) || ''
+                  : '') ||
+                (allSelected
+                  ? '전체 보기'
+                  : placementLabelMap.get(String(selectedPlacementId)) || '—');
+              const rowKey = `${dateLabel}-${index}-${placementId ?? ''}-${countryLabel}-${osLabel}-${deviceLabel}-${deviceFormatLabel}`;
+              return (
+                <tr key={rowKey} className="hover:bg-slate-800/40">
+                  <td className="px-4 py-3 font-semibold text-slate-100">{dateLabel}</td>
+                  <td className="px-4 py-3 text-slate-100">{countryLabel}</td>
+                  <td className="px-4 py-3 text-slate-100">{placementDisplay}</td>
+                  <td className="px-4 py-3 text-slate-100">{osLabel}</td>
+                  <td className="px-4 py-3 text-slate-100">{deviceLabel}</td>
+                  <td className="px-4 py-3 text-slate-100">{deviceFormatLabel}</td>
+                  <td className="px-4 py-3 text-right text-slate-100">{formatNumber(impressions)}</td>
+                  <td className="px-4 py-3 text-right text-slate-100">{formatNumber(clicks)}</td>
+                  <td className="px-4 py-3 text-right text-slate-100">{`${formatDecimal(ctrRaw, 3)}%`}</td>
+                  <td className="px-4 py-3 text-right text-slate-100">{formatDecimal(cpmRaw, 3)}</td>
+                  <td className="px-4 py-3 text-right text-slate-100">{formatDecimal(revenue, 3)}</td>
+                </tr>
+              );
+            })}
+            {!rows.length && !loading && (
+              <tr>
+                <td colSpan={11} className="px-4 py-12 text-center text-sm text-slate-400">
+                  통계를 불러오면 여기에 표시됩니다.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+      {loading && (
+        <div className="border-t border-slate-800/70 bg-slate-900/70 px-4 py-3 text-right text-xs text-slate-400">
+          통계를 불러오는 중입니다…
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/admin/adsterra/AdsterraSummaryCards.jsx
+++ b/components/admin/adsterra/AdsterraSummaryCards.jsx
@@ -1,0 +1,21 @@
+export default function AdsterraSummaryCards({ totals, formatNumber, formatDecimal }) {
+  return (
+    <div className="grid gap-4 md:grid-cols-3">
+      <div className="rounded-2xl border border-white/5 bg-slate-900/80 p-4 shadow-lg shadow-black/20">
+        <p className="text-xs uppercase tracking-[0.25em] text-slate-400">총 노출수</p>
+        <p className="mt-2 text-2xl font-bold text-white">{formatNumber(totals.impressions)}</p>
+        <p className="mt-1 text-xs text-slate-500">선택한 기간 · 필터 기준 합계</p>
+      </div>
+      <div className="rounded-2xl border border-white/5 bg-slate-900/80 p-4 shadow-lg shadow-black/20">
+        <p className="text-xs uppercase tracking-[0.25em] text-slate-400">총 클릭수</p>
+        <p className="mt-2 text-2xl font-bold text-white">{formatNumber(totals.clicks)}</p>
+        <p className="mt-1 text-xs text-slate-500">필터 기준 평균 CTR {formatDecimal(totals.ctr, 2)}%</p>
+      </div>
+      <div className="rounded-2xl border border-white/5 bg-slate-900/80 p-4 shadow-lg shadow-black/20">
+        <p className="text-xs uppercase tracking-[0.25em] text-slate-400">총 수익 (USD)</p>
+        <p className="mt-2 text-2xl font-bold text-white">{formatDecimal(totals.revenue, 3)}</p>
+        <p className="mt-1 text-xs text-slate-500">필터 기준 평균 CPM {formatDecimal(totals.cpm, 3)}</p>
+      </div>
+    </div>
+  );
+}

--- a/components/admin/adsterra/filters/AdsterraFilterChips.jsx
+++ b/components/admin/adsterra/filters/AdsterraFilterChips.jsx
@@ -1,0 +1,37 @@
+function Chip({ label, value, onClear }) {
+  if (!value) return null;
+  return (
+    <button
+      type="button"
+      onClick={onClear}
+      className="inline-flex items-center gap-2 rounded-full bg-slate-800/70 px-3 py-1 text-xs text-slate-200 transition hover:bg-slate-700"
+    >
+      <span>{label}: {value}</span>
+      <span className="text-slate-400">✕</span>
+    </button>
+  );
+}
+
+export default function AdsterraFilterChips({
+  countryFilter,
+  osFilter,
+  deviceFilter,
+  deviceFormatFilter,
+  onCountryFilterChange,
+  onOsFilterChange,
+  onDeviceFilterChange,
+  onDeviceFormatFilterChange,
+}) {
+  const hasFilters = countryFilter || osFilter || deviceFilter || deviceFormatFilter;
+  if (!hasFilters) return null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 text-xs text-slate-300">
+      <span className="text-slate-500">활성 필터:</span>
+      <Chip label="국가" value={countryFilter} onClear={() => onCountryFilterChange('')} />
+      <Chip label="OS" value={osFilter} onClear={() => onOsFilterChange('')} />
+      <Chip label="디바이스" value={deviceFilter} onClear={() => onDeviceFilterChange('')} />
+      <Chip label="포맷" value={deviceFormatFilter} onClear={() => onDeviceFormatFilterChange('')} />
+    </div>
+  );
+}

--- a/components/admin/analytics/AnalyticsEmptyState.jsx
+++ b/components/admin/analytics/AnalyticsEmptyState.jsx
@@ -1,0 +1,9 @@
+export default function AnalyticsEmptyState() {
+  return (
+    <tr>
+      <td colSpan={7} className="px-4 py-12 text-center text-sm text-slate-400">
+        분석할 콘텐츠가 없습니다.
+      </td>
+    </tr>
+  );
+}

--- a/components/admin/analytics/AnalyticsOverview.jsx
+++ b/components/admin/analytics/AnalyticsOverview.jsx
@@ -1,0 +1,27 @@
+export default function AnalyticsOverview({
+  itemCount,
+  totals,
+  averageLikeRate,
+  formatNumber,
+  formatPercent,
+}) {
+  return (
+    <div className="grid gap-4 md:grid-cols-3">
+      <div className="rounded-2xl border border-white/5 bg-slate-900/80 p-4 shadow-lg shadow-black/20">
+        <p className="text-xs uppercase tracking-[0.25em] text-slate-400">콘텐츠</p>
+        <p className="mt-2 text-2xl font-bold text-white">{formatNumber(itemCount)}</p>
+        <p className="mt-1 text-xs text-slate-500">등록된 메타 파일 수</p>
+      </div>
+      <div className="rounded-2xl border border-white/5 bg-slate-900/80 p-4 shadow-lg shadow-black/20">
+        <p className="text-xs uppercase tracking-[0.25em] text-slate-400">총 조회수</p>
+        <p className="mt-2 text-2xl font-bold text-white">{formatNumber(totals.views)}</p>
+        <p className="mt-1 text-xs text-slate-500">metrics 기준 누적</p>
+      </div>
+      <div className="rounded-2xl border border-white/5 bg-slate-900/80 p-4 shadow-lg shadow-black/20">
+        <p className="text-xs uppercase tracking-[0.25em] text-slate-400">평균 좋아요율</p>
+        <p className="mt-2 text-2xl font-bold text-white">{formatPercent(averageLikeRate)}</p>
+        <p className="mt-1 text-xs text-slate-500">조회가 있는 콘텐츠 평균</p>
+      </div>
+    </div>
+  );
+}

--- a/components/admin/analytics/AnalyticsRow.jsx
+++ b/components/admin/analytics/AnalyticsRow.jsx
@@ -1,0 +1,63 @@
+export default function AnalyticsRow({
+  row,
+  metrics,
+  metricsLoading,
+  formatNumber,
+  formatPercent,
+  onEdit,
+  visibleColumns,
+}) {
+  const viewsDisplay = metrics ? formatNumber(metrics.views) : metricsLoading ? '불러오는 중…' : '—';
+  const likesDisplay = metrics ? formatNumber(metrics.likes) : metricsLoading ? '불러오는 중…' : '—';
+  const likeRateDisplay = metrics && metrics.views > 0 ? formatPercent(metrics.likes / metrics.views) : '—';
+
+  return (
+    <tr className="hover:bg-slate-800/40">
+      <td className="px-4 py-3">
+        <div className="font-semibold text-slate-100">{row.title || row.slug}</div>
+        <div className="text-xs text-slate-500">{row.slug}</div>
+      </td>
+      <td className="px-4 py-3">
+        <span className="inline-flex rounded-full bg-slate-800 px-2 py-0.5 text-[11px] uppercase tracking-widest text-slate-300">
+          {row.type || 'unknown'}
+        </span>
+      </td>
+      {visibleColumns.views && (
+        <td className="px-4 py-3 text-right text-slate-100">{viewsDisplay}</td>
+      )}
+      {visibleColumns.likes && (
+        <td className="px-4 py-3 text-right text-slate-100">{likesDisplay}</td>
+      )}
+      {visibleColumns.likeRate && (
+        <td className="px-4 py-3 text-right text-slate-100">{likeRateDisplay}</td>
+      )}
+      {visibleColumns.route && (
+        <td className="px-4 py-3 text-right">
+          {row.routePath ? (
+            <a
+              href={row.routePath}
+              target="_blank"
+              rel="noreferrer"
+              className="text-xs font-semibold text-sky-300 hover:text-sky-200"
+            >
+              열기
+            </a>
+          ) : (
+            <span className="text-xs text-slate-500">—</span>
+          )}
+        </td>
+      )}
+      {visibleColumns.edit && (
+        <td className="px-4 py-3 text-right">
+          <button
+            type="button"
+            onClick={() => onEdit(row)}
+            className="inline-flex items-center justify-center rounded-full border border-slate-600/60 px-3 py-1 text-xs font-semibold text-slate-200 transition hover:bg-slate-800"
+          >
+            수정
+          </button>
+        </td>
+      )}
+    </tr>
+  );
+}

--- a/components/admin/analytics/AnalyticsTable.jsx
+++ b/components/admin/analytics/AnalyticsTable.jsx
@@ -1,0 +1,55 @@
+import AnalyticsEmptyState from './AnalyticsEmptyState';
+import AnalyticsRow from './AnalyticsRow';
+
+export default function AnalyticsTable({
+  rows,
+  metricsLoading,
+  metricsError,
+  formatNumber,
+  formatPercent,
+  onEdit,
+  visibleColumns,
+}) {
+  return (
+    <div className="overflow-hidden rounded-2xl bg-slate-900/80 ring-1 ring-slate-800/70">
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-slate-800/70 text-sm">
+          <thead className="bg-slate-900/60 text-left text-xs uppercase tracking-widest text-slate-400">
+            <tr>
+              <th className="px-4 py-3 font-semibold">콘텐츠</th>
+              <th className="px-4 py-3 font-semibold">타입</th>
+              {visibleColumns.views && <th className="px-4 py-3 text-right font-semibold">조회수</th>}
+              {visibleColumns.likes && <th className="px-4 py-3 text-right font-semibold">좋아요</th>}
+              {visibleColumns.likeRate && <th className="px-4 py-3 text-right font-semibold">좋아요율</th>}
+              {visibleColumns.route && <th className="px-4 py-3 text-right font-semibold">링크</th>}
+              {visibleColumns.edit && <th className="px-4 py-3 text-right font-semibold">편집</th>}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-800/60">
+            {rows.map((row) => (
+              <AnalyticsRow
+                key={row.slug}
+                row={row}
+                metrics={row.metrics}
+                metricsLoading={metricsLoading}
+                formatNumber={formatNumber}
+                formatPercent={formatPercent}
+                onEdit={onEdit}
+                visibleColumns={visibleColumns}
+              />
+            ))}
+            {!rows.length && <AnalyticsEmptyState />}
+          </tbody>
+        </table>
+      </div>
+      {metricsLoading && (
+        <div className="border-t border-slate-800/70 bg-slate-900/70 px-4 py-3 text-right text-xs text-slate-400">
+          메트릭을 불러오는 중입니다…
+        </div>
+      )}
+      {metricsError && (
+        <div className="border-t border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">{metricsError}</div>
+      )}
+    </div>
+  );
+}

--- a/components/admin/analytics/AnalyticsToolbar.jsx
+++ b/components/admin/analytics/AnalyticsToolbar.jsx
@@ -1,0 +1,59 @@
+export default function AnalyticsToolbar({
+  sortKey,
+  sortDirection,
+  onSortChange,
+  visibleColumns,
+  onToggleColumn,
+  onExportCsv,
+}) {
+  return (
+    <div className="flex flex-col gap-3 rounded-2xl bg-slate-900/70 p-4 ring-1 ring-slate-800/60 md:flex-row md:items-center md:justify-between">
+      <div className="flex flex-wrap items-center gap-2 text-xs">
+        <span className="rounded-full bg-slate-950/60 px-3 py-1 text-slate-400">정렬 기준</span>
+        <button
+          type="button"
+          onClick={() => onSortChange('views')}
+          className={`rounded-full px-3 py-1 font-semibold transition ${
+            sortKey === 'views' ? 'bg-indigo-500 text-white' : 'bg-slate-800 text-slate-300'
+          }`}
+        >
+          조회수 {sortKey === 'views' ? (sortDirection === 'asc' ? '↑' : '↓') : ''}
+        </button>
+        <button
+          type="button"
+          onClick={() => onSortChange('likes')}
+          className={`rounded-full px-3 py-1 font-semibold transition ${
+            sortKey === 'likes' ? 'bg-indigo-500 text-white' : 'bg-slate-800 text-slate-300'
+          }`}
+        >
+          좋아요 {sortKey === 'likes' ? (sortDirection === 'asc' ? '↑' : '↓') : ''}
+        </button>
+      </div>
+      <div className="flex flex-wrap items-center gap-3 text-xs text-slate-300">
+        <div className="flex flex-wrap items-center gap-2">
+          {Object.entries(visibleColumns).map(([key, value]) => (
+            <label
+              key={key}
+              className="flex items-center gap-1 rounded-full bg-slate-950/50 px-3 py-1 capitalize"
+            >
+              <input
+                type="checkbox"
+                checked={value}
+                onChange={() => onToggleColumn(key)}
+                className="accent-indigo-400"
+              />
+              {key}
+            </label>
+          ))}
+        </div>
+        <button
+          type="button"
+          onClick={onExportCsv}
+          className="rounded-full bg-gradient-to-r from-emerald-400 via-teal-400 to-cyan-400 px-4 py-2 text-xs font-semibold text-slate-950 shadow-lg shadow-emerald-500/30 transition hover:brightness-110"
+        >
+          CSV 다운로드
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/admin/analytics/export/AnalyticsCsvExporter.js
+++ b/components/admin/analytics/export/AnalyticsCsvExporter.js
@@ -1,0 +1,42 @@
+function escapeCsvValue(value) {
+  if (value === null || value === undefined) return '';
+  const stringValue = String(value);
+  if (/[",\n]/.test(stringValue)) {
+    return `"${stringValue.replace(/"/g, '""')}"`;
+  }
+  return stringValue;
+}
+
+export function buildAnalyticsCsv(rows) {
+  const header = ['slug', 'title', 'type', 'views', 'likes', 'like_rate'];
+  const lines = [header.join(',')];
+  rows.forEach((row) => {
+    const metrics = row.metrics || { views: 0, likes: 0 };
+    const likeRate = metrics.views > 0 ? metrics.likes / metrics.views : 0;
+    lines.push(
+      [
+        escapeCsvValue(row.slug),
+        escapeCsvValue(row.title || ''),
+        escapeCsvValue(row.type || ''),
+        metrics.views ?? 0,
+        metrics.likes ?? 0,
+        likeRate.toFixed(4),
+      ].join(',')
+    );
+  });
+  return lines.join('\n');
+}
+
+export function downloadAnalyticsCsv(rows) {
+  if (typeof window === 'undefined') return;
+  const csv = buildAnalyticsCsv(rows);
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.setAttribute('download', `laffy-analytics-${Date.now()}.csv`);
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}

--- a/components/admin/feedback/TokenNotice.jsx
+++ b/components/admin/feedback/TokenNotice.jsx
@@ -1,0 +1,10 @@
+export default function TokenNotice() {
+  return (
+    <div className="rounded-2xl border border-rose-500/30 bg-rose-500/10 p-4 text-sm text-rose-100">
+      <p className="font-semibold">토큰이 필요합니다</p>
+      <p className="mt-1">
+        URL 끝에 <code className="rounded bg-black/30 px-1">?token=YOUR_ADMIN_TOKEN</code> 을 붙여 접근해 주세요.
+      </p>
+    </div>
+  );
+}

--- a/components/admin/feedback/UndoToast.jsx
+++ b/components/admin/feedback/UndoToast.jsx
@@ -1,0 +1,37 @@
+export default function UndoToast({ info, status, onUndo, onDismiss }) {
+  if (!info) return null;
+
+  return (
+    <div className="fixed bottom-6 left-1/2 z-40 w-[min(90vw,26rem)] -translate-x-1/2">
+      <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-slate-900/90 px-4 py-3 text-sm text-slate-200 shadow-[0_25px_60px_rgba(15,23,42,0.55)] backdrop-blur">
+        <div className="flex-1" role="status" aria-live="polite">
+          {status === 'error'
+            ? '복원에 실패했어요. 다시 시도해 주세요.'
+            : status === 'success'
+              ? '복원이 완료됐어요!'
+              : `${info.title ? `‘${info.title}’` : '콘텐츠'} 항목을 삭제했어요.`}
+        </div>
+        <button
+          type="button"
+          onClick={onUndo}
+          disabled={status === 'pending' || status === 'success'}
+          className={`inline-flex items-center justify-center rounded-full px-3 py-1 text-sm font-semibold shadow ${
+            status === 'pending' || status === 'success'
+              ? 'cursor-default bg-white/40 text-slate-700'
+              : 'bg-white text-slate-900 hover:bg-white/90'
+          }`}
+        >
+          {status === 'pending' ? '복원 중…' : status === 'success' ? '완료' : '되돌리기'}
+        </button>
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="inline-flex h-8 w-8 items-center justify-center rounded-full text-slate-400 transition hover:bg-slate-800 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-200"
+          aria-label="되돌리기 알림 닫기"
+        >
+          ✕
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/admin/layout/AdminNav.jsx
+++ b/components/admin/layout/AdminNav.jsx
@@ -1,0 +1,30 @@
+export default function AdminNav({ items, activeView, onChange }) {
+  return (
+    <nav className="rounded-full bg-slate-900/60 p-1 shadow-inner shadow-black/40">
+      <div className="grid grid-cols-1 gap-1 sm:grid-cols-3">
+        {items.map((item) => {
+          const active = activeView === item.key;
+          const disabled = item.disabled;
+          return (
+            <button
+              key={item.key}
+              type="button"
+              onClick={() => {
+                if (!disabled) onChange(item.key);
+              }}
+              disabled={disabled}
+              aria-pressed={active}
+              className={`rounded-full px-4 py-2 text-sm font-semibold transition-all duration-200 ease-out focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-400 ${
+                active
+                  ? 'bg-gradient-to-r from-indigo-400 via-sky-400 to-emerald-400 text-slate-950 shadow-lg shadow-emerald-500/30'
+                  : 'text-slate-400 hover:text-slate-100'
+              } ${disabled ? 'cursor-not-allowed opacity-40' : ''}`}
+            >
+              {item.label}
+            </button>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/components/admin/layout/AdminPageShell.jsx
+++ b/components/admin/layout/AdminPageShell.jsx
@@ -1,0 +1,14 @@
+import Head from 'next/head';
+
+export default function AdminPageShell({ children }) {
+  return (
+    <>
+      <Head>
+        <title>Admin · Laffy</title>
+      </Head>
+      <div className="min-h-screen bg-gradient-to-b from-slate-950 via-slate-900 to-slate-950 px-4 py-8 text-slate-100 sm:px-6">
+        <main className="mx-auto w-full max-w-5xl space-y-6">{children}</main>
+      </div>
+    </>
+  );
+}

--- a/components/admin/modals/DeleteModal.jsx
+++ b/components/admin/modals/DeleteModal.jsx
@@ -1,0 +1,85 @@
+import ModalPortal from './ModalPortal';
+
+export default function DeleteModal({ pendingDelete, status, error, onClose, onConfirm }) {
+  if (!pendingDelete) return null;
+  const deleting = status === 'pending';
+
+  return (
+    <ModalPortal>
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 backdrop-blur">
+        <div
+          className="relative w-full max-w-lg overflow-hidden rounded-3xl border border-rose-500/40 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 shadow-[0_40px_120px_rgba(127,29,29,0.55)]"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="admin-delete-modal-title"
+        >
+          <div className="pointer-events-none absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-rose-500 via-orange-400 to-amber-300" />
+          <button
+            type="button"
+            onClick={onClose}
+            className="absolute right-4 top-4 inline-flex h-9 w-9 items-center justify-center rounded-full bg-slate-800/70 text-slate-300 transition hover:bg-slate-700 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-200"
+            aria-label="삭제 확인 창 닫기"
+          >
+            ✕
+          </button>
+          <div className="space-y-6 p-7 sm:p-9">
+            <header className="space-y-2">
+              <p className="text-xs uppercase tracking-[0.4em] text-slate-400/70">Delete Content</p>
+              <h3 id="admin-delete-modal-title" className="text-2xl font-semibold text-white sm:text-3xl">
+                {pendingDelete.title || pendingDelete.slug}
+              </h3>
+              <p className="text-[12px] text-slate-500">Slug · {pendingDelete.slug}</p>
+            </header>
+
+            <div className="space-y-4 text-sm text-slate-200/90">
+              <p>이 콘텐츠의 메타 데이터가 영구 삭제됩니다. 삭제 후 10초 안에 되돌리기가 가능합니다.</p>
+              <div className="space-y-2 rounded-2xl border border-rose-500/20 bg-slate-900/70 p-4 text-xs text-slate-300">
+                <div className="flex items-center justify-between gap-3">
+                  <span className="uppercase tracking-widest text-slate-500">Slug</span>
+                  <span className="font-mono text-[11px] text-slate-200">{pendingDelete.slug}</span>
+                </div>
+                {pendingDelete.routePath && (
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="uppercase tracking-widest text-slate-500">Route</span>
+                    <span className="truncate text-[11px] text-slate-200">{pendingDelete.routePath}</span>
+                  </div>
+                )}
+                {pendingDelete.preview && (
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="uppercase tracking-widest text-slate-500">Preview</span>
+                    <span className="truncate text-[11px] text-slate-200">{pendingDelete.preview}</span>
+                  </div>
+                )}
+              </div>
+              <p className="text-[12px] text-rose-200/80">
+                이 작업은 메타 파일을 삭제하지만 원본 미디어는 별도 보관됩니다. 필요 시 되돌리기를 눌러 복구할 수 있습니다.
+              </p>
+            </div>
+
+            {error && (
+              <div className="rounded-2xl border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">{error}</div>
+            )}
+
+            <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+              <button
+                type="button"
+                onClick={onClose}
+                className="inline-flex items-center justify-center rounded-full border border-slate-600/60 px-5 py-2.5 text-sm font-semibold text-slate-200 transition hover:bg-slate-800"
+              >
+                취소
+              </button>
+              <button
+                type="button"
+                onClick={onConfirm}
+                disabled={deleting}
+                className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-rose-500 via-red-500 to-orange-500 px-6 py-2.5 text-sm font-semibold text-white shadow-[0_18px_42px_rgba(248,113,113,0.35)] transition hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-200 disabled:cursor-wait disabled:opacity-70"
+              >
+                {deleting ? '삭제 중…' : '영구 삭제'}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </ModalPortal>
+  );
+}

--- a/components/admin/modals/EditContentModal.jsx
+++ b/components/admin/modals/EditContentModal.jsx
@@ -1,0 +1,187 @@
+import ModalPortal from './ModalPortal';
+
+export default function EditContentModal({
+  editingItem,
+  editForm,
+  editStatus,
+  editError,
+  editUploadState,
+  editUploadMessage,
+  editFileInputRef,
+  onClose,
+  onFieldChange,
+  onImageUpload,
+  onRevertImage,
+  onOpenTimestamps,
+  onSave,
+}) {
+  if (!editingItem) return null;
+  const saving = editStatus === 'saving';
+  const success = editStatus === 'success';
+
+  return (
+    <ModalPortal>
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/75 backdrop-blur-sm px-4 py-10">
+        <div
+          className="relative w-full max-w-2xl overflow-hidden rounded-3xl border border-slate-700/60 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 shadow-[0_48px_140px_rgba(15,23,42,0.68)]"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="admin-edit-modal-title"
+        >
+          <div className="pointer-events-none absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500" />
+          <button
+            type="button"
+            onClick={onClose}
+            className="absolute right-4 top-4 inline-flex h-9 w-9 items-center justify-center rounded-full bg-slate-800/70 text-slate-300 transition hover:bg-slate-700 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-300"
+            aria-label="편집 창 닫기"
+          >
+            ✕
+          </button>
+          <div className="space-y-6 p-7 sm:p-10">
+            <header className="space-y-2">
+              <p className="text-xs uppercase tracking-[0.4em] text-slate-400/70">Edit Content</p>
+              <h3 id="admin-edit-modal-title" className="text-2xl font-semibold text-white sm:text-3xl">
+                {editingItem.title || editingItem.slug}
+              </h3>
+              <p className="text-[12px] text-slate-500">Slug · {editingItem.slug}</p>
+            </header>
+
+            <div className="grid gap-5">
+              <div className="space-y-2">
+                <label className="text-xs uppercase tracking-widest text-slate-400">Title</label>
+                <input
+                  value={editForm.title}
+                  onChange={(event) => onFieldChange('title', event.target.value)}
+                  className="w-full rounded-2xl border border-slate-700/60 bg-slate-900/80 px-4 py-3 text-sm text-white shadow-inner shadow-black/40 transition focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                  placeholder="콘텐츠 제목"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <label className="text-xs uppercase tracking-widest text-slate-400">Description</label>
+                <textarea
+                  value={editForm.description}
+                  onChange={(event) => onFieldChange('description', event.target.value)}
+                  rows={4}
+                  className="w-full rounded-2xl border border-slate-700/60 bg-slate-900/80 px-4 py-3 text-sm text-white shadow-inner shadow-black/40 transition focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                  placeholder="간단한 설명을 입력해 주세요."
+                />
+              </div>
+
+              <div className="space-y-2">
+                <label className="text-xs uppercase tracking-widest text-slate-400">Duration (seconds)</label>
+                <input
+                  type="number"
+                  min="0"
+                  step="1"
+                  inputMode="numeric"
+                  value={editForm.durationSeconds}
+                  onChange={(event) => onFieldChange('durationSeconds', event.target.value)}
+                  className="w-full rounded-2xl border border-slate-700/60 bg-slate-900/80 px-4 py-3 text-sm text-white shadow-inner shadow-black/40 transition focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                  placeholder="예: 123"
+                />
+                <p className="text-xs text-slate-500">초 단위로 입력해 주세요. 비워두면 기존 값이 유지됩니다.</p>
+              </div>
+
+              <div className="space-y-3">
+                <label className="text-xs uppercase tracking-widest text-slate-400">대표 이미지</label>
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+                  <div className="relative h-36 w-full overflow-hidden rounded-2xl border border-slate-700/60 bg-slate-900/70 sm:h-44 sm:w-44">
+                    {editForm.previewUrl ? (
+                      <img src={editForm.previewUrl} alt={`${editingItem.slug} preview`} className="h-full w-full object-cover" />
+                    ) : (
+                      <div className="grid h-full w-full place-items-center text-xs text-slate-500">이미지가 없습니다</div>
+                    )}
+                    {editUploadState === 'uploading' && (
+                      <div className="absolute inset-0 grid place-items-center bg-slate-950/70 text-xs font-medium text-indigo-200">
+                        업로드 중…
+                      </div>
+                    )}
+                  </div>
+                  <div className="flex-1 space-y-3 text-xs text-slate-300/80">
+                    <p>새로운 이미지를 업로드하면 즉시 교체됩니다. 이미지 비율은 원본에 맞춰 표시돼요.</p>
+                    <div className="flex flex-wrap gap-3">
+                      <input
+                        ref={editFileInputRef}
+                        type="file"
+                        accept="image/jpeg,image/png,image/webp"
+                        className="hidden"
+                        onChange={onImageUpload}
+                      />
+                      <button
+                        type="button"
+                        onClick={() => editFileInputRef.current?.click()}
+                        className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 px-4 py-2 text-sm font-semibold text-white shadow-[0_12px_35px_rgba(99,102,241,0.4)] transition hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-200"
+                      >
+                        이미지 교체
+                      </button>
+                      <button
+                        type="button"
+                        onClick={onRevertImage}
+                        disabled={!editForm.imageUrl}
+                        className="inline-flex items-center justify-center rounded-full border border-slate-600/60 px-4 py-2 text-sm font-semibold text-slate-200 transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-40"
+                      >
+                        원본으로
+                      </button>
+                    </div>
+                    {editUploadMessage && (
+                      <p
+                        className={`text-xs ${
+                          editUploadState === 'error'
+                            ? 'text-rose-300'
+                            : editUploadState === 'success'
+                              ? 'text-emerald-300'
+                              : 'text-slate-400'
+                        }`}
+                      >
+                        {editUploadMessage}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </div>
+
+              <div className="rounded-2xl border border-slate-700/60 bg-slate-900/80 p-4 text-sm text-slate-200">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <p className="text-xs uppercase tracking-widest text-slate-400">타임스탬프</p>
+                    <p className="text-[12px] text-slate-500">총 {editingItem.timestamps?.length ?? 0}개</p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => onOpenTimestamps(editingItem)}
+                    className="inline-flex items-center justify-center rounded-full border border-slate-600/60 px-4 py-2 text-xs font-semibold text-slate-200 transition hover:bg-slate-800"
+                  >
+                    타임스탬프 편집
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            {editError && (
+              <div className="rounded-2xl border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">{editError}</div>
+            )}
+
+            <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+              <button
+                type="button"
+                onClick={onClose}
+                className="inline-flex items-center justify-center rounded-full border border-slate-600/60 px-5 py-2.5 text-sm font-semibold text-slate-200 transition hover:bg-slate-800"
+              >
+                취소
+              </button>
+              <button
+                type="button"
+                onClick={onSave}
+                disabled={saving}
+                className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-emerald-500 via-teal-500 to-cyan-500 px-6 py-2.5 text-sm font-semibold text-slate-950 shadow-[0_16px_40px_rgba(16,185,129,0.35)] transition hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-100 disabled:cursor-wait disabled:opacity-70"
+              >
+                {saving ? '저장 중…' : success ? '저장 완료!' : '변경사항 저장'}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </ModalPortal>
+  );
+}

--- a/components/admin/modals/MetricsModal.jsx
+++ b/components/admin/modals/MetricsModal.jsx
@@ -1,0 +1,86 @@
+import ModalPortal from './ModalPortal';
+
+export default function MetricsModal({ editor, onClose, onChange, onSave }) {
+  if (!editor) return null;
+  const saving = editor.status === 'saving';
+  const success = editor.status === 'success';
+
+  return (
+    <ModalPortal>
+      <div className="fixed inset-0 z-40 flex items-center justify-center bg-slate-950/75 backdrop-blur-sm px-4 py-10">
+        <div
+          className="relative w-full max-w-md overflow-hidden rounded-3xl border border-slate-700/60 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 shadow-[0_32px_100px_rgba(15,23,42,0.7)]"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="admin-metrics-modal-title"
+        >
+          <div className="pointer-events-none absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-emerald-500 via-teal-400 to-cyan-400" />
+          <button
+            type="button"
+            onClick={onClose}
+            className="absolute right-4 top-4 inline-flex h-9 w-9 items-center justify-center rounded-full bg-slate-800/70 text-slate-300 transition hover:bg-slate-700 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300"
+            aria-label="메트릭 편집 닫기"
+          >
+            ✕
+          </button>
+          <div className="space-y-6 p-7 sm:p-9">
+            <header className="space-y-2">
+              <p className="text-xs uppercase tracking-[0.4em] text-slate-400/70">Metrics</p>
+              <h3 id="admin-metrics-modal-title" className="text-xl font-semibold text-white sm:text-2xl">
+                {editor.title}
+              </h3>
+              <p className="text-[12px] text-slate-500">Slug · {editor.slug}</p>
+            </header>
+
+            <div className="grid gap-4">
+              <div className="space-y-2">
+                <label className="text-xs uppercase tracking-widest text-slate-400">조회수</label>
+                <input
+                  value={editor.views}
+                  onChange={(event) => onChange('views', event.target.value)}
+                  placeholder="숫자 입력"
+                  inputMode="numeric"
+                  className="w-full rounded-2xl border border-slate-700/60 bg-slate-900/80 px-4 py-3 text-sm text-white shadow-inner shadow-black/40 transition focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+                />
+              </div>
+              <div className="space-y-2">
+                <label className="text-xs uppercase tracking-widest text-slate-400">좋아요</label>
+                <input
+                  value={editor.likes}
+                  onChange={(event) => onChange('likes', event.target.value)}
+                  placeholder="숫자 입력"
+                  inputMode="numeric"
+                  className="w-full rounded-2xl border border-slate-700/60 bg-slate-900/80 px-4 py-3 text-sm text-white shadow-inner shadow-black/40 transition focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+                />
+              </div>
+            </div>
+
+            {editor.error && (
+              <div className="rounded-2xl border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">
+                {editor.error}
+              </div>
+            )}
+
+            <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+              <button
+                type="button"
+                onClick={onClose}
+                className="inline-flex items-center justify-center rounded-full border border-slate-600/60 px-5 py-2.5 text-sm font-semibold text-slate-200 transition hover:bg-slate-800"
+              >
+                취소
+              </button>
+              <button
+                type="button"
+                onClick={onSave}
+                disabled={saving}
+                className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-emerald-500 via-teal-500 to-cyan-500 px-6 py-2.5 text-sm font-semibold text-slate-950 shadow-[0_16px_40px_rgba(16,185,129,0.35)] transition hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-100 disabled:cursor-wait disabled:opacity-70"
+              >
+                {saving ? '저장 중…' : success ? '저장 완료!' : '메트릭 저장'}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </ModalPortal>
+  );
+}

--- a/components/admin/modals/ModalPortal.jsx
+++ b/components/admin/modals/ModalPortal.jsx
@@ -1,0 +1,21 @@
+import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+export default function ModalPortal({ children }) {
+  const [mounted, setMounted] = useState(false);
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    const container = document.createElement('div');
+    container.className = 'admin-modal-portal';
+    document.body.appendChild(container);
+    containerRef.current = container;
+    setMounted(true);
+    return () => {
+      container.remove();
+    };
+  }, []);
+
+  if (!mounted || !containerRef.current) return null;
+  return createPortal(children, containerRef.current);
+}

--- a/components/admin/modals/TimestampsEditorModal.jsx
+++ b/components/admin/modals/TimestampsEditorModal.jsx
@@ -1,0 +1,120 @@
+import ModalPortal from './ModalPortal';
+
+export default function TimestampsEditorModal({
+  editor,
+  onClose,
+  onFieldChange,
+  onAddTimestamp,
+  onRemoveTimestamp,
+  onSave,
+}) {
+  if (!editor) return null;
+  const { timestamps, title, status, error } = editor;
+  const saving = status === 'saving';
+
+  return (
+    <ModalPortal>
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 backdrop-blur px-4 py-10">
+        <div
+          className="relative w-full max-w-3xl overflow-hidden rounded-3xl border border-indigo-500/40 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 shadow-[0_48px_140px_rgba(55,65,81,0.7)]"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="timestamps-editor-title"
+        >
+          <div className="pointer-events-none absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-indigo-500 via-sky-500 to-emerald-400" />
+          <button
+            type="button"
+            onClick={onClose}
+            className="absolute right-4 top-4 inline-flex h-9 w-9 items-center justify-center rounded-full bg-slate-800/70 text-slate-300 transition hover:bg-slate-700 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-200"
+            aria-label="타임스탬프 편집 닫기"
+          >
+            ✕
+          </button>
+          <div className="space-y-6 p-8">
+            <header className="space-y-2">
+              <p className="text-xs uppercase tracking-[0.4em] text-slate-400/70">Timestamps</p>
+              <h3 id="timestamps-editor-title" className="text-2xl font-semibold text-white">
+                {title} · 구간 편집
+              </h3>
+            </header>
+
+            <div className="space-y-4">
+              {timestamps.map((stamp, index) => (
+                <div
+                  key={stamp.id}
+                  className="grid gap-3 rounded-2xl border border-slate-700/60 bg-slate-900/70 p-4 sm:grid-cols-12 sm:items-center"
+                >
+                  <div className="sm:col-span-2">
+                    <label className="text-xs uppercase tracking-widest text-slate-400">Seconds</label>
+                    <input
+                      type="number"
+                      min="0"
+                      step="1"
+                      value={stamp.seconds}
+                      onChange={(event) => onFieldChange(index, 'seconds', event.target.value)}
+                      className="mt-1 w-full rounded-xl border border-slate-700/60 bg-slate-900/80 px-3 py-2 text-sm text-white focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                    />
+                  </div>
+                  <div className="sm:col-span-4">
+                    <label className="text-xs uppercase tracking-widest text-slate-400">Label</label>
+                    <input
+                      value={stamp.label}
+                      onChange={(event) => onFieldChange(index, 'label', event.target.value)}
+                      className="mt-1 w-full rounded-xl border border-slate-700/60 bg-slate-900/80 px-3 py-2 text-sm text-white focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                    />
+                  </div>
+                  <div className="sm:col-span-4">
+                    <label className="text-xs uppercase tracking-widest text-slate-400">Description</label>
+                    <input
+                      value={stamp.description}
+                      onChange={(event) => onFieldChange(index, 'description', event.target.value)}
+                      className="mt-1 w-full rounded-xl border border-slate-700/60 bg-slate-900/80 px-3 py-2 text-sm text-white focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                    />
+                  </div>
+                  <div className="sm:col-span-2 flex items-end justify-end">
+                    <button
+                      type="button"
+                      onClick={() => onRemoveTimestamp(index)}
+                      className="inline-flex items-center justify-center rounded-full border border-rose-500/40 px-3 py-2 text-xs font-semibold text-rose-200 transition hover:bg-rose-500/10"
+                    >
+                      삭제
+                    </button>
+                  </div>
+                </div>
+              ))}
+              <button
+                type="button"
+                onClick={onAddTimestamp}
+                className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-sky-500 via-indigo-500 to-purple-500 px-4 py-2 text-sm font-semibold text-white shadow-[0_12px_35px_rgba(59,130,246,0.4)] transition hover:brightness-110"
+              >
+                + 타임스탬프 추가
+              </button>
+            </div>
+
+            {error && (
+              <div className="rounded-2xl border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">{error}</div>
+            )}
+
+            <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+              <button
+                type="button"
+                onClick={onClose}
+                className="inline-flex items-center justify-center rounded-full border border-slate-600/60 px-5 py-2.5 text-sm font-semibold text-slate-200 transition hover:bg-slate-800"
+              >
+                취소
+              </button>
+              <button
+                type="button"
+                onClick={onSave}
+                disabled={saving}
+                className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-emerald-500 via-teal-500 to-cyan-500 px-6 py-2.5 text-sm font-semibold text-slate-950 shadow-[0_16px_40px_rgba(16,185,129,0.35)] transition hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-100 disabled:cursor-wait disabled:opacity-70"
+              >
+                {saving ? '저장 중…' : '타임스탬프 저장'}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </ModalPortal>
+  );
+}

--- a/components/admin/uploads/UploadFilters.jsx
+++ b/components/admin/uploads/UploadFilters.jsx
@@ -1,0 +1,71 @@
+const SORT_OPTIONS = [
+  { value: 'recent', label: '최신순' },
+  { value: 'title', label: '제목순' },
+  { value: 'duration', label: '재생시간' },
+];
+
+export default function UploadFilters({
+  search,
+  onSearchChange,
+  typeFilter,
+  onTypeFilterChange,
+  orientationFilter,
+  onOrientationFilterChange,
+  sortOption,
+  onSortOptionChange,
+}) {
+  return (
+    <div className="flex flex-col gap-3 rounded-2xl bg-slate-900/70 p-4 ring-1 ring-slate-800/60 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-1 flex-wrap items-center gap-3">
+        <div className="flex items-center gap-2 rounded-full bg-slate-950/50 px-3 py-1">
+          <span className="text-xs text-slate-500">검색</span>
+          <input
+            value={search}
+            onChange={(event) => onSearchChange(event.target.value)}
+            placeholder="제목·슬러그"
+            className="w-32 bg-transparent text-sm text-slate-200 outline-none sm:w-48"
+          />
+        </div>
+        <div className="flex items-center gap-2 rounded-full bg-slate-950/50 px-3 py-1 text-xs">
+          <span className="text-slate-500">타입</span>
+          <select
+            value={typeFilter}
+            onChange={(event) => onTypeFilterChange(event.target.value)}
+            className="bg-transparent text-slate-200 outline-none"
+          >
+            <option value="">전체</option>
+            <option value="video">영상</option>
+            <option value="image">이미지</option>
+          </select>
+        </div>
+        <div className="flex items-center gap-2 rounded-full bg-slate-950/50 px-3 py-1 text-xs">
+          <span className="text-slate-500">방향</span>
+          <select
+            value={orientationFilter}
+            onChange={(event) => onOrientationFilterChange(event.target.value)}
+            className="bg-transparent text-slate-200 outline-none"
+          >
+            <option value="">전체</option>
+            <option value="landscape">가로</option>
+            <option value="portrait">세로</option>
+            <option value="square">정사각형</option>
+          </select>
+        </div>
+      </div>
+      <div className="flex items-center gap-2 self-start rounded-full bg-slate-950/40 px-3 py-1 text-xs sm:self-auto">
+        <span className="text-slate-500">정렬</span>
+        <select
+          value={sortOption}
+          onChange={(event) => onSortOptionChange(event.target.value)}
+          className="bg-transparent text-slate-200 outline-none"
+        >
+          {SORT_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+}

--- a/components/admin/uploads/UploadForm.jsx
+++ b/components/admin/uploads/UploadForm.jsx
@@ -1,0 +1,84 @@
+import ClientBlobUploader from '../../ClientBlobUploader';
+
+export default function UploadForm({
+  hasToken,
+  title,
+  description,
+  orientation,
+  duration,
+  onTitleChange,
+  onDescriptionChange,
+  onOrientationChange,
+  onDurationChange,
+  handleUploadUrl,
+  onUploaded,
+}) {
+  return (
+    <div className="space-y-4 rounded-2xl bg-slate-900/80 p-5 ring-1 ring-slate-800/70">
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div>
+          <label className="mb-1 block text-xs uppercase tracking-widest text-slate-400">Title</label>
+          <input
+            disabled={!hasToken}
+            type="text"
+            placeholder="Title"
+            value={title}
+            onChange={(event) => onTitleChange(event.target.value)}
+            className="w-full rounded-lg bg-slate-800 px-3 py-2 text-sm disabled:opacity-40"
+          />
+        </div>
+        <div>
+          <label className="mb-1 block text-xs uppercase tracking-widest text-slate-400">Duration (s)</label>
+          <input
+            disabled={!hasToken}
+            type="number"
+            min="0"
+            placeholder="0"
+            value={duration}
+            onChange={(event) => onDurationChange(event.target.value)}
+            className="w-full rounded-lg bg-slate-800 px-3 py-2 text-sm disabled:opacity-40"
+          />
+        </div>
+        <div>
+          <label className="mb-1 block text-xs uppercase tracking-widest text-slate-400">Orientation</label>
+          <select
+            disabled={!hasToken}
+            value={orientation}
+            onChange={(event) => onOrientationChange(event.target.value)}
+            className="w-full rounded-lg bg-slate-800 px-3 py-2 text-sm disabled:opacity-40"
+          >
+            <option value="landscape">landscape</option>
+            <option value="portrait">portrait</option>
+            <option value="square">square</option>
+          </select>
+        </div>
+        <div>
+          <label className="mb-1 block text-xs uppercase tracking-widest text-slate-400">Description</label>
+          <input
+            disabled={!hasToken}
+            type="text"
+            placeholder="Description"
+            value={description}
+            onChange={(event) => onDescriptionChange(event.target.value)}
+            className="w-full rounded-lg bg-slate-800 px-3 py-2 text-sm disabled:opacity-40"
+          />
+        </div>
+      </div>
+      <div className="pt-2">
+        <label className="mb-2 block text-xs uppercase tracking-widest text-slate-400">Upload</label>
+        {hasToken ? (
+          <ClientBlobUploader
+            handleUploadUrl={handleUploadUrl}
+            accept="image/jpeg,image/png,image/webp,video/mp4"
+            maxSizeMB={200}
+            onUploaded={onUploaded}
+          />
+        ) : (
+          <div className="rounded-xl border border-slate-800/70 bg-slate-900/70 px-4 py-3 text-sm text-slate-400">
+            관리자 토큰이 필요합니다.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/admin/uploads/UploadTagChips.jsx
+++ b/components/admin/uploads/UploadTagChips.jsx
@@ -1,0 +1,22 @@
+export default function UploadTagChips({ item }) {
+  const tags = [];
+  if (item.type) tags.push({ label: item.type.toUpperCase(), tone: 'bg-slate-800' });
+  if (item.orientation) tags.push({ label: item.orientation, tone: 'bg-indigo-900/60' });
+  if (item.durationSeconds) tags.push({ label: `${item.durationSeconds}s`, tone: 'bg-emerald-900/50' });
+  if (item.publishedAt) tags.push({ label: item.publishedAt.slice(0, 10), tone: 'bg-slate-800/80' });
+
+  if (!tags.length) return null;
+
+  return (
+    <div className="flex flex-wrap gap-2 pt-1 text-[11px]">
+      {tags.map((tag) => (
+        <span
+          key={`${tag.label}-${tag.tone}`}
+          className={`rounded-full px-2 py-0.5 uppercase tracking-wide text-slate-200 ${tag.tone}`}
+        >
+          {tag.label}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/components/admin/uploads/UploadedItemActions.jsx
+++ b/components/admin/uploads/UploadedItemActions.jsx
@@ -1,0 +1,52 @@
+export default function UploadedItemActions({
+  item,
+  hasToken,
+  copied,
+  onCopy,
+  onEdit,
+  onDelete,
+}) {
+  return (
+    <div className="flex items-center gap-2 pt-1">
+      {item.routePath && (
+        <>
+          <a
+            href={item.routePath}
+            target="_blank"
+            rel="noreferrer"
+            className="rounded-full bg-indigo-600 px-3 py-1 text-white hover:bg-indigo-500"
+          >
+            Open Route
+          </a>
+          <button
+            onClick={() => onCopy(item)}
+            className={`rounded-full px-3 py-1 text-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 ${
+              copied
+                ? 'bg-gradient-to-r from-emerald-400 via-teal-400 to-cyan-400 text-slate-950 shadow-lg shadow-emerald-500/30'
+                : 'bg-slate-800 text-slate-200 hover:bg-slate-700'
+            }`}
+          >
+            {copied ? 'Copied ✨' : 'Copy'}
+          </button>
+          {copied && <span className="sr-only" aria-live="polite">링크가 복사되었습니다.</span>}
+        </>
+      )}
+      {hasToken && !item._error && (
+        <button
+          type="button"
+          onClick={() => onEdit(item)}
+          className="rounded-full bg-gradient-to-r from-emerald-400/30 via-teal-400/25 to-cyan-400/25 px-3 py-1 text-sm font-semibold text-emerald-100 shadow-[0_12px_30px_rgba(16,185,129,0.25)] backdrop-blur transition hover:brightness-115 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-200"
+        >
+          Edit
+        </button>
+      )}
+      <button
+        disabled={!hasToken}
+        onClick={() => onDelete(item)}
+        className="ml-auto rounded-full bg-rose-600 px-3 py-1 hover:bg-rose-500 disabled:opacity-50"
+      >
+        Delete
+      </button>
+    </div>
+  );
+}

--- a/components/admin/uploads/UploadedItemCard.jsx
+++ b/components/admin/uploads/UploadedItemCard.jsx
@@ -1,0 +1,45 @@
+import UploadTagChips from './UploadTagChips';
+import UploadedItemActions from './UploadedItemActions';
+
+export default function UploadedItemCard({
+  item,
+  hasToken,
+  copiedSlug,
+  onCopy,
+  onEdit,
+  onDelete,
+}) {
+  const copied = copiedSlug === item.slug;
+  return (
+    <div className="overflow-hidden rounded-2xl bg-slate-900/80 ring-1 ring-slate-800/70">
+      <div className="relative aspect-video w-full bg-slate-950/60">
+        {item.preview ? (
+          <img src={item.preview} alt={item.title || item.slug} className="h-full w-full object-cover" />
+        ) : (
+          <div className="grid h-full w-full place-items-center text-xs text-slate-400">No preview</div>
+        )}
+        {item.type && (
+          <span className="absolute left-3 top-3 rounded-full bg-black/60 px-2 py-0.5 text-[11px] font-semibold uppercase text-white">
+            {item.type}
+          </span>
+        )}
+      </div>
+      <div className="space-y-2 p-3 text-sm">
+        <div className="truncate font-semibold text-slate-100">{item.title || item.slug}</div>
+        <div className="truncate text-[12px] text-slate-400">{item.slug}</div>
+        {item.description && (
+          <p className="line-clamp-2 text-[12px] leading-relaxed text-slate-400/85">{item.description}</p>
+        )}
+        <UploadTagChips item={item} />
+        <UploadedItemActions
+          item={item}
+          hasToken={hasToken}
+          copied={copied}
+          onCopy={onCopy}
+          onEdit={onEdit}
+          onDelete={onDelete}
+        />
+      </div>
+    </div>
+  );
+}

--- a/components/admin/uploads/UploadsSection.jsx
+++ b/components/admin/uploads/UploadsSection.jsx
@@ -1,0 +1,101 @@
+import { useMemo, useState } from 'react';
+import UploadFilters from './UploadFilters';
+import UploadForm from './UploadForm';
+import UploadedItemCard from './UploadedItemCard';
+
+export default function UploadsSection({
+  hasToken,
+  items,
+  copiedSlug,
+  onCopy,
+  onEdit,
+  onDelete,
+  registerMeta,
+  uploadFormState,
+}) {
+  const [search, setSearch] = useState('');
+  const [typeFilter, setTypeFilter] = useState('');
+  const [orientationFilter, setOrientationFilter] = useState('');
+  const [sortOption, setSortOption] = useState('recent');
+
+  const filteredItems = useMemo(() => {
+    const normalizedSearch = search.trim().toLowerCase();
+    let next = items.filter((item) => {
+      const matchesSearch = normalizedSearch
+        ? [item.title, item.slug, item.description]
+            .filter(Boolean)
+            .some((value) => String(value).toLowerCase().includes(normalizedSearch))
+        : true;
+      if (!matchesSearch) return false;
+      if (typeFilter && (item.type || '').toLowerCase() !== typeFilter) return false;
+      if (orientationFilter && (item.orientation || '') !== orientationFilter) return false;
+      return true;
+    });
+
+    if (sortOption === 'title') {
+      next = [...next].sort((a, b) => {
+        const aTitle = (a.title || a.slug || '').toLowerCase();
+        const bTitle = (b.title || b.slug || '').toLowerCase();
+        return aTitle.localeCompare(bTitle);
+      });
+    } else if (sortOption === 'duration') {
+      next = [...next].sort((a, b) => (Number(b.durationSeconds) || 0) - (Number(a.durationSeconds) || 0));
+    }
+
+    return next;
+  }, [items, orientationFilter, search, sortOption, typeFilter]);
+
+  return (
+    <section className="space-y-8">
+      <UploadForm
+        hasToken={hasToken}
+        title={uploadFormState.title}
+        description={uploadFormState.description}
+        orientation={uploadFormState.orientation}
+        duration={uploadFormState.duration}
+        onTitleChange={uploadFormState.setTitle}
+        onDescriptionChange={uploadFormState.setDescription}
+        onOrientationChange={uploadFormState.setOrientation}
+        onDurationChange={uploadFormState.setDuration}
+        handleUploadUrl={uploadFormState.handleUploadUrl}
+        onUploaded={registerMeta}
+      />
+
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-semibold uppercase tracking-widest text-slate-400">
+            Uploaded ({filteredItems.length}/{items.length})
+          </h2>
+        </div>
+        <UploadFilters
+          search={search}
+          onSearchChange={setSearch}
+          typeFilter={typeFilter}
+          onTypeFilterChange={setTypeFilter}
+          orientationFilter={orientationFilter}
+          onOrientationFilterChange={setOrientationFilter}
+          sortOption={sortOption}
+          onSortOptionChange={setSortOption}
+        />
+        <div className="grid gap-3 sm:grid-cols-2">
+          {filteredItems.map((item) => (
+            <UploadedItemCard
+              key={item.pathname || item.slug || item.routePath || item.url}
+              item={item}
+              hasToken={hasToken}
+              copiedSlug={copiedSlug}
+              onCopy={onCopy}
+              onEdit={onEdit}
+              onDelete={onDelete}
+            />
+          ))}
+          {!filteredItems.length && (
+            <div className="col-span-full rounded-2xl border border-dashed border-slate-700 px-4 py-12 text-center text-sm text-slate-400">
+              조건에 맞는 콘텐츠가 없습니다.
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/hooks/admin/useAdminItems.js
+++ b/hooks/admin/useAdminItems.js
@@ -1,0 +1,122 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import normalizeMeta from '../../lib/admin/normalizeMeta';
+
+const POLL_INTERVAL = 15000;
+
+export default function useAdminItems({ enabled, queryString }) {
+  const [items, setItems] = useState([]);
+  const refreshRef = useRef(null);
+
+  const refresh = useCallback(async () => {
+    if (!enabled) {
+      setItems([]);
+      return;
+    }
+
+    try {
+      const res = await fetch(`/api/admin/list${queryString}`);
+      if (!res.ok) {
+        setItems([]);
+        return;
+      }
+      const data = await res.json();
+      const baseItems = Array.isArray(data.items) ? data.items : [];
+
+      const enriched = await Promise.all(
+        baseItems.map(async (item) => {
+          try {
+            const metaFetchUrl = item.url
+              ? `${item.url}${item.url.includes('?') ? '&' : '?'}_=${Date.now()}`
+              : item.url;
+            const metaRes = await fetch(metaFetchUrl, { cache: 'no-store' });
+            if (!metaRes.ok) return { ...item, _error: true };
+            const meta = await metaRes.json();
+            const normalized = normalizeMeta(meta);
+            const fallbackSlug = item.pathname?.replace(/^content\//, '').replace(/\.json$/, '');
+            const slug = normalized.slug || fallbackSlug || '';
+            const type = normalized.type || 'video';
+            const preview = normalized.preview || normalized.thumbnail || normalized.poster || '';
+            const routePath = slug
+              ? type === 'image'
+                ? `/x/${slug}`
+                : `/m/${slug}`
+              : '';
+            const title = normalized.title || slug;
+            const summary = normalized.summary || normalized.description || '';
+            const description = normalized.description || summary;
+            const src = normalized.src || meta?.sourceUrl || '';
+            const poster = normalized.poster || '';
+            const thumbnail = normalized.thumbnail || poster || '';
+            const orientation = normalized.orientation || 'landscape';
+            const durationSeconds = Number.isFinite(normalized.durationSeconds)
+              ? normalized.durationSeconds
+              : 0;
+            const timestamps = Array.isArray(normalized.timestamps)
+              ? normalized.timestamps
+              : [];
+            const likes = Number.isFinite(normalized.likes) ? normalized.likes : 0;
+            const views = Number.isFinite(normalized.views) ? normalized.views : 0;
+            const publishedAt = normalized.publishedAt || '';
+
+            return {
+              ...item,
+              slug,
+              type,
+              preview,
+              routePath,
+              title,
+              summary,
+              description,
+              src,
+              poster,
+              thumbnail,
+              orientation,
+              durationSeconds,
+              timestamps,
+              likes,
+              views,
+              publishedAt,
+              rawMeta: meta,
+            };
+          } catch (error) {
+            const slug = item.pathname?.replace(/^content\//, '').replace(/\.json$/, '');
+            console.error('Failed to fetch meta', error);
+            return { ...item, slug, _error: true };
+          }
+        })
+      );
+
+      setItems(enriched);
+    } catch (error) {
+      console.error('Failed to refresh admin items', error);
+      setItems([]);
+    }
+  }, [enabled, queryString]);
+
+  useEffect(() => {
+    refreshRef.current = refresh;
+  }, [refresh]);
+
+  useEffect(() => {
+    if (!enabled) return undefined;
+    refresh();
+    const interval = setInterval(() => {
+      refreshRef.current?.();
+    }, POLL_INTERVAL);
+
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        refreshRef.current?.();
+      }
+    };
+
+    document.addEventListener('visibilitychange', onVisibility);
+
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
+  }, [enabled, refresh]);
+
+  return { items, setItems, refresh };
+}

--- a/hooks/admin/useAdminModals.js
+++ b/hooks/admin/useAdminModals.js
@@ -1,0 +1,582 @@
+import { upload } from '@vercel/blob/client';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+export default function useAdminModals({ hasToken, queryString, setItems, refresh }) {
+  const [editingItem, setEditingItem] = useState(null);
+  const [editForm, setEditForm] = useState({
+    title: '',
+    description: '',
+    imageUrl: '',
+    previewUrl: '',
+    durationSeconds: '',
+  });
+  const [editInitialPreview, setEditInitialPreview] = useState('');
+  const [editError, setEditError] = useState('');
+  const [editStatus, setEditStatus] = useState('idle');
+  const [editUploadState, setEditUploadState] = useState('idle');
+  const [editUploadMessage, setEditUploadMessage] = useState('');
+
+  const [pendingDelete, setPendingDelete] = useState(null);
+  const [deleteStatus, setDeleteStatus] = useState('idle');
+  const [deleteError, setDeleteError] = useState('');
+
+  const [undoInfo, setUndoInfo] = useState(null);
+  const [undoStatus, setUndoStatus] = useState('idle');
+
+  const [timestampsEditor, setTimestampsEditor] = useState(null);
+
+  const editFileInputRef = useRef(null);
+  const undoTimeoutRef = useRef(null);
+
+  const qs = useMemo(() => queryString || '', [queryString]);
+
+  const openEditModal = useCallback((item) => {
+    if (!item) return;
+    const initialPreview =
+      item.type === 'image'
+        ? item.src || item.preview || ''
+        : item.poster || item.thumbnail || item.preview || '';
+    const numericDuration = (() => {
+      const parsed = Number(item.durationSeconds);
+      if (!Number.isFinite(parsed) || parsed < 0) return 0;
+      return Math.round(parsed);
+    })();
+
+    setEditForm({
+      title: item.title || item.slug,
+      description: item.description || '',
+      imageUrl: '',
+      previewUrl: initialPreview,
+      durationSeconds: String(numericDuration),
+    });
+    setEditInitialPreview(initialPreview);
+    setEditUploadMessage('');
+    setEditUploadState('idle');
+    setEditError('');
+    setEditStatus('idle');
+    if (editFileInputRef.current) editFileInputRef.current.value = '';
+    setEditingItem({
+      ...item,
+      durationSeconds: numericDuration,
+    });
+  }, []);
+
+  const closeEditModal = useCallback(() => {
+    setEditingItem(null);
+    setEditForm({
+      title: '',
+      description: '',
+      imageUrl: '',
+      previewUrl: '',
+      durationSeconds: '',
+    });
+    setEditInitialPreview('');
+    setEditUploadMessage('');
+    setEditUploadState('idle');
+    setEditError('');
+    setEditStatus('idle');
+    if (editFileInputRef.current) editFileInputRef.current.value = '';
+  }, []);
+
+  const handleEditFieldChange = useCallback((field, value) => {
+    setEditForm((prev) => ({ ...prev, [field]: value }));
+    if ((field === 'title' || field === 'durationSeconds') && editError) setEditError('');
+  }, [editError]);
+
+  const handleEditImageUpload = useCallback(async (event) => {
+    const file = event?.target?.files?.[0];
+    if (!file || !editingItem) return;
+
+    setEditUploadMessage('');
+    setEditError('');
+
+    if (!file.type.startsWith('image/')) {
+      setEditUploadState('error');
+      setEditUploadMessage('이미지 파일만 업로드할 수 있어요.');
+      if (editFileInputRef.current) editFileInputRef.current.value = '';
+      return;
+    }
+
+    const maxSizeMB = 200;
+    if (file.size > maxSizeMB * 1024 * 1024) {
+      setEditUploadState('error');
+      setEditUploadMessage(`이미지 크기가 너무 커요. 최대 ${maxSizeMB}MB까지 가능합니다.`);
+      if (editFileInputRef.current) editFileInputRef.current.value = '';
+      return;
+    }
+
+    try {
+      setEditUploadState('uploading');
+      const sanitizedName = file.name.replace(/\s+/g, '-');
+      const uniqueName = `${Date.now()}-${sanitizedName}`;
+      const blob = await upload(`images/${uniqueName}`, file, {
+        access: 'public',
+        handleUploadUrl: `/api/blob/upload${qs}`,
+        contentType: file.type,
+      });
+      setEditForm((prev) => ({ ...prev, imageUrl: blob.url, previewUrl: blob.url }));
+      setEditUploadState('success');
+      setEditUploadMessage('새 이미지가 업로드되었습니다.');
+    } catch (error) {
+      console.error('Edit image upload failed', error);
+      setEditUploadState('error');
+      setEditUploadMessage('이미지 업로드에 실패했어요. 잠시 후 다시 시도해주세요.');
+    } finally {
+      if (editFileInputRef.current) editFileInputRef.current.value = '';
+    }
+  }, [editingItem, qs]);
+
+  const handleRevertImage = useCallback(() => {
+    setEditForm((prev) => ({ ...prev, imageUrl: '', previewUrl: editInitialPreview }));
+    setEditUploadState('idle');
+    setEditUploadMessage('기존 이미지로 되돌렸어요.');
+    if (editFileInputRef.current) editFileInputRef.current.value = '';
+  }, [editInitialPreview]);
+
+  const buildRegisterPayload = useCallback((item) => {
+    if (!item) return null;
+    const typeValue = (item.type || '').toLowerCase();
+    const isImage = typeValue === 'image';
+    const previewCandidates = [item.preview, item.poster, item.thumbnail];
+    const basePreview =
+      previewCandidates.find((value) => typeof value === 'string' && value.trim().length > 0) || '';
+    const srcCandidates = [item.src, item.poster, item.thumbnail, basePreview];
+    const assetUrl =
+      srcCandidates.find((value) => typeof value === 'string' && value.trim().length > 0) || '';
+    if (!assetUrl) return null;
+
+    const posterCandidates = isImage
+      ? [item.poster, assetUrl, item.thumbnail, basePreview]
+      : [item.poster, item.thumbnail, basePreview];
+    const posterUrl =
+      posterCandidates.find((value) => typeof value === 'string' && value.trim().length > 0) || '';
+
+    const thumbnailCandidates = isImage
+      ? [item.thumbnail, posterUrl, assetUrl, basePreview]
+      : [item.thumbnail, posterUrl, basePreview];
+    const thumbnailUrl =
+      thumbnailCandidates.find((value) => typeof value === 'string' && value.trim().length > 0) || '';
+
+    const likesNumber = Number(item.likes);
+    const viewsNumber = Number(item.views);
+    const rawDuration = Number(item.durationSeconds);
+    const durationSeconds = Number.isFinite(rawDuration) && rawDuration >= 0 ? Math.round(rawDuration) : 0;
+
+    return {
+      slug: item.slug,
+      title: item.title || item.slug,
+      description: item.description || '',
+      url: assetUrl,
+      durationSeconds,
+      orientation: item.orientation || 'landscape',
+      type: isImage ? 'image' : typeValue || 'video',
+      poster: posterUrl || null,
+      thumbnail: thumbnailUrl || null,
+      likes: Number.isFinite(likesNumber) ? likesNumber : 0,
+      views: Number.isFinite(viewsNumber) ? viewsNumber : 0,
+      publishedAt: item.publishedAt || '',
+    };
+  }, []);
+
+  const clearUndoTimer = useCallback(() => {
+    if (undoTimeoutRef.current) {
+      clearTimeout(undoTimeoutRef.current);
+      undoTimeoutRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => () => clearUndoTimer(), [clearUndoTimer]);
+
+  const handleSaveEdit = useCallback(async () => {
+    if (!editingItem) return;
+    if (!hasToken) {
+      setEditError('관리자 토큰이 필요합니다.');
+      return;
+    }
+
+    const trimmedTitle = (editForm.title || '').trim();
+    if (!trimmedTitle) {
+      setEditError('제목을 입력해 주세요.');
+      return;
+    }
+
+    const trimmedDescription = (editForm.description || '').trim();
+    const isImageType = editingItem.type === 'image';
+    const rawDurationInput =
+      typeof editForm.durationSeconds === 'string'
+        ? editForm.durationSeconds.trim()
+        : String(editForm.durationSeconds || '').trim();
+
+    let resolvedDurationSeconds;
+    if (rawDurationInput === '') {
+      const currentDuration = Number(editingItem.durationSeconds);
+      resolvedDurationSeconds = Number.isFinite(currentDuration)
+        ? Math.max(0, Math.round(currentDuration))
+        : 0;
+    } else {
+      const parsed = Number(rawDurationInput);
+      if (!Number.isFinite(parsed) || parsed < 0) {
+        setEditError('재생 시간을 올바른 숫자로 입력해 주세요.');
+        return;
+      }
+      resolvedDurationSeconds = Math.max(0, Math.round(parsed));
+    }
+
+    const newImageUrl = editForm.imageUrl;
+    const basePreview = editInitialPreview || editingItem.preview || '';
+
+    const assetUrl = isImageType
+      ? newImageUrl || editingItem.src || editingItem.poster || editingItem.thumbnail || basePreview || ''
+      : editingItem.src || editingItem.poster || editingItem.thumbnail || basePreview || newImageUrl || '';
+
+    const posterUrl = isImageType
+      ? newImageUrl || assetUrl
+      : newImageUrl || editingItem.poster || editingItem.thumbnail || basePreview || '';
+
+    const thumbnailUrl = isImageType
+      ? newImageUrl || assetUrl
+      : newImageUrl || editingItem.thumbnail || editingItem.poster || basePreview || '';
+
+    if (!assetUrl) {
+      setEditStatus('idle');
+      setEditError('원본 소스를 찾을 수 없어요. 이미지를 다시 업로드해 주세요.');
+      return;
+    }
+
+    setEditStatus('saving');
+    setEditError('');
+
+    try {
+      const res = await fetch(`/api/admin/register${qs}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          slug: editingItem.slug,
+          title: trimmedTitle,
+          description: trimmedDescription,
+          url: assetUrl,
+          durationSeconds: resolvedDurationSeconds,
+          orientation: editingItem.orientation,
+          type: editingItem.type,
+          poster: posterUrl,
+          thumbnail: thumbnailUrl,
+          likes: editingItem.likes,
+          views: editingItem.views,
+          publishedAt: editingItem.publishedAt,
+          metaUrl: editingItem.url,
+        }),
+      });
+
+      if (!res.ok) {
+        const payload = await res.json().catch(() => ({}));
+        const message = payload?.error || 'save_failed';
+        throw new Error(message);
+      }
+
+      setEditStatus('success');
+      setItems((prev) =>
+        prev.map((it) =>
+          it.slug === editingItem.slug
+            ? { ...it, durationSeconds: resolvedDurationSeconds }
+            : it
+        )
+      );
+      setEditForm((prev) => ({
+        ...prev,
+        durationSeconds: String(resolvedDurationSeconds),
+      }));
+      setEditingItem((prev) =>
+        prev
+          ? {
+              ...prev,
+              durationSeconds: resolvedDurationSeconds,
+            }
+          : prev
+      );
+      await refresh();
+      setTimeout(() => {
+        closeEditModal();
+      }, 900);
+    } catch (error) {
+      console.error('Edit save failed', error);
+      setEditStatus('error');
+      setEditError(
+        error?.message === 'save_failed'
+          ? '저장에 실패했어요. 잠시 후 다시 시도해 주세요.'
+          : error?.message || '저장에 실패했어요. 잠시 후 다시 시도해 주세요.'
+      );
+    }
+  }, [
+    closeEditModal,
+    editForm.description,
+    editForm.durationSeconds,
+    editForm.imageUrl,
+    editForm.title,
+    editInitialPreview,
+    editingItem,
+    hasToken,
+    qs,
+    refresh,
+    setItems,
+  ]);
+
+  const openDeleteModal = useCallback((item) => {
+    setPendingDelete(item);
+    setDeleteStatus('idle');
+    setDeleteError('');
+  }, []);
+
+  const closeDeleteModal = useCallback(() => {
+    setPendingDelete(null);
+    setDeleteStatus('idle');
+    setDeleteError('');
+  }, []);
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!pendingDelete) return;
+    const item = pendingDelete;
+    const payload = buildRegisterPayload(item);
+    const metaUrl = typeof item.url === 'string' ? item.url : '';
+    const body = item.url
+      ? { url: item.url, slug: item.slug, type: item.type }
+      : { pathname: item.pathname, slug: item.slug, type: item.type };
+    setDeleteStatus('pending');
+    setDeleteError('');
+
+    try {
+      const res = await fetch(`/api/admin/delete${qs}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) throw new Error('delete_failed');
+
+      closeDeleteModal();
+      if (payload) {
+        clearUndoTimer();
+        setUndoInfo({
+          payload,
+          metaUrl,
+          title: payload.title,
+          slug: item.slug,
+        });
+        setUndoStatus('idle');
+        undoTimeoutRef.current = setTimeout(() => {
+          setUndoInfo(null);
+          setUndoStatus('idle');
+        }, 10000);
+      } else {
+        setUndoInfo(null);
+        setUndoStatus('idle');
+      }
+      refresh();
+    } catch (error) {
+      console.error('Delete failed', error);
+      setDeleteStatus('error');
+      setDeleteError('삭제에 실패했어요. 잠시 후 다시 시도해 주세요.');
+    }
+  }, [
+    pendingDelete,
+    buildRegisterPayload,
+    qs,
+    clearUndoTimer,
+    closeDeleteModal,
+    refresh,
+  ]);
+
+  const handleUndoDelete = useCallback(async () => {
+    if (!undoInfo) return;
+    setUndoStatus('pending');
+    try {
+      const res = await fetch(`/api/admin/register${qs}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          ...undoInfo.payload,
+          metaUrl: undoInfo.metaUrl,
+        }),
+      });
+      if (!res.ok) throw new Error('undo_failed');
+      setUndoStatus('success');
+      clearUndoTimer();
+      undoTimeoutRef.current = setTimeout(() => {
+        setUndoInfo(null);
+        setUndoStatus('idle');
+      }, 1200);
+      await refresh();
+    } catch (error) {
+      console.error('Undo failed', error);
+      setUndoStatus('error');
+    }
+  }, [undoInfo, qs, refresh, clearUndoTimer]);
+
+  const handleDismissUndo = useCallback(() => {
+    clearUndoTimer();
+    setUndoInfo(null);
+    setUndoStatus('idle');
+  }, [clearUndoTimer]);
+
+  const openTimestampsEditor = useCallback((item) => {
+    if (!item) return;
+    const sourceItem = item.timestamps && Array.isArray(item.timestamps) ? item : editingItem || item;
+    const toEditor = (sourceItem.timestamps || []).map((stamp, index) => ({
+      id: `${stamp.seconds ?? index}-${index}-${Date.now()}`,
+      seconds: Number.isFinite(Number(stamp.seconds)) ? Number(stamp.seconds) : 0,
+      label: stamp.label || '',
+      description: stamp.description || '',
+    }));
+    setTimestampsEditor({
+      slug: sourceItem.slug,
+      title: sourceItem.title || sourceItem.slug,
+      timestamps: toEditor,
+      status: 'idle',
+      error: '',
+      metaUrl: sourceItem.url,
+    });
+  }, [editingItem]);
+
+  const closeTimestampsEditor = useCallback(() => {
+    setTimestampsEditor(null);
+  }, []);
+
+  const handleTimestampsFieldChange = useCallback((index, field, value) => {
+    setTimestampsEditor((prev) => {
+      if (!prev) return prev;
+      const next = [...prev.timestamps];
+      if (!next[index]) return prev;
+      if (field === 'seconds') {
+        next[index] = {
+          ...next[index],
+          seconds: value,
+        };
+      } else {
+        next[index] = {
+          ...next[index],
+          [field]: value,
+        };
+      }
+      return { ...prev, timestamps: next, error: '', status: prev.status === 'error' ? 'idle' : prev.status };
+    });
+  }, []);
+
+  const handleAddTimestamp = useCallback(() => {
+    setTimestampsEditor((prev) => {
+      if (!prev) return prev;
+      const next = [...prev.timestamps, { id: `new-${Date.now()}`, seconds: 0, label: '', description: '' }];
+      return { ...prev, timestamps: next };
+    });
+  }, []);
+
+  const handleRemoveTimestamp = useCallback((index) => {
+    setTimestampsEditor((prev) => {
+      if (!prev) return prev;
+      const next = prev.timestamps.filter((_, idx) => idx !== index);
+      return { ...prev, timestamps: next };
+    });
+  }, []);
+
+  const handleSaveTimestamps = useCallback(async () => {
+    if (!timestampsEditor) return;
+    if (!hasToken) {
+      setTimestampsEditor((prev) => (prev ? { ...prev, error: '관리자 토큰이 필요합니다.', status: 'error' } : prev));
+      return;
+    }
+
+    const normalized = timestampsEditor.timestamps
+      .map((stamp) => {
+        const secondsNumber = Number(stamp.seconds);
+        if (!Number.isFinite(secondsNumber) || secondsNumber < 0) return null;
+        const next = { seconds: Math.round(secondsNumber) };
+        if (stamp.label) next.label = stamp.label;
+        if (stamp.description) next.description = stamp.description;
+        return next;
+      })
+      .filter(Boolean);
+
+    setTimestampsEditor((prev) => (prev ? { ...prev, status: 'saving', error: '' } : prev));
+
+    try {
+      const res = await fetch(`/api/admin/register${qs}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          slug: timestampsEditor.slug,
+          metaUrl: timestampsEditor.metaUrl,
+          timestamps: normalized,
+        }),
+      });
+      if (!res.ok) throw new Error('save_failed');
+      await refresh();
+      setItems((prev) =>
+        prev.map((item) =>
+          item.slug === timestampsEditor.slug
+            ? {
+                ...item,
+                timestamps: normalized,
+              }
+            : item
+        )
+      );
+      setEditingItem((prev) =>
+        prev && prev.slug === timestampsEditor.slug
+          ? {
+              ...prev,
+              timestamps: normalized,
+            }
+          : prev
+      );
+      setTimestampsEditor((prev) =>
+        prev
+          ? {
+              ...prev,
+              status: 'success',
+              error: '',
+              timestamps: normalized.map((stamp, index) => ({
+                id: `saved-${index}-${Date.now()}`,
+                ...stamp,
+              })),
+            }
+          : prev
+      );
+      setTimeout(() => {
+        closeTimestampsEditor();
+      }, 900);
+    } catch (error) {
+      console.error('Timestamps save failed', error);
+      setTimestampsEditor((prev) => (prev ? { ...prev, status: 'error', error: '타임스탬프 저장에 실패했어요. 잠시 후 다시 시도해 주세요.' } : prev));
+    }
+  }, [closeTimestampsEditor, hasToken, qs, refresh, setItems, timestampsEditor]);
+
+  return {
+    editingItem,
+    editForm,
+    editStatus,
+    editError,
+    editUploadState,
+    editUploadMessage,
+    editFileInputRef,
+    openEditModal,
+    closeEditModal,
+    handleEditFieldChange,
+    handleEditImageUpload,
+    handleRevertImage,
+    handleSaveEdit,
+    pendingDelete,
+    deleteStatus,
+    deleteError,
+    openDeleteModal,
+    closeDeleteModal,
+    handleConfirmDelete,
+    undoInfo,
+    undoStatus,
+    handleUndoDelete,
+    handleDismissUndo,
+    timestampsEditor,
+    openTimestampsEditor,
+    closeTimestampsEditor,
+    handleTimestampsFieldChange,
+    handleAddTimestamp,
+    handleRemoveTimestamp,
+    handleSaveTimestamps,
+  };
+}

--- a/hooks/admin/useAdsterraStats.js
+++ b/hooks/admin/useAdsterraStats.js
@@ -1,0 +1,445 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+export const ADSTERRA_ALL_PLACEMENTS_VALUE = '__all__';
+
+export default function useAdsterraStats({
+  enabled,
+  defaultRange,
+  envToken,
+  domainName,
+  domainKey,
+  initialDomainId = '',
+}) {
+  const [activeToken, setActiveToken] = useState(envToken || '');
+  const [domainId, setDomainId] = useState(initialDomainId || '');
+  const [placements, setPlacements] = useState([]);
+  const [placementId, setPlacementId] = useState(ADSTERRA_ALL_PLACEMENTS_VALUE);
+  const [startDate, setStartDate] = useState(defaultRange.start);
+  const [endDate, setEndDate] = useState(defaultRange.end);
+  const [stats, setStats] = useState([]);
+  const [loadingPlacements, setLoadingPlacements] = useState(false);
+  const [loadingStats, setLoadingStats] = useState(false);
+  const [error, setError] = useState('');
+  const [status, setStatus] = useState('');
+  const [countryFilter, setCountryFilter] = useState('');
+  const [osFilter, setOsFilter] = useState('');
+  const [deviceFilter, setDeviceFilter] = useState('');
+  const [deviceFormatFilter, setDeviceFormatFilter] = useState('');
+
+  const placementsRequestRef = useRef(0);
+  const statsRequestRef = useRef(0);
+  const domainRequestRef = useRef(0);
+  const domainResolvingRef = useRef(false);
+  const placementsInitializedRef = useRef(false);
+
+  useEffect(() => {
+    if (envToken && !activeToken) setActiveToken(envToken);
+  }, [envToken, activeToken]);
+
+  const resolveDomainId = useCallback(async () => {
+    if (!activeToken) return;
+    if (domainId || domainResolvingRef.current) return;
+
+    const requestId = domainRequestRef.current + 1;
+    domainRequestRef.current = requestId;
+    domainResolvingRef.current = true;
+    setStatus('도메인 정보를 불러오는 중이에요.');
+    setError('');
+
+    try {
+      const res = await fetch('/api/adsterra/domains', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ token: activeToken }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(json?.error || '도메인 목록을 불러오지 못했어요.');
+      }
+      if (domainRequestRef.current !== requestId) return;
+
+      const domains = Array.isArray(json?.domains) ? json.domains : [];
+      const normalizedName = (domainName || '').trim().toLowerCase();
+      const normalizedKey = (domainKey || '').trim().toLowerCase();
+
+      const matched = domains.find((domain) => {
+        if (!domain || typeof domain !== 'object') return false;
+        const domainIdValue = (domain.id ?? '').toString().trim();
+        const domainTitleValue = (domain.title ?? '').toString().trim();
+        const normalizedTitle = domainTitleValue.toLowerCase();
+        if (normalizedName && normalizedTitle === normalizedName) {
+          return true;
+        }
+        if (!normalizedKey) return false;
+        return (
+          normalizedTitle === normalizedKey || domainIdValue.toLowerCase() === normalizedKey
+        );
+      });
+
+      if (matched && matched.id) {
+        setDomainId(String(matched.id));
+        setStatus(`도메인 ${matched.title || matched.id}을(를) 사용해요.`);
+        setError('');
+      } else {
+        setStatus('');
+        setError('도메인 목록에서 일치하는 항목을 찾지 못했어요. 환경 변수를 확인해 주세요.');
+      }
+    } catch (err) {
+      if (domainRequestRef.current === requestId) {
+        setStatus('');
+        setError(err.message || '도메인 목록을 불러오지 못했어요.');
+      }
+    } finally {
+      if (domainRequestRef.current === requestId) {
+        domainResolvingRef.current = false;
+      }
+    }
+  }, [activeToken, domainId, domainKey, domainName]);
+
+  useEffect(() => {
+    if (!activeToken || domainId) return;
+    resolveDomainId();
+  }, [activeToken, domainId, resolveDomainId]);
+
+  const fetchPlacements = useCallback(async () => {
+    if (loadingPlacements) return;
+    if (!activeToken) {
+      setError('통계 API 토큰이 설정되지 않았어요.');
+      return;
+    }
+    if (!domainId) {
+      setError('도메인 정보가 올바르지 않습니다.');
+      return;
+    }
+
+    placementsInitializedRef.current = true;
+    const requestId = placementsRequestRef.current + 1;
+    placementsRequestRef.current = requestId;
+    setLoadingPlacements(true);
+    setError('');
+    setStatus('');
+
+    try {
+      const res = await fetch('/api/adsterra/placements', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ token: activeToken, domainId }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(json?.error || '플레이스먼트를 불러오지 못했어요.');
+      }
+      if (placementsRequestRef.current !== requestId) return;
+
+      const placementsItems = Array.isArray(json?.placements) ? json.placements : [];
+      setPlacements(placementsItems);
+
+      const extractPlacementId = (placement) => {
+        if (!placement || typeof placement !== 'object') return '';
+        const idValue =
+          placement.id ??
+          placement.ID ??
+          placement.placement_id ??
+          placement.placementId ??
+          placement.value;
+        return idValue !== undefined && idValue !== null ? String(idValue) : '';
+      };
+
+      const isAllSelected = placementId === ADSTERRA_ALL_PLACEMENTS_VALUE;
+
+      if (placementsItems.length) {
+        const hasCurrent = placementsItems.some(
+          (placement) => extractPlacementId(placement) === placementId
+        );
+        if (!hasCurrent && !isAllSelected) {
+          const firstId = extractPlacementId(placementsItems[0]);
+          if (firstId) {
+            setPlacementId(firstId);
+          }
+        }
+      } else {
+        setPlacementId(ADSTERRA_ALL_PLACEMENTS_VALUE);
+      }
+      setStatus(placementsItems.length ? '플레이스먼트를 불러왔어요.' : '등록된 플레이스먼트를 찾을 수 없어요.');
+    } catch (err) {
+      if (placementsRequestRef.current === requestId) {
+        setPlacements([]);
+        setPlacementId(ADSTERRA_ALL_PLACEMENTS_VALUE);
+        setStats([]);
+        setError(err.message || '플레이스먼트를 불러오지 못했어요.');
+      }
+    } finally {
+      if (placementsRequestRef.current === requestId) {
+        setLoadingPlacements(false);
+      }
+    }
+  }, [activeToken, domainId, loadingPlacements, placementId]);
+
+  useEffect(() => {
+    placementsInitializedRef.current = false;
+  }, [activeToken, domainId]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (placementsInitializedRef.current) return;
+    if (!activeToken) {
+      setError('통계 API 토큰이 설정되지 않았어요.');
+      return;
+    }
+    if (!domainId) {
+      resolveDomainId();
+      return;
+    }
+    fetchPlacements();
+  }, [enabled, activeToken, fetchPlacements, domainId, resolveDomainId]);
+
+  const canFetchStats = useMemo(
+    () =>
+      Boolean(
+        activeToken &&
+          domainId &&
+          startDate &&
+          endDate &&
+          (placementId === ADSTERRA_ALL_PLACEMENTS_VALUE || placementId)
+      ),
+    [activeToken, domainId, endDate, placementId, startDate]
+  );
+
+  const fetchStats = useCallback(async () => {
+    if (!activeToken) {
+      setError('통계 API 토큰 환경 변수를 확인해 주세요.');
+      return;
+    }
+    if (!domainId) {
+      setError('도메인 정보가 설정되지 않았어요. 환경 변수를 확인해 주세요.');
+      return;
+    }
+    if (placementId !== ADSTERRA_ALL_PLACEMENTS_VALUE && !placementId) {
+      setError('광고 포맷(플레이스먼트)을 선택해 주세요.');
+      return;
+    }
+    if (!startDate || !endDate) {
+      setError('조회 기간을 모두 입력해 주세요.');
+      return;
+    }
+
+    const start = new Date(startDate);
+    const end = new Date(endDate);
+    if (start > end) {
+      setError('시작일은 종료일보다 늦을 수 없어요.');
+      return;
+    }
+
+    const requestId = statsRequestRef.current + 1;
+    statsRequestRef.current = requestId;
+    setLoadingStats(true);
+    setError('');
+    setStatus('');
+    setStats([]);
+
+    try {
+      const res = await fetch('/api/adsterra/stats', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          token: activeToken,
+          domainId,
+          placementId: placementId === ADSTERRA_ALL_PLACEMENTS_VALUE ? undefined : placementId,
+          allPlacements: placementId === ADSTERRA_ALL_PLACEMENTS_VALUE,
+          startDate,
+          endDate,
+          groupBy: ['date'],
+        }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(json?.error || '통계를 불러오지 못했어요.');
+      }
+      if (statsRequestRef.current !== requestId) return;
+      const items = Array.isArray(json?.items) ? json.items : [];
+      setStats(items);
+      setStatus(`총 ${items.length}건의 통계를 불러왔어요. (필터는 클라이언트에서 적용됩니다)`);
+    } catch (err) {
+      if (statsRequestRef.current === requestId) {
+        setStats([]);
+        setError(err.message || '통계를 불러오지 못했어요.');
+      }
+    } finally {
+      if (statsRequestRef.current === requestId) {
+        setLoadingStats(false);
+      }
+    }
+  }, [activeToken, domainId, endDate, placementId, startDate]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (!canFetchStats) return;
+    fetchStats();
+  }, [enabled, canFetchStats, fetchStats]);
+
+  const placementLabelMap = useMemo(() => {
+    const map = new Map();
+    placements.forEach((placement) => {
+      if (!placement || typeof placement !== 'object') return;
+      const id = placement.id ?? placement.ID ?? placement.placement_id ?? placement.placementId;
+      if (!id && id !== 0) return;
+      const label =
+        placement.title ||
+        placement.alias ||
+        placement.name ||
+        placement.placement ||
+        placement.ad_format ||
+        placement.format ||
+        String(id);
+      map.set(String(id), label);
+    });
+    return map;
+  }, [placements]);
+
+  const makeUniqueSortedOptions = useCallback((getter) => {
+    const values = new Set();
+    stats.forEach((row) => {
+      const value = getter(row);
+      if (value) values.add(String(value));
+    });
+    return Array.from(values).sort((a, b) => a.localeCompare(b));
+  }, [stats]);
+
+  const countryOptions = useMemo(
+    () =>
+      makeUniqueSortedOptions(
+        (row) => row?.country ?? row?.Country ?? row?.geo ?? row?.Geo
+      ),
+    [makeUniqueSortedOptions]
+  );
+  const osOptions = useMemo(
+    () =>
+      makeUniqueSortedOptions(
+        (row) => row?.os ?? row?.OS ?? row?.platform ?? row?.Platform
+      ),
+    [makeUniqueSortedOptions]
+  );
+  const deviceOptions = useMemo(
+    () =>
+      makeUniqueSortedOptions(
+        (row) => row?.device ?? row?.Device ?? row?.device_type ?? row?.deviceType
+      ),
+    [makeUniqueSortedOptions]
+  );
+  const deviceFormatOptions = useMemo(
+    () =>
+      makeUniqueSortedOptions(
+        (row) => row?.device_format ?? row?.deviceFormat ?? row?.DeviceFormat
+      ),
+    [makeUniqueSortedOptions]
+  );
+
+  const filteredStats = useMemo(() => {
+    const normalize = (value) => {
+      if (value === null || value === undefined) return '';
+      return String(value).trim().toLowerCase();
+    };
+
+    const normalizedCountry = normalize(countryFilter);
+    const normalizedOs = normalize(osFilter);
+    const normalizedDevice = normalize(deviceFilter);
+    const normalizedDeviceFormat = normalize(deviceFormatFilter);
+
+    return stats.filter((row) => {
+      const countryValue = row?.country ?? row?.Country ?? row?.geo ?? row?.Geo;
+      if (normalizedCountry && normalize(countryValue) !== normalizedCountry) return false;
+
+      const osValue = row?.os ?? row?.OS ?? row?.platform ?? row?.Platform;
+      if (normalizedOs && normalize(osValue) !== normalizedOs) return false;
+
+      const deviceValue = row?.device ?? row?.Device ?? row?.device_type ?? row?.deviceType;
+      if (normalizedDevice && normalize(deviceValue) !== normalizedDevice) return false;
+
+      const deviceFormatValue =
+        row?.device_format ?? row?.deviceFormat ?? row?.DeviceFormat;
+      if (normalizedDeviceFormat && normalize(deviceFormatValue) !== normalizedDeviceFormat)
+        return false;
+
+      return true;
+    });
+  }, [stats, countryFilter, osFilter, deviceFilter, deviceFormatFilter]);
+
+  const totals = useMemo(() => {
+    if (!Array.isArray(filteredStats) || !filteredStats.length) {
+      return { impressions: 0, clicks: 0, revenue: 0, ctr: 0, cpm: 0 };
+    }
+
+    const totalsValue = filteredStats.reduce(
+      (acc, row) => {
+        const impressions = Number(row?.impression ?? row?.impressions ?? 0);
+        const clicks = Number(row?.clicks ?? row?.click ?? 0);
+        const revenue = Number(row?.revenue ?? 0);
+        return {
+          impressions: acc.impressions + (Number.isFinite(impressions) ? impressions : 0),
+          clicks: acc.clicks + (Number.isFinite(clicks) ? clicks : 0),
+          revenue: acc.revenue + (Number.isFinite(revenue) ? revenue : 0),
+        };
+      },
+      { impressions: 0, clicks: 0, revenue: 0 }
+    );
+
+    const ctr = totalsValue.impressions > 0 ? (totalsValue.clicks / totalsValue.impressions) * 100 : 0;
+    const cpm = totalsValue.impressions > 0 ? (totalsValue.revenue / totalsValue.impressions) * 1000 : 0;
+
+    return { ...totalsValue, ctr, cpm };
+  }, [filteredStats]);
+
+  const resetDates = useCallback(() => {
+    setStartDate(defaultRange.start);
+    setEndDate(defaultRange.end);
+  }, [defaultRange.end, defaultRange.start]);
+
+  const placementLabel = useCallback(
+    (id) => {
+      if (id === ADSTERRA_ALL_PLACEMENTS_VALUE) return '전체 보기';
+      return placementLabelMap.get(String(id)) || '';
+    },
+    [placementLabelMap]
+  );
+
+  return {
+    activeToken,
+    setActiveToken,
+    domainId,
+    setDomainId,
+    placements,
+    placementId,
+    setPlacementId,
+    startDate,
+    setStartDate,
+    endDate,
+    setEndDate,
+    stats,
+    filteredStats,
+    loadingPlacements,
+    loadingStats,
+    error,
+    status,
+    setStatus,
+    setError,
+    fetchPlacements,
+    fetchStats,
+    countryFilter,
+    setCountryFilter,
+    osFilter,
+    setOsFilter,
+    deviceFilter,
+    setDeviceFilter,
+    deviceFormatFilter,
+    setDeviceFormatFilter,
+    countryOptions,
+    osOptions,
+    deviceOptions,
+    deviceFormatOptions,
+    totals,
+    canFetchStats,
+    resetDates,
+    placementLabelMap,
+    placementLabel,
+  };
+}

--- a/hooks/admin/useAnalyticsMetrics.js
+++ b/hooks/admin/useAnalyticsMetrics.js
@@ -1,0 +1,235 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { buildAnalyticsCsv } from '../../components/admin/analytics/export/AnalyticsCsvExporter';
+
+const DEFAULT_COLUMNS = {
+  views: true,
+  likes: true,
+  likeRate: true,
+  route: true,
+  edit: true,
+};
+
+export default function useAnalyticsMetrics({ items, enabled }) {
+  const [metricsBySlug, setMetricsBySlug] = useState({});
+  const [metricsLoading, setMetricsLoading] = useState(false);
+  const [metricsError, setMetricsError] = useState(null);
+  const [sortKey, setSortKey] = useState('views');
+  const [sortDirection, setSortDirection] = useState('desc');
+  const [visibleColumns, setVisibleColumns] = useState(DEFAULT_COLUMNS);
+  const [metricsEditor, setMetricsEditor] = useState(null);
+
+  const pendingMetricsRef = useRef(new Set());
+
+  useEffect(() => {
+    setMetricsBySlug((prev) => {
+      if (!prev || typeof prev !== 'object') return {};
+      const next = {};
+      items.forEach((item) => {
+        if (item.slug && prev[item.slug]) next[item.slug] = prev[item.slug];
+      });
+      return next;
+    });
+  }, [items]);
+
+  useEffect(() => {
+    if (!enabled) return undefined;
+    const slugs = items.map((item) => item.slug).filter(Boolean);
+    const pendingSet = pendingMetricsRef.current;
+    const fetchTargets = slugs.filter((slug) => !metricsBySlug[slug] && !pendingSet.has(slug));
+
+    if (!fetchTargets.length) {
+      setMetricsLoading(false);
+      return undefined;
+    }
+
+    fetchTargets.forEach((slug) => pendingSet.add(slug));
+    let cancelled = false;
+
+    setMetricsLoading(true);
+    setMetricsError(null);
+
+    (async () => {
+      try {
+        const results = await Promise.all(
+          fetchTargets.map(async (slug) => {
+            const res = await fetch(`/api/metrics/get?slug=${encodeURIComponent(slug)}`);
+            if (!res.ok) {
+              throw new Error('metrics_error');
+            }
+            const data = await res.json();
+            return {
+              slug,
+              metrics: {
+                views: Number(data?.views) || 0,
+                likes: Math.max(0, Number(data?.likes) || 0),
+              },
+            };
+          })
+        );
+        if (cancelled) return;
+        setMetricsBySlug((prev) => {
+          const next = { ...prev };
+          results.forEach(({ slug, metrics }) => {
+            next[slug] = metrics;
+          });
+          return next;
+        });
+      } catch (error) {
+        if (!cancelled) {
+          console.error('Metrics fetch failed', error);
+          setMetricsError('메트릭을 불러오지 못했어요.');
+        }
+      } finally {
+        fetchTargets.forEach((slug) => pendingSet.delete(slug));
+        if (!cancelled) setMetricsLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      fetchTargets.forEach((slug) => pendingSet.delete(slug));
+      setMetricsLoading(false);
+    };
+  }, [enabled, items, metricsBySlug]);
+
+  const analyticsRows = useMemo(
+    () =>
+      items
+        .filter((item) => item.slug)
+        .map((item) => ({
+          ...item,
+          metrics: metricsBySlug[item.slug] || null,
+        })),
+    [items, metricsBySlug]
+  );
+
+  const sortedAnalyticsRows = useMemo(() => {
+    const rows = [...analyticsRows];
+    const directionMultiplier = sortDirection === 'asc' ? 1 : -1;
+    rows.sort((a, b) => {
+      const metricsA = a.metrics || {};
+      const metricsB = b.metrics || {};
+      const aValue = sortKey === 'likes' ? metricsA.likes ?? 0 : metricsA.views ?? 0;
+      const bValue = sortKey === 'likes' ? metricsB.likes ?? 0 : metricsB.views ?? 0;
+      return (bValue - aValue) * directionMultiplier;
+    });
+    return rows;
+  }, [analyticsRows, sortDirection, sortKey]);
+
+  const analyticsTotals = useMemo(
+    () =>
+      analyticsRows.reduce(
+        (acc, row) => {
+          if (!row.metrics) return acc;
+          return {
+            views: acc.views + (row.metrics.views || 0),
+            likes: acc.likes + (row.metrics.likes || 0),
+          };
+        },
+        { views: 0, likes: 0 }
+      ),
+    [analyticsRows]
+  );
+
+  const averageLikeRate = useMemo(() => {
+    const withViews = analyticsRows.filter((row) => row.metrics && row.metrics.views > 0);
+    if (!withViews.length) return 0;
+    const totalRate = withViews.reduce(
+      (acc, row) => acc + row.metrics.likes / row.metrics.views,
+      0
+    );
+    return totalRate / withViews.length;
+  }, [analyticsRows]);
+
+  const toggleColumn = useCallback((column) => {
+    setVisibleColumns((prev) => ({
+      ...prev,
+      [column]: !prev[column],
+    }));
+  }, []);
+
+  const setSort = useCallback((key) => {
+    setSortKey((prevKey) => {
+      if (prevKey === key) {
+        setSortDirection((prevDirection) => (prevDirection === 'asc' ? 'desc' : 'asc'));
+        return prevKey;
+      }
+      setSortDirection('desc');
+      return key;
+    });
+  }, []);
+
+  const openMetricsEditor = useCallback((row) => {
+    if (!row?.slug) return;
+    const baseViews =
+      typeof row.metrics?.views === 'number'
+        ? row.metrics.views
+        : typeof row.views === 'number'
+          ? row.views
+          : null;
+    const baseLikes =
+      typeof row.metrics?.likes === 'number'
+        ? row.metrics.likes
+        : typeof row.likes === 'number'
+          ? row.likes
+          : null;
+    const views = baseViews === null ? '' : String(baseViews);
+    const likes = baseLikes === null ? '' : String(baseLikes);
+    setMetricsEditor({
+      slug: row.slug,
+      title: row.title || row.slug,
+      views,
+      likes,
+      status: 'idle',
+      error: '',
+    });
+  }, []);
+
+  const closeMetricsEditor = useCallback(() => {
+    setMetricsEditor(null);
+  }, []);
+
+  const handleMetricsFieldChange = useCallback((field, value) => {
+    setMetricsEditor((prev) => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        [field]: value,
+        error: '',
+        status: prev.status === 'error' ? 'idle' : prev.status,
+      };
+    });
+  }, []);
+
+  const updateMetricsForSlug = useCallback((slug, views, likes) => {
+    setMetricsBySlug((prev) => ({
+      ...prev,
+      [slug]: { views, likes },
+    }));
+  }, []);
+
+  const buildCsv = useCallback(() => buildAnalyticsCsv(sortedAnalyticsRows), [sortedAnalyticsRows]);
+
+  return {
+    analyticsRows,
+    sortedAnalyticsRows,
+    analyticsTotals,
+    averageLikeRate,
+    metricsBySlug,
+    metricsLoading,
+    metricsError,
+    setMetricsBySlug,
+    sortKey,
+    sortDirection,
+    setSort,
+    visibleColumns,
+    toggleColumn,
+    metricsEditor,
+    openMetricsEditor,
+    closeMetricsEditor,
+    handleMetricsFieldChange,
+    setMetricsEditor,
+    updateMetricsForSlug,
+    buildCsv,
+  };
+}

--- a/hooks/admin/useClipboard.js
+++ b/hooks/admin/useClipboard.js
@@ -1,0 +1,63 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export default function useClipboard(timeoutMs = 1800) {
+  const [copiedSlug, setCopiedSlug] = useState('');
+  const timeoutRef = useRef(null);
+
+  const clearTimer = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => clearTimer, [clearTimer]);
+
+  const copy = useCallback(
+    async (slug, routePath) => {
+      if (!routePath) return false;
+      try {
+        const origin = typeof window !== 'undefined' ? window.location.origin : '';
+        const absoluteUrl = origin ? new URL(routePath, origin).toString() : routePath;
+        const canUseClipboard =
+          typeof navigator !== 'undefined' &&
+          navigator.clipboard &&
+          typeof navigator.clipboard.writeText === 'function';
+
+        if (canUseClipboard) {
+          await navigator.clipboard.writeText(absoluteUrl);
+        } else if (typeof document !== 'undefined') {
+          const textarea = document.createElement('textarea');
+          textarea.value = absoluteUrl;
+          textarea.setAttribute('readonly', '');
+          textarea.style.position = 'absolute';
+          textarea.style.left = '-9999px';
+          document.body.appendChild(textarea);
+          textarea.select();
+          if (typeof document.execCommand === 'function') {
+            document.execCommand('copy');
+          } else {
+            throw new Error('Clipboard API unavailable');
+          }
+          document.body.removeChild(textarea);
+        } else {
+          return false;
+        }
+
+        clearTimer();
+        setCopiedSlug(slug || routePath);
+        timeoutRef.current = setTimeout(() => {
+          setCopiedSlug('');
+          timeoutRef.current = null;
+        }, timeoutMs);
+        return true;
+      } catch (error) {
+        console.error('Copy failed', error);
+        return false;
+      }
+    },
+    [clearTimer, timeoutMs]
+  );
+
+  return { copiedSlug, copy };
+}

--- a/lib/admin/normalizeMeta.js
+++ b/lib/admin/normalizeMeta.js
@@ -1,0 +1,111 @@
+export function normalizeTimestamp(stamp) {
+  if (!stamp || typeof stamp !== 'object') return null;
+  const numericSeconds = Number(
+    stamp.seconds ?? stamp.time ?? stamp.at ?? stamp.offset ?? stamp.position
+  );
+  if (!Number.isFinite(numericSeconds) || numericSeconds < 0) {
+    return null;
+  }
+
+  const label =
+    typeof stamp.label === 'string'
+      ? stamp.label.trim()
+      : typeof stamp.title === 'string'
+        ? stamp.title.trim()
+        : '';
+  const descriptionValue =
+    typeof stamp.description === 'string' ? stamp.description.trim() : '';
+  const slugValue = typeof stamp.slug === 'string' ? stamp.slug.trim() : '';
+  const urlValue = typeof stamp.url === 'string' ? stamp.url.trim() : '';
+
+  const normalizedStamp = {
+    seconds: numericSeconds,
+  };
+
+  if (label) normalizedStamp.label = label;
+  if (descriptionValue) normalizedStamp.description = descriptionValue;
+  if (slugValue) normalizedStamp.slug = slugValue;
+  if (urlValue) normalizedStamp.url = urlValue;
+
+  return normalizedStamp;
+}
+
+export default function normalizeMeta(meta) {
+  if (!meta || typeof meta !== 'object') {
+    return {
+      slug: '',
+      type: '',
+      title: '',
+      summary: '',
+      description: '',
+      orientation: 'landscape',
+      durationSeconds: 0,
+      timestamps: [],
+      preview: '',
+      poster: '',
+      thumbnail: '',
+      src: '',
+      publishedAt: '',
+      likes: 0,
+      views: 0,
+    };
+  }
+
+  const rawSlug = typeof meta.slug === 'string' ? meta.slug.trim() : '';
+  const rawType = typeof meta.type === 'string' ? meta.type.trim().toLowerCase() : '';
+  const rawTitle = typeof meta.title === 'string' ? meta.title.trim() : '';
+  const rawSummary = typeof meta.summary === 'string' ? meta.summary.trim() : '';
+  const rawDescription = typeof meta.description === 'string' ? meta.description.trim() : '';
+  const orientation = meta.orientation === 'portrait' ? 'portrait' : 'landscape';
+
+  const parseDuration = (value) => {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric) || numeric < 0) return 0;
+    return Math.round(numeric);
+  };
+
+  const durationSeconds = parseDuration(
+    meta.durationSeconds ?? meta.duration ?? meta.length ?? meta.seconds
+  );
+
+  const timestamps = Array.isArray(meta.timestamps)
+    ? meta.timestamps
+        .map((stamp) => normalizeTimestamp(stamp))
+        .filter(Boolean)
+    : [];
+
+  const preview =
+    (typeof meta.preview === 'string' && meta.preview.trim()) ||
+    (typeof meta.thumbnail === 'string' && meta.thumbnail.trim()) ||
+    (typeof meta.poster === 'string' && meta.poster.trim()) ||
+    '';
+  const poster = typeof meta.poster === 'string' ? meta.poster.trim() : '';
+  const thumbnail =
+    (typeof meta.thumbnail === 'string' && meta.thumbnail.trim()) || poster || '';
+  const src =
+    (typeof meta.src === 'string' && meta.src.trim()) ||
+    (typeof meta.url === 'string' && meta.url.trim()) ||
+    '';
+
+  const publishedAt = typeof meta.publishedAt === 'string' ? meta.publishedAt : '';
+  const likesNumeric = Number(meta.likes);
+  const viewsNumeric = Number(meta.views);
+
+  return {
+    slug: rawSlug,
+    type: rawType,
+    title: rawTitle,
+    summary: rawSummary,
+    description: rawDescription,
+    orientation,
+    durationSeconds,
+    timestamps,
+    preview,
+    poster,
+    thumbnail,
+    src,
+    publishedAt,
+    likes: Number.isFinite(likesNumeric) && likesNumeric >= 0 ? likesNumeric : 0,
+    views: Number.isFinite(viewsNumeric) && viewsNumeric >= 0 ? viewsNumeric : 0,
+  };
+}

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -1,186 +1,146 @@
-import Head from 'next/head';
 import { useRouter } from 'next/router';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { upload } from '@vercel/blob/client';
-import ClientBlobUploader from '../components/ClientBlobUploader';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import AdminPageShell from '../components/admin/layout/AdminPageShell';
+import AdminNav from '../components/admin/layout/AdminNav';
+import TokenNotice from '../components/admin/feedback/TokenNotice';
+import UploadsSection from '../components/admin/uploads/UploadsSection';
+import AnalyticsOverview from '../components/admin/analytics/AnalyticsOverview';
+import AnalyticsToolbar from '../components/admin/analytics/AnalyticsToolbar';
+import AnalyticsTable from '../components/admin/analytics/AnalyticsTable';
+import AdsterraControls from '../components/admin/adsterra/AdsterraControls';
+import AdsterraSummaryCards from '../components/admin/adsterra/AdsterraSummaryCards';
+import AdsterraStatsTable from '../components/admin/adsterra/AdsterraStatsTable';
+import AdsterraChartPanel from '../components/admin/adsterra/AdsterraChartPanel';
+import MetricsModal from '../components/admin/modals/MetricsModal';
+import DeleteModal from '../components/admin/modals/DeleteModal';
+import EditContentModal from '../components/admin/modals/EditContentModal';
+import TimestampsEditorModal from '../components/admin/modals/TimestampsEditorModal';
+import UndoToast from '../components/admin/feedback/UndoToast';
+import useClipboard from '../hooks/admin/useClipboard';
+import useAdminItems from '../hooks/admin/useAdminItems';
+import useAnalyticsMetrics from '../hooks/admin/useAnalyticsMetrics';
+import useAdsterraStats, { ADSTERRA_ALL_PLACEMENTS_VALUE } from '../hooks/admin/useAdsterraStats';
+import useAdminModals from '../hooks/admin/useAdminModals';
+import { downloadAnalyticsCsv } from '../components/admin/analytics/export/AnalyticsCsvExporter';
 
-const ADSTERRA_ALL_PLACEMENTS_VALUE = '__all__';
-
-function toDateInputValue(date) {
-  if (!(date instanceof Date) || Number.isNaN(date.valueOf())) {
-    return '';
-  }
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-}
+const NAV_ITEMS = [
+  { key: 'uploads', label: '업로드 · 목록', requiresToken: false },
+  { key: 'analytics', label: '분석', requiresToken: true },
+  { key: 'adsterra', label: '통계', requiresToken: true },
+];
 
 function getDefaultAdsterraDateRange() {
   const end = new Date();
   end.setHours(0, 0, 0, 0);
   const start = new Date(end);
   start.setDate(start.getDate() - 6);
-  return {
-    start: toDateInputValue(start),
-    end: toDateInputValue(end),
+  const toInput = (date) => {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
   };
+  return { start: toInput(start), end: toInput(end) };
 }
 
-function normalizeMeta(meta) {
-  if (!meta || typeof meta !== 'object') {
-    return {
-      slug: '',
-      type: '',
-      title: '',
-      summary: '',
-      description: '',
-      orientation: 'landscape',
-      durationSeconds: 0,
-      timestamps: [],
-      preview: '',
-      poster: '',
-      thumbnail: '',
-      src: '',
-      publishedAt: '',
-      likes: 0,
-      views: 0,
-    };
+async function generateSlug(blob) {
+  const raw = `${blob?.pathname || ''}-${blob?.url || ''}-${Date.now()}-${Math.random()}`;
+  const cryptoObj = globalThis.crypto;
+  if (cryptoObj?.subtle && typeof TextEncoder !== 'undefined') {
+    const encoder = new TextEncoder();
+    const digest = await cryptoObj.subtle.digest('SHA-256', encoder.encode(raw));
+    const hex = Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, '0')).join('');
+    return hex.slice(0, 16);
   }
-
-  const rawSlug = typeof meta.slug === 'string' ? meta.slug.trim() : '';
-  const rawType = typeof meta.type === 'string' ? meta.type.trim().toLowerCase() : '';
-  const rawTitle = typeof meta.title === 'string' ? meta.title.trim() : '';
-  const rawSummary = typeof meta.summary === 'string' ? meta.summary.trim() : '';
-  const rawDescription = typeof meta.description === 'string' ? meta.description.trim() : '';
-  const orientation = meta.orientation === 'portrait' ? 'portrait' : 'landscape';
-
-  const parseDuration = (value) => {
-    const numeric = Number(value);
-    if (!Number.isFinite(numeric) || numeric < 0) return 0;
-    return Math.round(numeric);
-  };
-
-  const durationSeconds = parseDuration(
-    meta.durationSeconds ?? meta.duration ?? meta.length ?? meta.seconds
-  );
-
-  const normalizeTimestamp = (stamp) => {
-    if (!stamp || typeof stamp !== 'object') return null;
-    const numericSeconds = Number(
-      stamp.seconds ?? stamp.time ?? stamp.at ?? stamp.offset ?? stamp.position
-    );
-    if (!Number.isFinite(numericSeconds) || numericSeconds < 0) {
-      return null;
-    }
-
-    const label =
-      typeof stamp.label === 'string'
-        ? stamp.label.trim()
-        : typeof stamp.title === 'string'
-          ? stamp.title.trim()
-          : '';
-    const descriptionValue =
-      typeof stamp.description === 'string' ? stamp.description.trim() : '';
-    const slugValue = typeof stamp.slug === 'string' ? stamp.slug.trim() : '';
-    const urlValue = typeof stamp.url === 'string' ? stamp.url.trim() : '';
-
-    const normalizedStamp = {
-      seconds: numericSeconds,
-    };
-
-    if (label) normalizedStamp.label = label;
-    if (descriptionValue) normalizedStamp.description = descriptionValue;
-    if (slugValue) normalizedStamp.slug = slugValue;
-    if (urlValue) normalizedStamp.url = urlValue;
-
-    return normalizedStamp;
-  };
-
-  const timestamps = Array.isArray(meta.timestamps)
-    ? meta.timestamps
-        .map((stamp) => normalizeTimestamp(stamp))
-        .filter(Boolean)
-    : [];
-
-  const preview =
-    (typeof meta.preview === 'string' && meta.preview.trim()) ||
-    (typeof meta.thumbnail === 'string' && meta.thumbnail.trim()) ||
-    (typeof meta.poster === 'string' && meta.poster.trim()) ||
-    '';
-  const poster = typeof meta.poster === 'string' ? meta.poster.trim() : '';
-  const thumbnail =
-    (typeof meta.thumbnail === 'string' && meta.thumbnail.trim()) || poster || '';
-  const src =
-    (typeof meta.src === 'string' && meta.src.trim()) ||
-    (typeof meta.url === 'string' && meta.url.trim()) ||
-    '';
-
-  const publishedAt = typeof meta.publishedAt === 'string' ? meta.publishedAt : '';
-  const likesNumeric = Number(meta.likes);
-  const viewsNumeric = Number(meta.views);
-
-  return {
-    slug: rawSlug,
-    type: rawType,
-    title: rawTitle,
-    summary: rawSummary,
-    description: rawDescription,
-    orientation,
-    durationSeconds,
-    timestamps,
-    preview,
-    poster,
-    thumbnail,
-    src,
-    publishedAt,
-    likes: Number.isFinite(likesNumeric) && likesNumeric >= 0 ? likesNumeric : 0,
-    views: Number.isFinite(viewsNumeric) && viewsNumeric >= 0 ? viewsNumeric : 0,
-  };
+  if (typeof cryptoObj?.randomUUID === 'function') {
+    return cryptoObj.randomUUID().replace(/-/g, '').slice(0, 16);
+  }
+  return raw.toLowerCase().replace(/[^a-z0-9]/g, '').slice(0, 16) || `slug-${Date.now()}`;
 }
 
-export default function Admin() {
+export default function AdminPage() {
   const router = useRouter();
   const token = typeof router.query.token === 'string' ? router.query.token : '';
+  const hasToken = Boolean(token);
 
+  const qs = useMemo(() => (hasToken ? `?token=${encodeURIComponent(token)}` : ''), [hasToken, token]);
+
+  const [view, setView] = useState('uploads');
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [orientation, setOrientation] = useState('landscape');
   const [duration, setDuration] = useState('0');
-  const [items, setItems] = useState([]);
-  const [copiedSlug, setCopiedSlug] = useState('');
-  const [editingItem, setEditingItem] = useState(null);
-  const [editForm, setEditForm] = useState({ title: '', description: '', imageUrl: '', previewUrl: '', durationSeconds: '' });
-  const [editInitialPreview, setEditInitialPreview] = useState('');
-  const [editError, setEditError] = useState('');
-  const [editStatus, setEditStatus] = useState('idle');
-  const [editUploadState, setEditUploadState] = useState('idle');
-  const [editUploadMessage, setEditUploadMessage] = useState('');
-  const [pendingDelete, setPendingDelete] = useState(null);
-  const [deleteStatus, setDeleteStatus] = useState('idle');
-  const [deleteError, setDeleteError] = useState('');
-  const [undoInfo, setUndoInfo] = useState(null);
-  const [undoStatus, setUndoStatus] = useState('idle');
-  const [view, setView] = useState('uploads');
-  const [metricsBySlug, setMetricsBySlug] = useState({});
-  const [metricsLoading, setMetricsLoading] = useState(false);
-  const [metricsError, setMetricsError] = useState(null);
-  const [metricsEditor, setMetricsEditor] = useState(null);
-  const metricsSaving = metricsEditor?.status === 'saving';
-  const metricsSuccess = metricsEditor?.status === 'success';
 
-  const copyTimeoutRef = useRef(null);
-  const pendingMetricsRef = useRef(new Set());
-  const editFileInputRef = useRef(null);
-  const undoTimeoutRef = useRef(null);
-  const adsterraPlacementsRequestRef = useRef(0);
-  const adsterraPlacementsInitializedRef = useRef(false);
-  const adsterraStatsRequestRef = useRef(0);
-  const adsterraDomainRequestRef = useRef(0);
-  const adsterraDomainResolvingRef = useRef(false);
+  const { items, setItems, refresh } = useAdminItems({ enabled: hasToken, queryString: qs });
+  const { copiedSlug, copy } = useClipboard();
+  const analytics = useAnalyticsMetrics({ items, enabled: hasToken && view === 'analytics' });
 
-  const hasToken = Boolean(token);
-  const qs = useMemo(() => (hasToken ? `?token=${encodeURIComponent(token)}` : ''), [token, hasToken]);
+  const defaultAdsterraRange = useMemo(() => getDefaultAdsterraDateRange(), []);
+  const adsterraEnvToken = useMemo(
+    () => (process.env.NEXT_PUBLIC_ADSTERRA_API_TOKEN || process.env.NEXT_PUBLIC_ADSTERRA_TOKEN || '').trim(),
+    []
+  );
+  const adsterraDomainIdEnv = useMemo(() => {
+    const raw = process.env.NEXT_PUBLIC_ADSTERRA_DOMAIN_ID;
+    return typeof raw === 'string' ? raw.trim() : '';
+  }, []);
+  const adsterraDomainNameEnv = useMemo(() => {
+    const raw = process.env.NEXT_PUBLIC_ADSTERRA_DOMAIN_NAME;
+    return typeof raw === 'string' ? raw.trim() : 'laffy.org';
+  }, []);
+  const adsterraDomainKeyEnv = useMemo(() => {
+    const raw = process.env.NEXT_PUBLIC_ADSTERRA_DOMAIN_KEY;
+    return typeof raw === 'string' ? raw.trim() : '';
+  }, []);
+
+  const adsterra = useAdsterraStats({
+    enabled: hasToken && view === 'adsterra',
+    defaultRange: defaultAdsterraRange,
+    envToken: adsterraEnvToken,
+    domainName: adsterraDomainNameEnv,
+    domainKey: adsterraDomainKeyEnv || adsterraDomainIdEnv,
+    initialDomainId: adsterraDomainIdEnv,
+  });
+
+  const {
+    editingItem,
+    editForm,
+    editStatus,
+    editError,
+    editUploadState,
+    editUploadMessage,
+    editFileInputRef,
+    openEditModal,
+    closeEditModal,
+    handleEditFieldChange,
+    handleEditImageUpload,
+    handleRevertImage,
+    handleSaveEdit,
+    pendingDelete,
+    deleteStatus,
+    deleteError,
+    openDeleteModal,
+    closeDeleteModal,
+    handleConfirmDelete,
+    undoInfo,
+    undoStatus,
+    handleUndoDelete,
+    handleDismissUndo,
+    timestampsEditor,
+    openTimestampsEditor,
+    closeTimestampsEditor,
+    handleTimestampsFieldChange,
+    handleAddTimestamp,
+    handleRemoveTimestamp,
+    handleSaveTimestamps,
+  } = useAdminModals({ hasToken, queryString: qs, setItems, refresh });
+
+  useEffect(() => {
+    if (!hasToken && (view === 'analytics' || view === 'adsterra')) {
+      setView('uploads');
+    }
+  }, [hasToken, view]);
+
   const numberFormatter = useMemo(() => new Intl.NumberFormat('ko-KR'), []);
   const decimalFormatterTwo = useMemo(
     () => new Intl.NumberFormat('ko-KR', { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
@@ -190,238 +150,6 @@ export default function Admin() {
     () => new Intl.NumberFormat('ko-KR', { minimumFractionDigits: 3, maximumFractionDigits: 3 }),
     []
   );
-  const defaultAdsterraRange = useMemo(() => getDefaultAdsterraDateRange(), []);
-  const adsterraEnvToken = useMemo(
-    () => (process.env.NEXT_PUBLIC_ADSTERRA_API_TOKEN || process.env.NEXT_PUBLIC_ADSTERRA_TOKEN || '').trim(),
-    []
-  );
-  const [adsterraDomainId, setAdsterraDomainId] = useState(() => {
-    const raw = process.env.NEXT_PUBLIC_ADSTERRA_DOMAIN_ID;
-    if (typeof raw === 'string') {
-      const trimmed = raw.trim();
-      if (trimmed) return trimmed;
-    }
-    return '';
-  });
-  const adsterraDomainName = useMemo(() => {
-    const raw = process.env.NEXT_PUBLIC_ADSTERRA_DOMAIN_NAME;
-    if (typeof raw === 'string') {
-      const trimmed = raw.trim();
-      if (trimmed) return trimmed;
-    }
-    return 'laffy.org';
-  }, []);
-  const adsterraDomainKey = useMemo(() => {
-    const raw = process.env.NEXT_PUBLIC_ADSTERRA_DOMAIN_KEY;
-    if (typeof raw === 'string') {
-      const trimmed = raw.trim();
-      if (trimmed) return trimmed;
-    }
-    return '';
-  }, []);
-  const [adsterraActiveToken, setAdsterraActiveToken] = useState(adsterraEnvToken);
-  const [adsterraPlacements, setAdsterraPlacements] = useState([]);
-  const [adsterraPlacementId, setAdsterraPlacementId] = useState(ADSTERRA_ALL_PLACEMENTS_VALUE);
-  const [adsterraStartDate, setAdsterraStartDate] = useState(defaultAdsterraRange.start);
-  const [adsterraEndDate, setAdsterraEndDate] = useState(defaultAdsterraRange.end);
-  const [adsterraStats, setAdsterraStats] = useState([]);
-  const [adsterraLoadingPlacements, setAdsterraLoadingPlacements] = useState(false);
-  const [adsterraLoadingStats, setAdsterraLoadingStats] = useState(false);
-  const [adsterraError, setAdsterraError] = useState('');
-  const [adsterraStatus, setAdsterraStatus] = useState('');
-  const [adsterraCountryFilter, setAdsterraCountryFilter] = useState('');
-  const [adsterraOsFilter, setAdsterraOsFilter] = useState('');
-  const [adsterraDeviceFilter, setAdsterraDeviceFilter] = useState('');
-  const [adsterraDeviceFormatFilter, setAdsterraDeviceFormatFilter] = useState('');
-
-  const navItems = useMemo(
-    () => [
-      { key: 'uploads', label: '업로드 · 목록', requiresToken: false },
-      { key: 'analytics', label: '분석', requiresToken: true },
-      { key: 'adsterra', label: '통계', requiresToken: true },
-    ],
-    []
-  );
-
-  const refresh = useCallback(async () => {
-    if (!hasToken) return;
-    try {
-      const res = await fetch(`/api/admin/list${qs}`);
-      if (!res.ok) {
-        setItems([]);
-        return;
-      }
-      const data = await res.json();
-      const baseItems = Array.isArray(data.items) ? data.items : [];
-      const enriched = await Promise.all(
-        baseItems.map(async (it) => {
-          try {
-            const metaFetchUrl = it.url
-              ? `${it.url}${it.url.includes('?') ? '&' : '?'}_=${Date.now()}`
-              : it.url;
-            const metaRes = await fetch(metaFetchUrl, { cache: 'no-store' });
-            if (!metaRes.ok) return { ...it, _error: true };
-            const meta = await metaRes.json();
-            const normalized = normalizeMeta(meta);
-            const fallbackSlug = it.pathname
-              ?.replace(/^content\//, '')
-              .replace(/\.json$/, '');
-            const slug = normalized.slug || fallbackSlug || '';
-            const type = normalized.type || 'video';
-            const preview = normalized.preview || normalized.thumbnail || normalized.poster || '';
-            const routePath = slug
-              ? type === 'image'
-                ? `/x/${slug}`
-                : `/m/${slug}`
-              : '';
-            const titleValue = normalized.title || slug;
-            const summaryValue = normalized.summary || normalized.description || '';
-            const descriptionValue = normalized.description || summaryValue;
-            const sourceUrl = normalized.src || meta?.sourceUrl || '';
-            const poster = normalized.poster || '';
-            const thumbnail = normalized.thumbnail || poster || '';
-            const orientationValue = normalized.orientation || 'landscape';
-            const durationSeconds = Number.isFinite(normalized.durationSeconds)
-              ? normalized.durationSeconds
-              : 0;
-            const timestamps = Array.isArray(normalized.timestamps)
-              ? normalized.timestamps
-              : [];
-            const likes = Number.isFinite(normalized.likes) ? normalized.likes : 0;
-            const views = Number.isFinite(normalized.views) ? normalized.views : 0;
-            const publishedAt = normalized.publishedAt || '';
-
-            return {
-              ...it,
-              slug,
-              type,
-              preview,
-              routePath,
-              title: titleValue,
-              summary: summaryValue,
-              description: descriptionValue,
-              src: sourceUrl,
-              poster,
-              thumbnail,
-              orientation: orientationValue,
-              durationSeconds,
-              timestamps,
-              likes,
-              views,
-              publishedAt,
-              rawMeta: meta,
-            };
-          } catch {
-            const slug = it.pathname?.replace(/^content\//, '').replace(/\.json$/, '');
-            return { ...it, slug, _error: true };
-          }
-        })
-      );
-      setItems(enriched);
-    } catch {
-      setItems([]);
-    }
-  }, [hasToken, qs]);
-
-  useEffect(() => { refresh(); }, [refresh]);
-
-  useEffect(() => {
-    if (!hasToken) return undefined;
-    const interval = setInterval(() => { refresh(); }, 15000);
-    const onVisibility = () => {
-      if (document.visibilityState === 'visible') refresh();
-    };
-    document.addEventListener('visibilitychange', onVisibility);
-    return () => {
-      clearInterval(interval);
-      document.removeEventListener('visibilitychange', onVisibility);
-    };
-  }, [hasToken, refresh]);
-
-  useEffect(() => () => {
-    if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
-    if (undoTimeoutRef.current) clearTimeout(undoTimeoutRef.current);
-  }, []);
-
-  useEffect(() => {
-    if (!hasToken && (view === 'analytics' || view === 'adsterra')) setView('uploads');
-  }, [hasToken, view]);
-
-  useEffect(() => {
-    setMetricsBySlug((prev) => {
-      if (!prev || typeof prev !== 'object') return {};
-      const next = {};
-      items.forEach((item) => {
-        if (item.slug && prev[item.slug]) next[item.slug] = prev[item.slug];
-      });
-      const prevKeys = Object.keys(prev);
-      const nextKeys = Object.keys(next);
-      if (
-        prevKeys.length === nextKeys.length &&
-        nextKeys.every((key) => prev[key] === next[key])
-      ) {
-        return prev;
-      }
-      return next;
-    });
-  }, [items]);
-
-  useEffect(() => {
-    if (!hasToken || view !== 'analytics') return undefined;
-    const slugs = items.map((it) => it.slug).filter(Boolean);
-    const pendingSet = pendingMetricsRef.current;
-    const fetchTargets = slugs.filter((slug) => !metricsBySlug[slug] && !pendingSet.has(slug));
-    if (!fetchTargets.length) {
-      setMetricsLoading(false);
-      return undefined;
-    }
-
-    fetchTargets.forEach((slug) => pendingSet.add(slug));
-    let cancelled = false;
-
-    setMetricsLoading(true);
-    setMetricsError(null);
-
-    (async () => {
-      try {
-        const results = await Promise.all(
-          fetchTargets.map(async (slug) => {
-            const res = await fetch(`/api/metrics/get?slug=${encodeURIComponent(slug)}`);
-            if (!res.ok) {
-              throw new Error('metrics_error');
-            }
-            const data = await res.json();
-            return {
-              slug,
-              metrics: {
-                views: Number(data?.views) || 0,
-                likes: Math.max(0, Number(data?.likes) || 0),
-              },
-            };
-          })
-        );
-        if (cancelled) return;
-        setMetricsBySlug((prev) => {
-          const next = { ...prev };
-          results.forEach(({ slug, metrics }) => {
-            next[slug] = metrics;
-          });
-          return next;
-        });
-      } catch (err) {
-        if (!cancelled) setMetricsError('메트릭을 불러오지 못했어요.');
-      } finally {
-        fetchTargets.forEach((slug) => pendingSet.delete(slug));
-        if (!cancelled) setMetricsLoading(false);
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-      fetchTargets.forEach((slug) => pendingSet.delete(slug));
-      setMetricsLoading(false);
-    };
-  }, [hasToken, view, items, metricsBySlug]);
 
   const formatNumber = useCallback(
     (value) => {
@@ -445,830 +173,86 @@ export default function Admin() {
     [decimalFormatterThree, decimalFormatterTwo]
   );
 
-  const analyticsRows = useMemo(
-    () =>
-      items
-        .filter((it) => it.slug)
-        .map((it) => ({
-          ...it,
-          metrics: metricsBySlug[it.slug] || null,
-        })),
-    [items, metricsBySlug]
-  );
-
-  const sortedAnalyticsRows = useMemo(
-    () =>
-      [...analyticsRows].sort((a, b) => {
-        const aViews = a.metrics?.views ?? 0;
-        const bViews = b.metrics?.views ?? 0;
-        return bViews - aViews;
-      }),
-    [analyticsRows]
-  );
-
-  const analyticsTotals = useMemo(
-    () =>
-      analyticsRows.reduce(
-        (acc, row) => {
-          if (!row.metrics) return acc;
-          return {
-            views: acc.views + (row.metrics.views || 0),
-            likes: acc.likes + (row.metrics.likes || 0),
-          };
-        },
-        { views: 0, likes: 0 }
-      ),
-    [analyticsRows]
-  );
-
-  const averageLikeRate = useMemo(() => {
-    const withViews = analyticsRows.filter((row) => row.metrics && row.metrics.views > 0);
-    if (!withViews.length) return 0;
-    const totalRate = withViews.reduce((acc, row) => acc + row.metrics.likes / row.metrics.views, 0);
-    return totalRate / withViews.length;
-  }, [analyticsRows]);
-
-  const adsterraPlacementLabelMap = useMemo(() => {
-    const map = new Map();
-    adsterraPlacements.forEach((placement) => {
-      if (!placement || typeof placement !== 'object') return;
-      const id = placement.id ?? placement.ID ?? placement.placement_id ?? placement.placementId;
-      if (!id && id !== 0) return;
-      const label = placement.title
-        || placement.alias
-        || placement.name
-        || placement.placement
-        || placement.ad_format
-        || placement.format
-        || String(id);
-      map.set(String(id), label);
-    });
-    return map;
-  }, [adsterraPlacements]);
-
-  const adsterraCountryOptions = useMemo(() => {
-    const values = new Set();
-    adsterraStats.forEach((row) => {
-      const value = row?.country ?? row?.Country ?? row?.geo ?? row?.Geo;
-      if (value) values.add(String(value));
-    });
-    return Array.from(values).sort((a, b) => a.localeCompare(b));
-  }, [adsterraStats]);
-
-  const adsterraOsOptions = useMemo(() => {
-    const values = new Set();
-    adsterraStats.forEach((row) => {
-      const value = row?.os ?? row?.OS ?? row?.platform ?? row?.Platform;
-      if (value) values.add(String(value));
-    });
-    return Array.from(values).sort((a, b) => a.localeCompare(b));
-  }, [adsterraStats]);
-
-  const adsterraDeviceOptions = useMemo(() => {
-    const values = new Set();
-    adsterraStats.forEach((row) => {
-      const value = row?.device ?? row?.Device ?? row?.device_type ?? row?.deviceType;
-      if (value) values.add(String(value));
-    });
-    return Array.from(values).sort((a, b) => a.localeCompare(b));
-  }, [adsterraStats]);
-
-  const adsterraDeviceFormatOptions = useMemo(() => {
-    const values = new Set();
-    adsterraStats.forEach((row) => {
-      const value = row?.device_format ?? row?.deviceFormat ?? row?.DeviceFormat;
-      if (value) values.add(String(value));
-    });
-    return Array.from(values).sort((a, b) => a.localeCompare(b));
-  }, [adsterraStats]);
-
-  const filteredAdsterraStats = useMemo(() => {
-    const normalize = (value) => {
-      if (value === null || value === undefined) return '';
-      return String(value).trim().toLowerCase();
-    };
-
-    const normalizedCountry = normalize(adsterraCountryFilter);
-    const normalizedOs = normalize(adsterraOsFilter);
-    const normalizedDevice = normalize(adsterraDeviceFilter);
-    const normalizedDeviceFormat = normalize(adsterraDeviceFormatFilter);
-
-    return adsterraStats.filter((row) => {
-      const countryValue = row?.country ?? row?.Country ?? row?.geo ?? row?.Geo;
-      if (normalizedCountry && normalize(countryValue) !== normalizedCountry) return false;
-
-      const osValue = row?.os ?? row?.OS ?? row?.platform ?? row?.Platform;
-      if (normalizedOs && normalize(osValue) !== normalizedOs) return false;
-
-      const deviceValue = row?.device ?? row?.Device ?? row?.device_type ?? row?.deviceType;
-      if (normalizedDevice && normalize(deviceValue) !== normalizedDevice) return false;
-
-      const deviceFormatValue = row?.device_format ?? row?.deviceFormat ?? row?.DeviceFormat;
-      if (normalizedDeviceFormat && normalize(deviceFormatValue) !== normalizedDeviceFormat) return false;
-
-      return true;
-    });
-  }, [adsterraStats, adsterraCountryFilter, adsterraDeviceFilter, adsterraDeviceFormatFilter, adsterraOsFilter]);
-
-  const adsterraTotals = useMemo(() => {
-    if (!Array.isArray(filteredAdsterraStats) || !filteredAdsterraStats.length) {
-      return { impressions: 0, clicks: 0, revenue: 0, ctr: 0, cpm: 0 };
-    }
-
-    const totals = filteredAdsterraStats.reduce(
-      (acc, row) => {
-        const impressions = Number(row?.impression ?? row?.impressions ?? 0);
-        const clicks = Number(row?.clicks ?? row?.click ?? 0);
-        const revenue = Number(row?.revenue ?? 0);
-        return {
-          impressions: acc.impressions + (Number.isFinite(impressions) ? impressions : 0),
-          clicks: acc.clicks + (Number.isFinite(clicks) ? clicks : 0),
-          revenue: acc.revenue + (Number.isFinite(revenue) ? revenue : 0),
-        };
-      },
-      { impressions: 0, clicks: 0, revenue: 0 }
-    );
-
-    const ctr = totals.impressions > 0 ? (totals.clicks / totals.impressions) * 100 : 0;
-    const cpm = totals.impressions > 0 ? (totals.revenue / totals.impressions) * 1000 : 0;
-
-    return { ...totals, ctr, cpm };
-  }, [filteredAdsterraStats]);
-
-  const adsterraAllPlacementsSelected = adsterraPlacementId === ADSTERRA_ALL_PLACEMENTS_VALUE;
-
-  const adsterraCanFetchStats = Boolean(
-    adsterraActiveToken &&
-    adsterraDomainId &&
-    adsterraStartDate &&
-    adsterraEndDate &&
-    (adsterraAllPlacementsSelected || adsterraPlacementId)
-  );
-
   const formatPercent = useCallback((value) => {
     if (!Number.isFinite(value)) return '0%';
     return `${(value * 100).toFixed(1)}%`;
   }, []);
 
-  const uploadsVisible = view === 'uploads';
-  const analyticsVisible = view === 'analytics';
-  const adsterraVisible = view === 'adsterra';
+  const uploadFormState = useMemo(
+    () => ({
+      title,
+      description,
+      orientation,
+      duration,
+      setTitle,
+      setDescription,
+      setOrientation,
+      setDuration,
+      handleUploadUrl: `/api/blob/upload${qs}`,
+    }),
+    [description, duration, orientation, qs, title]
+  );
 
-  useEffect(() => {
-    if (adsterraEnvToken && !adsterraActiveToken) {
-      setAdsterraActiveToken(adsterraEnvToken);
-    }
-  }, [adsterraActiveToken, adsterraEnvToken]);
+  const registerMeta = useCallback(
+    async (blob) => {
+      if (!hasToken) return;
+      const slug = await generateSlug(blob);
+      const contentType = typeof blob?.contentType === 'string' ? blob.contentType : '';
+      const pathname = typeof blob?.pathname === 'string' ? blob.pathname : '';
+      const lowerPathname = pathname.toLowerCase();
+      const lowerUrl = typeof blob?.url === 'string' ? blob.url.toLowerCase() : '';
+      const imageExtPattern = /(\.jpe?g|\.png|\.webp)$/;
+      const hasImageExtension = imageExtPattern.test(lowerPathname) || imageExtPattern.test(lowerUrl);
+      const isImage = contentType.startsWith('image/') || hasImageExtension;
+      const normalizedType = isImage ? 'image' : 'video';
+      const durationSeconds = (() => {
+        const parsed = Number(duration);
+        return Number.isFinite(parsed) && parsed >= 0 ? Math.round(parsed) : 0;
+      })();
 
-  const resolveAdsterraDomainId = useCallback(async () => {
-    if (!adsterraActiveToken) {
-      return;
-    }
-    if (adsterraDomainId) {
-      return;
-    }
-    if (adsterraDomainResolvingRef.current) {
-      return;
-    }
-
-    const requestId = adsterraDomainRequestRef.current + 1;
-    adsterraDomainRequestRef.current = requestId;
-    adsterraDomainResolvingRef.current = true;
-    setAdsterraStatus('도메인 정보를 불러오는 중이에요.');
-    setAdsterraError('');
-
-    try {
-      const res = await fetch('/api/adsterra/domains', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ token: adsterraActiveToken }),
-      });
-      const json = await res.json().catch(() => ({}));
-      if (!res.ok) {
-        throw new Error(json?.error || '도메인 목록을 불러오지 못했어요.');
-      }
-      if (adsterraDomainRequestRef.current !== requestId) return;
-
-      const domains = Array.isArray(json?.domains) ? json.domains : [];
-      const normalizedName = adsterraDomainName.trim().toLowerCase();
-      const normalizedKey = adsterraDomainKey.trim().toLowerCase();
-      const matched = domains.find((domain) => {
-        if (!domain || typeof domain !== 'object') return false;
-        const domainIdValue = (domain.id ?? '').toString().trim();
-        const domainTitleValue = (domain.title ?? '').toString().trim();
-        const normalizedTitle = domainTitleValue.toLowerCase();
-        if (normalizedName && normalizedTitle === normalizedName) {
-          return true;
-        }
-        if (!normalizedKey) {
-          return false;
-        }
-        return normalizedTitle === normalizedKey || domainIdValue.toLowerCase() === normalizedKey;
-      });
-
-      if (matched && matched.id) {
-        setAdsterraDomainId(String(matched.id));
-        setAdsterraStatus(`도메인 ${matched.title || matched.id}을(를) 사용해요.`);
-        setAdsterraError('');
-      } else {
-        setAdsterraStatus('');
-        setAdsterraError('도메인 목록에서 일치하는 항목을 찾지 못했어요. 환경 변수를 확인해 주세요.');
-      }
-    } catch (error) {
-      if (adsterraDomainRequestRef.current === requestId) {
-        setAdsterraStatus('');
-        setAdsterraError(error.message || '도메인 목록을 불러오지 못했어요.');
-      }
-    } finally {
-      if (adsterraDomainRequestRef.current === requestId) {
-        adsterraDomainResolvingRef.current = false;
-      }
-    }
-  }, [adsterraActiveToken, adsterraDomainId, adsterraDomainKey, adsterraDomainName]);
-
-  useEffect(() => {
-    if (!adsterraActiveToken) return;
-    if (adsterraDomainId) return;
-    resolveAdsterraDomainId();
-  }, [adsterraActiveToken, adsterraDomainId, resolveAdsterraDomainId]);
-
-  const fetchAdsterraPlacements = useCallback(async () => {
-    if (adsterraLoadingPlacements) {
-      return;
-    }
-    if (!adsterraActiveToken) {
-      setAdsterraError('통계 API 토큰이 설정되지 않았어요.');
-      return;
-    }
-    if (!adsterraDomainId) {
-      setAdsterraError('도메인 정보가 올바르지 않습니다.');
-      return;
-    }
-
-    adsterraPlacementsInitializedRef.current = true;
-    const requestId = adsterraPlacementsRequestRef.current + 1;
-    adsterraPlacementsRequestRef.current = requestId;
-    setAdsterraLoadingPlacements(true);
-    setAdsterraError('');
-    setAdsterraStatus('');
-
-    try {
-      const res = await fetch('/api/adsterra/placements', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ token: adsterraActiveToken, domainId: adsterraDomainId }),
-      });
-      const json = await res.json().catch(() => ({}));
-      if (!res.ok) {
-        throw new Error(json?.error || '플레이스먼트를 불러오지 못했어요.');
-      }
-      if (adsterraPlacementsRequestRef.current !== requestId) return;
-      const placements = Array.isArray(json?.placements) ? json.placements : [];
-      setAdsterraPlacements(placements);
-
-      const extractPlacementId = (placement) => {
-        if (!placement || typeof placement !== 'object') return '';
-        const idValue = placement.id ?? placement.ID ?? placement.placement_id ?? placement.placementId ?? placement.value;
-        return idValue !== undefined && idValue !== null ? String(idValue) : '';
-      };
-
-      const isAllSelected = adsterraPlacementId === ADSTERRA_ALL_PLACEMENTS_VALUE;
-
-      if (placements.length) {
-        const hasCurrent = placements.some((placement) => extractPlacementId(placement) === adsterraPlacementId);
-        if (!hasCurrent && !isAllSelected) {
-          const firstId = extractPlacementId(placements[0]);
-          if (firstId) {
-            setAdsterraPlacementId(firstId);
-          }
-        }
-      } else {
-        setAdsterraPlacementId(ADSTERRA_ALL_PLACEMENTS_VALUE);
-      }
-      setAdsterraStatus(placements.length ? '플레이스먼트를 불러왔어요.' : '등록된 플레이스먼트를 찾을 수 없어요.');
-    } catch (error) {
-      if (adsterraPlacementsRequestRef.current === requestId) {
-        setAdsterraPlacements([]);
-        setAdsterraPlacementId(ADSTERRA_ALL_PLACEMENTS_VALUE);
-        setAdsterraStats([]);
-        setAdsterraError(error.message || '플레이스먼트를 불러오지 못했어요.');
-      }
-    } finally {
-      if (adsterraPlacementsRequestRef.current === requestId) {
-        setAdsterraLoadingPlacements(false);
-      }
-    }
-  }, [adsterraActiveToken, adsterraDomainId, adsterraLoadingPlacements, adsterraPlacementId]);
-
-  useEffect(() => {
-    adsterraPlacementsInitializedRef.current = false;
-  }, [adsterraActiveToken, adsterraDomainId]);
-
-  useEffect(() => {
-    if (!adsterraVisible) return;
-    if (adsterraPlacementsInitializedRef.current) return;
-    if (!adsterraActiveToken) {
-      setAdsterraError('통계 API 토큰이 설정되지 않았어요.');
-      return;
-    }
-    if (!adsterraDomainId) {
-      resolveAdsterraDomainId();
-      return;
-    }
-    fetchAdsterraPlacements();
-  }, [
-    adsterraVisible,
-    adsterraActiveToken,
-    fetchAdsterraPlacements,
-    adsterraDomainId,
-    resolveAdsterraDomainId,
-  ]);
-
-  const handleAdsterraPlacementChange = useCallback((value) => {
-    const placementValue = value === null || value === undefined ? '' : String(value);
-    setAdsterraPlacementId(placementValue);
-    setAdsterraStats([]);
-    setAdsterraStatus('');
-    setAdsterraError('');
-  }, []);
-
-  const handleResetAdsterraDates = useCallback(() => {
-    const defaults = getDefaultAdsterraDateRange();
-    setAdsterraStartDate(defaults.start);
-    setAdsterraEndDate(defaults.end);
-  }, []);
-
-  const handleFetchAdsterraStats = useCallback(async () => {
-    if (!adsterraActiveToken) {
-      setAdsterraError('통계 API 토큰 환경 변수를 확인해 주세요.');
-      return;
-    }
-    if (!adsterraDomainId) {
-      setAdsterraError('도메인 정보가 설정되지 않았어요. 환경 변수를 확인해 주세요.');
-      return;
-    }
-    if (!adsterraAllPlacementsSelected && !adsterraPlacementId) {
-      setAdsterraError('광고 포맷(플레이스먼트)을 선택해 주세요.');
-      return;
-    }
-    if (!adsterraStartDate || !adsterraEndDate) {
-      setAdsterraError('조회 기간을 모두 입력해 주세요.');
-      return;
-    }
-
-    const start = new Date(adsterraStartDate);
-    const end = new Date(adsterraEndDate);
-    if (start > end) {
-      setAdsterraError('시작일은 종료일보다 늦을 수 없어요.');
-      return;
-    }
-
-    const requestId = adsterraStatsRequestRef.current + 1;
-    adsterraStatsRequestRef.current = requestId;
-    setAdsterraLoadingStats(true);
-    setAdsterraError('');
-    setAdsterraStatus('');
-    setAdsterraStats([]);
-
-    try {
-      const res = await fetch('/api/adsterra/stats', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({
-          token: adsterraActiveToken,
-          domainId: adsterraDomainId,
-          placementId: adsterraAllPlacementsSelected ? undefined : adsterraPlacementId,
-          allPlacements: adsterraAllPlacementsSelected,
-          startDate: adsterraStartDate,
-          endDate: adsterraEndDate,
-          groupBy: ['date'],
-        }),
-      });
-      const json = await res.json().catch(() => ({}));
-      if (!res.ok) {
-        throw new Error(json?.error || '통계를 불러오지 못했어요.');
-      }
-      if (adsterraStatsRequestRef.current !== requestId) return;
-      const items = Array.isArray(json?.items) ? json.items : [];
-      setAdsterraStats(items);
-      setAdsterraStatus(`총 ${items.length}건의 통계를 불러왔어요. (필터는 클라이언트에서 적용됩니다)`);
-    } catch (error) {
-      if (adsterraStatsRequestRef.current === requestId) {
-        setAdsterraStats([]);
-        setAdsterraError(error.message || '통계를 불러오지 못했어요.');
-      }
-    } finally {
-      if (adsterraStatsRequestRef.current === requestId) {
-        setAdsterraLoadingStats(false);
-      }
-    }
-  }, [
-    adsterraActiveToken,
-    adsterraDomainId,
-    adsterraPlacementId,
-    adsterraStartDate,
-    adsterraEndDate,
-  ]);
-
-  useEffect(() => {
-    if (!adsterraVisible) return;
-    if (!adsterraCanFetchStats) return;
-    handleFetchAdsterraStats();
-  }, [adsterraVisible, adsterraCanFetchStats, handleFetchAdsterraStats]);
-
-  const openEditModal = useCallback((item) => {
-    if (!item) return;
-    const initialPreview = item.type === 'image'
-      ? item.src || item.preview || ''
-      : item.poster || item.thumbnail || item.preview || '';
-    const numericDuration = (() => {
-      const parsed = Number(item.durationSeconds);
-      if (!Number.isFinite(parsed) || parsed < 0) return 0;
-      return Math.round(parsed);
-    })();
-
-    setEditForm({
-      title: item.title || item.slug,
-      description: item.description || '',
-      imageUrl: '',
-      previewUrl: initialPreview,
-      durationSeconds: String(numericDuration),
-    });
-    setEditInitialPreview(initialPreview);
-    setEditUploadMessage('');
-    setEditUploadState('idle');
-    setEditError('');
-    setEditStatus('idle');
-    if (editFileInputRef.current) editFileInputRef.current.value = '';
-    setEditingItem({
-      ...item,
-      durationSeconds: numericDuration,
-    });
-  }, []);
-
-  const closeEditModal = useCallback(() => {
-    setEditingItem(null);
-    setEditForm({ title: '', description: '', imageUrl: '', previewUrl: '', durationSeconds: '' });
-    setEditInitialPreview('');
-    setEditUploadMessage('');
-    setEditUploadState('idle');
-    setEditError('');
-    setEditStatus('idle');
-    if (editFileInputRef.current) editFileInputRef.current.value = '';
-  }, []);
-
-  const handleEditFieldChange = useCallback((field, value) => {
-    setEditForm((prev) => ({ ...prev, [field]: value }));
-    if ((field === 'title' || field === 'durationSeconds') && editError) setEditError('');
-  }, [editError]);
-
-  const handleEditImageUpload = useCallback(async (event) => {
-    const file = event?.target?.files?.[0];
-    if (!file || !editingItem) return;
-
-    setEditUploadMessage('');
-    setEditError('');
-
-    if (!file.type.startsWith('image/')) {
-      setEditUploadState('error');
-      setEditUploadMessage('이미지 파일만 업로드할 수 있어요.');
-      if (editFileInputRef.current) editFileInputRef.current.value = '';
-      return;
-    }
-
-    const maxSizeMB = 200;
-    if (file.size > maxSizeMB * 1024 * 1024) {
-      setEditUploadState('error');
-      setEditUploadMessage(`이미지 크기가 너무 커요. 최대 ${maxSizeMB}MB까지 가능합니다.`);
-      if (editFileInputRef.current) editFileInputRef.current.value = '';
-      return;
-    }
-
-    try {
-      setEditUploadState('uploading');
-      const sanitizedName = file.name.replace(/\s+/g, '-');
-      const uniqueName = `${Date.now()}-${sanitizedName}`;
-      const blob = await upload(`images/${uniqueName}`, file, {
-        access: 'public',
-        handleUploadUrl: `/api/blob/upload${qs}`,
-        contentType: file.type,
-      });
-      setEditForm((prev) => ({ ...prev, imageUrl: blob.url, previewUrl: blob.url }));
-      setEditUploadState('success');
-      setEditUploadMessage('새 이미지가 업로드되었습니다.');
-    } catch (error) {
-      console.error('Edit image upload failed', error);
-      setEditUploadState('error');
-      setEditUploadMessage('이미지 업로드에 실패했어요. 잠시 후 다시 시도해주세요.');
-    } finally {
-      if (editFileInputRef.current) editFileInputRef.current.value = '';
-    }
-  }, [editingItem, qs]);
-
-  const handleRevertImage = useCallback(() => {
-    setEditForm((prev) => ({ ...prev, imageUrl: '', previewUrl: editInitialPreview }));
-    setEditUploadState('idle');
-    setEditUploadMessage('기존 이미지로 되돌렸어요.');
-    if (editFileInputRef.current) editFileInputRef.current.value = '';
-  }, [editInitialPreview]);
-
-  const buildRegisterPayload = useCallback((item) => {
-    if (!item) return null;
-    const typeValue = (item.type || '').toLowerCase();
-    const isImage = typeValue === 'image';
-    const previewCandidates = [item.preview, item.poster, item.thumbnail];
-    const basePreview = previewCandidates.find((value) => typeof value === 'string' && value.trim().length > 0) || '';
-    const srcCandidates = [item.src, item.poster, item.thumbnail, basePreview];
-    const assetUrl = srcCandidates.find((value) => typeof value === 'string' && value.trim().length > 0) || '';
-    if (!assetUrl) return null;
-
-    const posterCandidates = isImage
-      ? [item.poster, assetUrl, item.thumbnail, basePreview]
-      : [item.poster, item.thumbnail, basePreview];
-    const posterUrl = posterCandidates.find((value) => typeof value === 'string' && value.trim().length > 0) || '';
-
-    const thumbnailCandidates = isImage
-      ? [item.thumbnail, posterUrl, assetUrl, basePreview]
-      : [item.thumbnail, posterUrl, basePreview];
-    const thumbnailUrl = thumbnailCandidates.find((value) => typeof value === 'string' && value.trim().length > 0) || '';
-
-    const likesNumber = Number(item.likes);
-    const viewsNumber = Number(item.views);
-
-    const rawDuration = Number(item.durationSeconds);
-    const durationSeconds = Number.isFinite(rawDuration) && rawDuration >= 0 ? Math.round(rawDuration) : 0;
-
-    return {
-      slug: item.slug,
-      title: item.title || item.slug,
-      description: item.description || '',
-      url: assetUrl,
-      durationSeconds,
-      orientation: item.orientation || 'landscape',
-      type: isImage ? 'image' : (typeValue || 'video'),
-      poster: posterUrl || null,
-      thumbnail: thumbnailUrl || null,
-      likes: Number.isFinite(likesNumber) ? likesNumber : 0,
-      views: Number.isFinite(viewsNumber) ? viewsNumber : 0,
-      publishedAt: item.publishedAt || '',
-    };
-  }, []);
-
-  const clearUndoTimer = useCallback(() => {
-    if (undoTimeoutRef.current) {
-      clearTimeout(undoTimeoutRef.current);
-      undoTimeoutRef.current = null;
-    }
-  }, []);
-
-  const openDeleteModal = useCallback((item) => {
-    setPendingDelete(item);
-    setDeleteStatus('idle');
-    setDeleteError('');
-  }, []);
-
-  const closeDeleteModal = useCallback(() => {
-    setPendingDelete(null);
-    setDeleteStatus('idle');
-    setDeleteError('');
-  }, []);
-
-  const handleSaveEdit = useCallback(async () => {
-    if (!editingItem) return;
-    if (!hasToken) {
-      setEditError('관리자 토큰이 필요합니다.');
-      return;
-    }
-
-    const trimmedTitle = (editForm.title || '').trim();
-    if (!trimmedTitle) {
-      setEditError('제목을 입력해 주세요.');
-      return;
-    }
-
-    const trimmedDescription = (editForm.description || '').trim();
-    const isImageType = editingItem.type === 'image';
-    const rawDurationInput = typeof editForm.durationSeconds === 'string'
-      ? editForm.durationSeconds.trim()
-      : String(editForm.durationSeconds || '').trim();
-
-    let resolvedDurationSeconds;
-    if (rawDurationInput === '') {
-      const currentDuration = Number(editingItem.durationSeconds);
-      resolvedDurationSeconds = Number.isFinite(currentDuration)
-        ? Math.max(0, Math.round(currentDuration))
-        : 0;
-    } else {
-      const parsed = Number(rawDurationInput);
-      if (!Number.isFinite(parsed) || parsed < 0) {
-        setEditError('재생 시간을 올바른 숫자로 입력해 주세요.');
-        return;
-      }
-      resolvedDurationSeconds = Math.max(0, Math.round(parsed));
-    }
-
-    const newImageUrl = editForm.imageUrl;
-    const basePreview = editInitialPreview || editingItem.preview || '';
-
-    const assetUrl = isImageType
-      ? newImageUrl
-        || editingItem.src
-        || editingItem.poster
-        || editingItem.thumbnail
-        || basePreview
-        || ''
-      : editingItem.src
-        || editingItem.poster
-        || editingItem.thumbnail
-        || basePreview
-        || newImageUrl
-        || '';
-
-    const posterUrl = isImageType
-      ? (newImageUrl || assetUrl)
-      : (newImageUrl || editingItem.poster || editingItem.thumbnail || basePreview || '');
-
-    const thumbnailUrl = isImageType
-      ? (newImageUrl || assetUrl)
-      : (newImageUrl || editingItem.thumbnail || editingItem.poster || basePreview || '');
-
-    if (!assetUrl) {
-      setEditStatus('idle');
-      setEditError('원본 소스를 찾을 수 없어요. 이미지를 다시 업로드해 주세요.');
-      return;
-    }
-
-    setEditStatus('saving');
-    setEditError('');
-
-    try {
-      const res = await fetch(`/api/admin/register${qs}`, {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({
-          slug: editingItem.slug,
-          title: trimmedTitle,
-          description: trimmedDescription,
-          url: assetUrl,
-          durationSeconds: resolvedDurationSeconds,
-          orientation: editingItem.orientation,
-          type: editingItem.type,
-          poster: posterUrl,
-          thumbnail: thumbnailUrl,
-          likes: editingItem.likes,
-          views: editingItem.views,
-          publishedAt: editingItem.publishedAt,
-          metaUrl: editingItem.url,
-        }),
-      });
-
-      if (!res.ok) {
-        const payload = await res.json().catch(() => ({}));
-        const message = payload?.error || 'save_failed';
-        throw new Error(message);
-      }
-
-      setEditStatus('success');
-      setItems((prev) => prev.map((it) => (it.slug === editingItem.slug
-        ? { ...it, durationSeconds: resolvedDurationSeconds }
-        : it)));
-      setEditForm((prev) => ({
-        ...prev,
-        durationSeconds: String(resolvedDurationSeconds),
-      }));
-      setEditingItem((prev) => (prev ? {
-        ...prev,
-        durationSeconds: resolvedDurationSeconds,
-      } : prev));
-      await refresh();
-      setTimeout(() => {
-        closeEditModal();
-      }, 900);
-    } catch (error) {
-      console.error('Edit save failed', error);
-      setEditStatus('error');
-      setEditError(error?.message === 'save_failed'
-        ? '저장에 실패했어요. 잠시 후 다시 시도해 주세요.'
-        : error?.message || '저장에 실패했어요. 잠시 후 다시 시도해 주세요.');
-    }
-  }, [closeEditModal, editForm.description, editForm.durationSeconds, editForm.imageUrl, editForm.title, editInitialPreview, editingItem, hasToken, qs, refresh, setEditingItem]);
-
-  const handleConfirmDelete = useCallback(async () => {
-    if (!pendingDelete) return;
-    const item = pendingDelete;
-    const payload = buildRegisterPayload(item);
-    const metaUrl = typeof item.url === 'string' ? item.url : '';
-    const body = item.url
-      ? { url: item.url, slug: item.slug, type: item.type }
-      : { pathname: item.pathname, slug: item.slug, type: item.type };
-    setDeleteStatus('pending');
-    setDeleteError('');
-
-    try {
-      const res = await fetch(`/api/admin/delete${qs}`, {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify(body),
-      });
-      if (!res.ok) throw new Error('delete_failed');
-
-      closeDeleteModal();
-      if (payload) {
-        clearUndoTimer();
-        setUndoInfo({
-          payload,
-          metaUrl,
-          title: payload.title,
-          slug: item.slug,
+      try {
+        const res = await fetch(`/api/admin/register${qs}`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            slug,
+            title,
+            description,
+            url: blob.url,
+            durationSeconds,
+            orientation,
+            type: normalizedType,
+            poster: isImage ? blob.url : null,
+            thumbnail: isImage ? blob.url : null,
+          }),
         });
-        setUndoStatus('idle');
-        undoTimeoutRef.current = setTimeout(() => {
-          setUndoInfo(null);
-          setUndoStatus('idle');
-        }, 10000);
-      } else {
-        setUndoInfo(null);
-        setUndoStatus('idle');
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          alert(`메타 저장 실패: ${err.error || res.status}`);
+          return;
+        }
+        setTitle('');
+        setDescription('');
+        setDuration('0');
+        refresh();
+      } catch (error) {
+        console.error('Meta register failed', error);
       }
-      refresh();
-    } catch (error) {
-      console.error('Delete failed', error);
-      setDeleteStatus('error');
-      setDeleteError('삭제에 실패했어요. 잠시 후 다시 시도해 주세요.');
-    }
-  }, [pendingDelete, buildRegisterPayload, qs, clearUndoTimer, closeDeleteModal, refresh]);
+    },
+    [description, duration, hasToken, orientation, qs, refresh, title]
+  );
 
-  const handleUndoDelete = useCallback(async () => {
-    if (!undoInfo) return;
-    setUndoStatus('pending');
-    try {
-      const res = await fetch(`/api/admin/register${qs}`, {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({
-          ...undoInfo.payload,
-          metaUrl: undoInfo.metaUrl,
-        }),
-      });
-      if (!res.ok) throw new Error('undo_failed');
-      setUndoStatus('success');
-      clearUndoTimer();
-      undoTimeoutRef.current = setTimeout(() => {
-        setUndoInfo(null);
-        setUndoStatus('idle');
-      }, 1200);
-      await refresh();
-    } catch (error) {
-      console.error('Undo failed', error);
-      setUndoStatus('error');
-    }
-  }, [undoInfo, qs, refresh, clearUndoTimer]);
-
-  const handleDismissUndo = useCallback(() => {
-    clearUndoTimer();
-    setUndoInfo(null);
-    setUndoStatus('idle');
-  }, [clearUndoTimer]);
-
-  const openMetricsEditor = useCallback((row) => {
-    if (!row?.slug) return;
-    const baseViews = typeof row.metrics?.views === 'number'
-      ? row.metrics.views
-      : (typeof row.views === 'number' ? row.views : null);
-    const baseLikes = typeof row.metrics?.likes === 'number'
-      ? row.metrics.likes
-      : (typeof row.likes === 'number' ? row.likes : null);
-    const views = baseViews === null ? '' : String(baseViews);
-    const likes = baseLikes === null ? '' : String(baseLikes);
-    setMetricsEditor({
-      slug: row.slug,
-      title: row.title || row.slug,
-      views,
-      likes,
-      status: 'idle',
-      error: '',
-    });
-  }, []);
-
-  const closeMetricsEditor = useCallback(() => {
-    setMetricsEditor(null);
-  }, []);
-
-  const handleMetricsFieldChange = useCallback((field, value) => {
-    setMetricsEditor((prev) => {
-      if (!prev) return prev;
-      return {
-        ...prev,
-        [field]: value,
-        error: '',
-        status: prev.status === 'error' ? 'idle' : prev.status,
-      };
-    });
-  }, []);
+  const handleCopyRoute = useCallback(
+    async (item) => {
+      if (!item?.routePath) return;
+      await copy(item.slug, item.routePath);
+    },
+    [copy]
+  );
 
   const handleMetricsSave = useCallback(async () => {
-    if (!metricsEditor || !hasToken) return;
-    const { slug, views, likes } = metricsEditor;
+    const editor = analytics.metricsEditor;
+    if (!editor || !hasToken) return;
 
     const parseValue = (raw) => {
       if (raw === null || raw === undefined) return null;
@@ -1278,21 +262,25 @@ export default function Admin() {
       return Math.max(0, Math.round(num));
     };
 
-    const parsedViews = parseValue(views);
-    const parsedLikes = parseValue(likes);
+    const parsedViews = parseValue(editor.views);
+    const parsedLikes = parseValue(editor.likes);
 
-    if ((views && parsedViews === null) || (likes && parsedLikes === null)) {
-      setMetricsEditor((prev) => (prev ? {
-        ...prev,
-        status: 'error',
-        error: '숫자로 입력해 주세요.',
-      } : prev));
+    if ((editor.views && parsedViews === null) || (editor.likes && parsedLikes === null)) {
+      analytics.setMetricsEditor((prev) =>
+        prev
+          ? {
+              ...prev,
+              status: 'error',
+              error: '숫자로 입력해 주세요.',
+            }
+          : prev
+      );
       return;
     }
 
-    setMetricsEditor((prev) => (prev ? { ...prev, status: 'saving', error: '' } : prev));
+    analytics.setMetricsEditor((prev) => (prev ? { ...prev, status: 'saving', error: '' } : prev));
 
-    const payload = { slug };
+    const payload = { slug: editor.slug };
     if (parsedViews !== null) payload.views = parsedViews;
     if (parsedLikes !== null) payload.likes = parsedLikes;
 
@@ -1306,1024 +294,253 @@ export default function Admin() {
       const data = await res.json();
       const nextViews = Number(data?.views) || 0;
       const nextLikes = Number(data?.likes) || 0;
-      setMetricsBySlug((prev) => ({
-        ...prev,
-        [slug]: { views: nextViews, likes: nextLikes },
-      }));
-      setItems((prev) => prev.map((item) => (item.slug === slug ? {
-        ...item,
-        views: nextViews,
-        likes: nextLikes,
-      } : item)));
-      setMetricsEditor((prev) => (prev ? {
-        ...prev,
-        status: 'success',
-        views: String(nextViews),
-        likes: String(nextLikes),
-        error: '',
-      } : prev));
+      analytics.updateMetricsForSlug(editor.slug, nextViews, nextLikes);
+      setItems((prev) =>
+        prev.map((item) =>
+          item.slug === editor.slug
+            ? {
+                ...item,
+                views: nextViews,
+                likes: nextLikes,
+              }
+            : item
+        )
+      );
+      analytics.setMetricsEditor((prev) =>
+        prev
+          ? {
+              ...prev,
+              status: 'success',
+              views: String(nextViews),
+              likes: String(nextLikes),
+              error: '',
+            }
+          : prev
+      );
       setTimeout(() => {
-        setMetricsEditor((prev) => {
-          if (!prev || prev.slug === slug) return null;
-          return prev;
-        });
+        analytics.closeMetricsEditor();
       }, 900);
     } catch (error) {
-      setMetricsEditor((prev) => (prev ? {
-        ...prev,
-        status: 'error',
-        error: '메트릭 저장에 실패했어요. 잠시 후 다시 시도해 주세요.',
-      } : prev));
+      analytics.setMetricsEditor((prev) =>
+        prev
+          ? {
+              ...prev,
+              status: 'error',
+              error: '메트릭 저장에 실패했어요. 잠시 후 다시 시도해 주세요.',
+            }
+          : prev
+      );
     }
-  }, [hasToken, metricsEditor, qs]);
+  }, [analytics, hasToken, qs, setItems]);
 
-  async function generateSlug(blob) {
-    const raw = `${blob?.pathname || ''}-${blob?.url || ''}-${Date.now()}-${Math.random()}`;
-    const cryptoObj = globalThis.crypto;
-
-    if (cryptoObj?.subtle && typeof TextEncoder !== 'undefined') {
-      const encoder = new TextEncoder();
-      const digest = await cryptoObj.subtle.digest('SHA-256', encoder.encode(raw));
-      const hex = Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, '0')).join('');
-      return hex.slice(0, 16);
+  const [adsterraPresets, setAdsterraPresets] = useState([]);
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const stored = window.localStorage.getItem('laffy-adsterra-presets');
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed)) {
+          setAdsterraPresets(parsed);
+        }
+      }
+    } catch (error) {
+      console.error('Failed to load adsterra presets', error);
     }
+  }, []);
 
-    if (typeof cryptoObj?.randomUUID === 'function') {
-      return cryptoObj.randomUUID().replace(/-/g, '').slice(0, 16);
-    }
-
-    return raw
-      .toLowerCase()
-      .replace(/[^a-z0-9]/g, '')
-      .slice(0, 16) || `slug-${Date.now()}`;
-  }
-
-  async function registerMeta(blob) {
-    const slug = await generateSlug(blob);
-    const contentType = typeof blob?.contentType === 'string' ? blob.contentType : '';
-    const pathname = typeof blob?.pathname === 'string' ? blob.pathname : '';
-    const lowerPathname = pathname.toLowerCase();
-    const lowerUrl = typeof blob?.url === 'string' ? blob.url.toLowerCase() : '';
-    const imageExtPattern = /(\.jpe?g|\.png|\.webp)$/;
-    const hasImageExtension = imageExtPattern.test(lowerPathname) || imageExtPattern.test(lowerUrl);
-    const isImage = contentType.startsWith('image/') || hasImageExtension;
-    const normalizedType = isImage ? 'image' : 'video';
-
-    const res = await fetch(`/api/admin/register${qs}`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({
-        slug,
-        title,
-        description,
-        url: blob.url,
-        durationSeconds: (() => {
-          const parsed = Number(duration);
-          return Number.isFinite(parsed) && parsed >= 0 ? Math.round(parsed) : 0;
-        })(),
-        orientation,
-        type: normalizedType,
-        poster: isImage ? blob.url : null,
-        thumbnail: isImage ? blob.url : null,
-      }),
+  const handleSavePreset = useCallback((preset) => {
+    setAdsterraPresets((prev) => {
+      const next = [preset, ...prev].slice(0, 20);
+      if (typeof window !== 'undefined') {
+        try {
+          window.localStorage.setItem('laffy-adsterra-presets', JSON.stringify(next));
+        } catch (error) {
+          console.error('Failed to save adsterra presets', error);
+        }
+      }
+      return next;
     });
-    if (!res.ok) {
-      const err = await res.json().catch(() => ({}));
-      alert(`메타 저장 실패: ${err.error || res.status}`);
-      return;
-    }
-    setTitle('');
-    setDescription('');
-    setDuration('0');
-    refresh();
-  }
+  }, []);
 
-  const undoDisplayTitle = undoInfo?.title || undoInfo?.payload?.title || undoInfo?.payload?.slug || '';
+  const handleApplyPreset = useCallback(
+    (preset) => {
+      if (!preset) return;
+      if (preset.placementId !== undefined) {
+        adsterra.setPlacementId(
+          preset.placementId === null || preset.placementId === undefined
+            ? ADSTERRA_ALL_PLACEMENTS_VALUE
+            : preset.placementId
+        );
+      }
+      if (preset.startDate) adsterra.setStartDate(preset.startDate);
+      if (preset.endDate) adsterra.setEndDate(preset.endDate);
+      adsterra.setCountryFilter(preset.countryFilter || '');
+      adsterra.setOsFilter(preset.osFilter || '');
+      adsterra.setDeviceFilter(preset.deviceFilter || '');
+      adsterra.setDeviceFormatFilter(preset.deviceFormatFilter || '');
+    },
+    [adsterra]
+  );
+
+  const handleExportCsv = useCallback(() => {
+    downloadAnalyticsCsv(analytics.sortedAnalyticsRows);
+  }, [analytics.sortedAnalyticsRows]);
+
+  const visibleColumns = analytics.visibleColumns;
 
   return (
-    <>
-      <Head><title>Admin · Laffy</title></Head>
-      <div className="min-h-screen bg-gradient-to-b from-slate-950 via-slate-900 to-slate-950 px-4 py-8 text-slate-100 sm:px-6">
-        <main className="mx-auto w-full max-w-5xl space-y-6">
-          <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-            <h1 className="bg-gradient-to-r from-indigo-200 via-white to-pink-200 bg-clip-text text-3xl font-extrabold text-transparent">LAFFY Admin</h1>
-            <div className="flex items-center gap-2 self-start rounded-full bg-slate-900/70 px-3 py-1 text-xs text-slate-300">
-              <span className="uppercase tracking-[0.3em]">{hasToken ? 'ACCESS' : 'LOCKED'}</span>
-            </div>
-          </header>
+    <AdminPageShell>
+      <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <h1 className="bg-gradient-to-r from-indigo-200 via-white to-pink-200 bg-clip-text text-3xl font-extrabold text-transparent">
+          LAFFY Admin
+        </h1>
+        <div className="flex items-center gap-2 self-start rounded-full bg-slate-900/70 px-3 py-1 text-xs text-slate-300">
+          <span className="uppercase tracking-[0.3em]">{hasToken ? 'ACCESS' : 'LOCKED'}</span>
+        </div>
+      </header>
 
-          <nav className="rounded-full bg-slate-900/60 p-1 shadow-inner shadow-black/40">
-            <div className="grid grid-cols-1 gap-1 sm:grid-cols-3">
-              {navItems.map((item) => {
-                const active = view === item.key;
-                const disabled = item.requiresToken && !hasToken;
-                return (
-                  <button
-                    key={item.key}
-                    type="button"
-                    onClick={() => { if (!disabled) setView(item.key); }}
-                    disabled={disabled}
-                    aria-pressed={active}
-                    className={`rounded-full px-4 py-2 text-sm font-semibold transition-all duration-200 ease-out focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-400 ${active ? 'bg-gradient-to-r from-indigo-400 via-sky-400 to-emerald-400 text-slate-950 shadow-lg shadow-emerald-500/30' : 'text-slate-400 hover:text-slate-100'} ${disabled ? 'cursor-not-allowed opacity-40' : ''}`}
-                  >
-                    {item.label}
-                  </button>
-                );
-              })}
-            </div>
-          </nav>
+      <AdminNav
+        items={NAV_ITEMS.map((item) => ({ ...item, disabled: item.requiresToken && !hasToken }))}
+        activeView={view}
+        onChange={setView}
+      />
 
-          {!hasToken && (
-            <div className="rounded-2xl border border-rose-500/30 bg-rose-500/10 p-4 text-sm text-rose-100">
-              <p className="font-semibold">토큰이 필요합니다</p>
-              <p className="mt-1">URL 끝에 <code className="rounded bg-black/30 px-1">?token=YOUR_ADMIN_TOKEN</code> 을 붙여 접근해 주세요.</p>
-            </div>
-          )}
+      {!hasToken && <TokenNotice />}
 
-          <div className="relative min-h-[24rem]">
-            <section
-              className={`space-y-8 transition-all duration-200 ease-out ${uploadsVisible ? 'relative opacity-100' : 'absolute inset-0 -translate-y-2 opacity-0 pointer-events-none'}`}
-            >
-              <div className="space-y-4 rounded-2xl bg-slate-900/80 p-5 ring-1 ring-slate-800/70">
-                <div className="grid gap-3 sm:grid-cols-2">
-                  <div>
-                    <label className="mb-1 block text-xs uppercase tracking-widest text-slate-400">Title</label>
-                    <input
-                      disabled={!hasToken}
-                      type="text"
-                      placeholder="Title"
-                      value={title}
-                      onChange={(e) => setTitle(e.target.value)}
-                      className="w-full rounded-lg bg-slate-800 px-3 py-2 text-sm disabled:opacity-40"
-                    />
-                  </div>
-                  <div>
-                    <label className="mb-1 block text-xs uppercase tracking-widest text-slate-400">Duration (s)</label>
-                    <input
-                      disabled={!hasToken}
-                      type="number"
-                      min="0"
-                      placeholder="0"
-                      value={duration}
-                      onChange={(e) => setDuration(e.target.value)}
-                      className="w-full rounded-lg bg-slate-800 px-3 py-2 text-sm disabled:opacity-40"
-                    />
-                  </div>
-                  <div>
-                    <label className="mb-1 block text-xs uppercase tracking-widest text-slate-400">Orientation</label>
-                    <select
-                      disabled={!hasToken}
-                      value={orientation}
-                      onChange={(e) => setOrientation(e.target.value)}
-                      className="w-full rounded-lg bg-slate-800 px-3 py-2 text-sm disabled:opacity-40"
-                    >
-                      <option value="landscape">landscape</option>
-                      <option value="portrait">portrait</option>
-                      <option value="square">square</option>
-                    </select>
-                  </div>
-                  <div>
-                    <label className="mb-1 block text-xs uppercase tracking-widest text-slate-400">Description</label>
-                    <input
-                      disabled={!hasToken}
-                      type="text"
-                      placeholder="Description"
-                      value={description}
-                      onChange={(e) => setDescription(e.target.value)}
-                      className="w-full rounded-lg bg-slate-800 px-3 py-2 text-sm disabled:opacity-40"
-                    />
-                  </div>
-                </div>
-                <div className="pt-2">
-                  <label className="mb-2 block text-xs uppercase tracking-widest text-slate-400">Upload</label>
-                  <ClientBlobUploader
-                    handleUploadUrl={`/api/blob/upload${qs}`}
-                    accept="image/jpeg,image/png,image/webp,video/mp4"
-                    maxSizeMB={200}
-                    onUploaded={(blob) => registerMeta(blob)}
-                  />
-                </div>
-              </div>
+      <div className="relative min-h-[24rem]">
+        {view === 'uploads' && (
+          <UploadsSection
+            hasToken={hasToken}
+            items={items}
+            copiedSlug={copiedSlug}
+            onCopy={handleCopyRoute}
+            onEdit={openEditModal}
+            onDelete={openDeleteModal}
+            registerMeta={registerMeta}
+            uploadFormState={uploadFormState}
+          />
+        )}
 
-              <div className="space-y-4">
-                <h2 className="text-sm font-semibold uppercase tracking-widest text-slate-400">Uploaded</h2>
-                <div className="grid gap-3 sm:grid-cols-2">
-                  {items.map((it) => {
-                    const copied = copiedSlug === it.slug;
-                    return (
-                      <div key={it.pathname} className="overflow-hidden rounded-2xl bg-slate-900/80 ring-1 ring-slate-800/70">
-                        <div className="relative w-full aspect-video bg-slate-950/60">
-                          {it.preview ? (
-                            <img src={it.preview} alt={it.title || it.slug} className="h-full w-full object-cover" />
-                          ) : (
-                            <div className="grid h-full w-full place-items-center text-xs text-slate-400">No preview</div>
-                          )}
-                          {it.type && (
-                            <span className="absolute left-3 top-3 rounded-full bg-black/60 px-2 py-0.5 text-[11px] font-semibold uppercase text-white">
-                              {it.type}
-                            </span>
-                          )}
-                        </div>
-                        <div className="space-y-2 p-3 text-sm">
-                          <div className="truncate font-semibold text-slate-100">{it.title || it.slug}</div>
-                          <div className="truncate text-[12px] text-slate-400">{it.slug}</div>
-                          {it.description && (
-                            <p className="line-clamp-2 text-[12px] leading-relaxed text-slate-400/85">{it.description}</p>
-                          )}
-                          <div className="flex items-center gap-2 pt-1">
-                            {it.routePath && (
-                              <>
-                                <a
-                                  href={it.routePath}
-                                  target="_blank"
-                                  rel="noreferrer"
-                                  className="rounded-full bg-indigo-600 px-3 py-1 text-white hover:bg-indigo-500"
-                                >
-                                  Open Route
-                                </a>
-                                <button
-                                  onClick={async () => {
-                                    try {
-                                      const origin = typeof window !== 'undefined' ? window.location.origin : '';
-                                      const absoluteUrl = origin ? new URL(it.routePath, origin).toString() : it.routePath;
-                                      const canUseClipboard = typeof navigator !== 'undefined' && navigator.clipboard && typeof navigator.clipboard.writeText === 'function';
-                                      if (canUseClipboard) {
-                                        await navigator.clipboard.writeText(absoluteUrl);
-                                      } else if (typeof document !== 'undefined') {
-                                        const textarea = document.createElement('textarea');
-                                        textarea.value = absoluteUrl;
-                                        textarea.setAttribute('readonly', '');
-                                        textarea.style.position = 'absolute';
-                                        textarea.style.left = '-9999px';
-                                        document.body.appendChild(textarea);
-                                        textarea.select();
-                                        if (typeof document.execCommand === 'function') {
-                                          document.execCommand('copy');
-                                        } else {
-                                          throw new Error('Clipboard API unavailable');
-                                        }
-                                        document.body.removeChild(textarea);
-                                      }
-                                      setCopiedSlug(it.slug);
-                                      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
-                                      copyTimeoutRef.current = setTimeout(() => setCopiedSlug(''), 1800);
-                                    } catch (e) {
-                                      console.error('Copy failed', e);
-                                    }
-                                  }}
-                                  className={`rounded-full px-3 py-1 text-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 ${copied ? 'bg-gradient-to-r from-emerald-400 via-teal-400 to-cyan-400 text-slate-950 shadow-lg shadow-emerald-500/30' : 'bg-slate-800 text-slate-200 hover:bg-slate-700'}`}
-                                >
-                                  {copied ? 'Copied ✨' : 'Copy'}
-                                </button>
-                                {copied && (
-                                  <span className="sr-only" aria-live="polite">링크가 복사되었습니다.</span>
-                                )}
-                              </>
-                            )}
-                            {hasToken && !it._error && (
-                              <button
-                                type="button"
-                                onClick={() => openEditModal(it)}
-                                className="rounded-full bg-gradient-to-r from-emerald-400/30 via-teal-400/25 to-cyan-400/25 px-3 py-1 text-sm font-semibold text-emerald-100 shadow-[0_12px_30px_rgba(16,185,129,0.25)] backdrop-blur transition hover:brightness-115 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-200"
-                              >
-                                Edit
-                              </button>
-                            )}
-                            <button
-                              disabled={!hasToken}
-                              onClick={() => openDeleteModal(it)}
-                              className="ml-auto rounded-full bg-rose-600 px-3 py-1 hover:bg-rose-500 disabled:opacity-50"
-                            >
-                              Delete
-                            </button>
-                          </div>
-                        </div>
-                      </div>
-                    );
-                  })}
-                  {items.length === 0 && (
-                    <div className="col-span-full rounded-2xl border border-dashed border-slate-700 px-4 py-12 text-center text-sm text-slate-400">
-                      아직 업로드된 콘텐츠가 없습니다.
-                    </div>
-                  )}
-                </div>
-              </div>
-            </section>
-
-            <section
-              className={`space-y-6 transition-all duration-200 ease-out ${analyticsVisible ? 'relative opacity-100' : 'absolute inset-0 translate-y-2 opacity-0 pointer-events-none'}`}
-            >
-              <div className="grid gap-4 md:grid-cols-3">
-                <div className="rounded-2xl border border-white/5 bg-slate-900/80 p-4 shadow-lg shadow-black/20">
-                  <p className="text-xs uppercase tracking-[0.25em] text-slate-400">콘텐츠</p>
-                  <p className="mt-2 text-2xl font-bold text-white">{formatNumber(items.length)}</p>
-                  <p className="mt-1 text-xs text-slate-500">등록된 메타 파일 수</p>
-                </div>
-                <div className="rounded-2xl border border-white/5 bg-slate-900/80 p-4 shadow-lg shadow-black/20">
-                  <p className="text-xs uppercase tracking-[0.25em] text-slate-400">총 조회수</p>
-                  <p className="mt-2 text-2xl font-bold text-white">{formatNumber(analyticsTotals.views)}</p>
-                  <p className="mt-1 text-xs text-slate-500">metrics 기준 누적</p>
-                </div>
-                <div className="rounded-2xl border border-white/5 bg-slate-900/80 p-4 shadow-lg shadow-black/20">
-                  <p className="text-xs uppercase tracking-[0.25em] text-slate-400">평균 좋아요율</p>
-                  <p className="mt-2 text-2xl font-bold text-white">{formatPercent(averageLikeRate)}</p>
-                  <p className="mt-1 text-xs text-slate-500">조회가 있는 콘텐츠 평균</p>
-                </div>
-              </div>
-
-              {metricsError && (
-                <div className="rounded-xl border border-rose-500/40 bg-rose-500/10 p-4 text-sm text-rose-100">
-                  {metricsError}
-                </div>
-              )}
-
-              <div className="overflow-hidden rounded-2xl bg-slate-900/80 ring-1 ring-slate-800/70">
-                <div className="overflow-x-auto">
-                  <table className="min-w-full divide-y divide-slate-800/70 text-sm">
-                    <thead className="bg-slate-900/60 text-left text-xs uppercase tracking-widest text-slate-400">
-                      <tr>
-                        <th className="px-4 py-3 font-semibold">콘텐츠</th>
-                        <th className="px-4 py-3 font-semibold">타입</th>
-                        <th className="px-4 py-3 text-right font-semibold">조회수</th>
-                        <th className="px-4 py-3 text-right font-semibold">좋아요</th>
-                        <th className="px-4 py-3 text-right font-semibold">좋아요율</th>
-                        <th className="px-4 py-3 text-right font-semibold">링크</th>
-                        <th className="px-4 py-3 text-right font-semibold">편집</th>
-                      </tr>
-                    </thead>
-                    <tbody className="divide-y divide-slate-800/60">
-                      {sortedAnalyticsRows.map((row) => {
-                        const metrics = row.metrics;
-                        const viewsDisplay = metrics ? formatNumber(metrics.views) : metricsLoading ? '불러오는 중…' : '—';
-                        const likesDisplay = metrics ? formatNumber(metrics.likes) : metricsLoading ? '불러오는 중…' : '—';
-                        const likeRateDisplay = metrics && metrics.views > 0 ? formatPercent(metrics.likes / metrics.views) : '—';
-                        return (
-                          <tr key={row.slug} className="hover:bg-slate-800/40">
-                            <td className="px-4 py-3">
-                              <div className="font-semibold text-slate-100">{row.title || row.slug}</div>
-                              <div className="text-xs text-slate-500">{row.slug}</div>
-                            </td>
-                            <td className="px-4 py-3">
-                              <span className="inline-flex rounded-full bg-slate-800 px-2 py-0.5 text-[11px] uppercase tracking-widest text-slate-300">
-                                {row.type || 'unknown'}
-                              </span>
-                            </td>
-                            <td className="px-4 py-3 text-right text-slate-100">{viewsDisplay}</td>
-                            <td className="px-4 py-3 text-right text-slate-100">{likesDisplay}</td>
-                            <td className="px-4 py-3 text-right text-slate-100">{likeRateDisplay}</td>
-                            <td className="px-4 py-3 text-right">
-                              {row.routePath ? (
-                                <a
-                                  href={row.routePath}
-                                  target="_blank"
-                                  rel="noreferrer"
-                                  className="text-xs font-semibold text-sky-300 hover:text-sky-200"
-                                >
-                                  열기
-                                </a>
-                              ) : (
-                                <span className="text-xs text-slate-500">—</span>
-                              )}
-                            </td>
-                            <td className="px-4 py-3 text-right">
-                              <button
-                                type="button"
-                                onClick={() => openMetricsEditor(row)}
-                                className="inline-flex items-center justify-center rounded-full border border-slate-600/60 px-3 py-1 text-xs font-semibold text-slate-200 transition hover:bg-slate-800"
-                              >
-                                수정
-                              </button>
-                            </td>
-                          </tr>
-                        );
-                      })}
-                      {sortedAnalyticsRows.length === 0 && (
-                        <tr>
-                          <td colSpan={7} className="px-4 py-12 text-center text-sm text-slate-400">
-                            분석할 콘텐츠가 없습니다.
-                          </td>
-                        </tr>
-                      )}
-                    </tbody>
-                  </table>
-                </div>
-                {metricsLoading && (
-                  <div className="border-t border-slate-800/70 bg-slate-900/70 px-4 py-3 text-right text-xs text-slate-400">
-                    메트릭을 불러오는 중입니다…
-                  </div>
-                )}
-              </div>
-            </section>
-
-            <section
-              className={`space-y-6 transition-all duration-200 ease-out ${adsterraVisible ? 'relative opacity-100' : 'absolute inset-0 translate-y-2 opacity-0 pointer-events-none'}`}
-            >
-              <div className="space-y-4 rounded-2xl bg-slate-900/80 p-5 ring-1 ring-slate-800/70">
-                <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-                  <div>
-                    <p className="text-xs uppercase tracking-widest text-slate-400">연결된 도메인</p>
-                    <p className="text-sm font-semibold text-white">
-                      {adsterraDomainName}
-                      <span className="ml-2 text-xs font-normal text-slate-400">
-                        {adsterraDomainId ? `#${adsterraDomainId}` : '—'}
-                      </span>
-                    </p>
-                    <p className="mt-1 text-[11px] text-slate-500">환경 변수에 저장된 토큰으로 자동 연결돼요.</p>
-                  </div>
-                  <div className="flex flex-col gap-1 text-xs text-slate-400 md:items-end">
-                    <button
-                      type="button"
-                      onClick={() => {
-                        fetchAdsterraPlacements();
-                      }}
-                      disabled={!adsterraActiveToken || adsterraLoadingPlacements}
-                      className="inline-flex items-center justify-center rounded-full border border-slate-600/60 px-3 py-1 text-[11px] font-semibold text-slate-200 transition hover:bg-slate-800/60 disabled:cursor-not-allowed disabled:opacity-50"
-                    >
-                      플레이스먼트 새로고침
-                    </button>
-                    {adsterraLoadingPlacements && <span>플레이스먼트를 불러오는 중입니다…</span>}
-                    {!adsterraActiveToken && (
-                      <span className="text-rose-200">환경 변수에 통계 API 토큰을 설정해 주세요.</span>
-                    )}
-                  </div>
-                </div>
-
-                <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-                  <div className="md:col-span-2 xl:col-span-1">
-                    <label className="mb-1 block text-xs uppercase tracking-widest text-slate-400">광고 포맷 (플레이스먼트)</label>
-                    <select
-                      value={adsterraPlacementId}
-                      onChange={(e) => handleAdsterraPlacementChange(e.target.value)}
-                      disabled={!adsterraActiveToken || adsterraLoadingPlacements}
-                      className="w-full rounded-lg bg-slate-800 px-3 py-2 text-sm text-slate-100 disabled:opacity-40"
-                    >
-                      <option value={ADSTERRA_ALL_PLACEMENTS_VALUE}>전체 보기 (도메인 전체)</option>
-                      <option value="">플레이스먼트를 선택해 주세요</option>
-                      {adsterraPlacements.map((placement) => {
-                        const rawId = placement?.id ?? placement?.ID ?? placement?.placement_id ?? placement?.placementId ?? placement?.value;
-                        const optionValue = rawId !== undefined && rawId !== null ? String(rawId) : '';
-                        if (!optionValue) return null;
-                        const label = placement?.title
-                          || placement?.alias
-                          || placement?.placement
-                          || placement?.name
-                          || placement?.ad_format
-                          || `#${optionValue}`;
-                        return (
-                          <option key={optionValue} value={optionValue}>
-                            {label}
-                          </option>
-                        );
-                      })}
-                    </select>
-                  </div>
-                  <div>
-                    <label className="mb-1 block text-xs uppercase tracking-widest text-slate-400">시작일</label>
-                    <input
-                      type="date"
-                      value={adsterraStartDate}
-                      onChange={(e) => setAdsterraStartDate(e.target.value)}
-                      max={adsterraEndDate || undefined}
-                      className="w-full rounded-lg bg-slate-800 px-3 py-2 text-sm text-slate-100"
-                    />
-                  </div>
-                  <div>
-                    <label className="mb-1 block text-xs uppercase tracking-widest text-slate-400">종료일</label>
-                    <input
-                      type="date"
-                      value={adsterraEndDate}
-                      onChange={(e) => setAdsterraEndDate(e.target.value)}
-                      min={adsterraStartDate || undefined}
-                      className="w-full rounded-lg bg-slate-800 px-3 py-2 text-sm text-slate-100"
-                    />
-                  </div>
-                </div>
-
-                <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-                  <div>
-                    <label className="mb-1 block text-xs uppercase tracking-widest text-slate-400">국가 필터</label>
-                    <select
-                      value={adsterraCountryFilter}
-                      onChange={(e) => setAdsterraCountryFilter(e.target.value)}
-                      className="w-full rounded-lg bg-slate-800 px-3 py-2 text-sm text-slate-100"
-                    >
-                      <option value="">전체</option>
-                      {adsterraCountryOptions.map((country) => (
-                        <option key={country} value={country}>
-                          {country}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                  <div>
-                    <label className="mb-1 block text-xs uppercase tracking-widest text-slate-400">OS 필터</label>
-                    <select
-                      value={adsterraOsFilter}
-                      onChange={(e) => setAdsterraOsFilter(e.target.value)}
-                      className="w-full rounded-lg bg-slate-800 px-3 py-2 text-sm text-slate-100"
-                    >
-                      <option value="">전체</option>
-                      {adsterraOsOptions.map((os) => (
-                        <option key={os} value={os}>
-                          {os}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                  <div>
-                    <label className="mb-1 block text-xs uppercase tracking-widest text-slate-400">디바이스 필터</label>
-                    <select
-                      value={adsterraDeviceFilter}
-                      onChange={(e) => setAdsterraDeviceFilter(e.target.value)}
-                      className="w-full rounded-lg bg-slate-800 px-3 py-2 text-sm text-slate-100"
-                    >
-                      <option value="">전체</option>
-                      {adsterraDeviceOptions.map((device) => (
-                        <option key={device} value={device}>
-                          {device}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                  <div>
-                    <label className="mb-1 block text-xs uppercase tracking-widest text-slate-400">디바이스 포맷</label>
-                    <select
-                      value={adsterraDeviceFormatFilter}
-                      onChange={(e) => setAdsterraDeviceFormatFilter(e.target.value)}
-                      className="w-full rounded-lg bg-slate-800 px-3 py-2 text-sm text-slate-100"
-                    >
-                      <option value="">전체</option>
-                      {adsterraDeviceFormatOptions.map((format) => (
-                        <option key={format} value={format}>
-                          {format}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                </div>
-
-                <div className="flex flex-wrap items-center gap-3">
-                  <button
-                    type="button"
-                    onClick={handleFetchAdsterraStats}
-                    disabled={!adsterraCanFetchStats || adsterraLoadingStats}
-                    className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-emerald-400 via-teal-400 to-cyan-400 px-4 py-2 text-sm font-semibold text-slate-950 shadow-lg shadow-emerald-500/30 transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-60"
-                  >
-                    {adsterraLoadingStats ? '통계 불러오는 중…' : '통계 다시 불러오기'}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleResetAdsterraDates}
-                    className="inline-flex items-center justify-center rounded-full border border-slate-600/60 px-3 py-2 text-xs font-semibold text-slate-200 transition hover:bg-slate-800/60"
-                  >
-                    기간 초기화
-                  </button>
-                </div>
-
-                {adsterraStatus && (
-                  <div className="rounded-xl border border-emerald-500/40 bg-emerald-500/10 p-3 text-xs text-emerald-100">
-                    {adsterraStatus}
-                  </div>
-                )}
-                {adsterraError && (
-                  <div className="rounded-xl border border-rose-500/40 bg-rose-500/10 p-3 text-sm text-rose-100">
-                    {adsterraError}
-                  </div>
-                )}
-              </div>
-
-              <div className="grid gap-4 md:grid-cols-3">
-                <div className="rounded-2xl border border-white/5 bg-slate-900/80 p-4 shadow-lg shadow-black/20">
-                  <p className="text-xs uppercase tracking-[0.25em] text-slate-400">총 노출수</p>
-                  <p className="mt-2 text-2xl font-bold text-white">{formatNumber(adsterraTotals.impressions)}</p>
-                  <p className="mt-1 text-xs text-slate-500">선택한 기간 · 필터 기준 합계</p>
-                </div>
-                <div className="rounded-2xl border border-white/5 bg-slate-900/80 p-4 shadow-lg shadow-black/20">
-                  <p className="text-xs uppercase tracking-[0.25em] text-slate-400">총 클릭수</p>
-                  <p className="mt-2 text-2xl font-bold text-white">{formatNumber(adsterraTotals.clicks)}</p>
-                  <p className="mt-1 text-xs text-slate-500">필터 기준 평균 CTR {formatDecimal(adsterraTotals.ctr, 2)}%</p>
-                </div>
-                <div className="rounded-2xl border border-white/5 bg-slate-900/80 p-4 shadow-lg shadow-black/20">
-                  <p className="text-xs uppercase tracking-[0.25em] text-slate-400">총 수익 (USD)</p>
-                  <p className="mt-2 text-2xl font-bold text-white">{formatDecimal(adsterraTotals.revenue, 3)}</p>
-                  <p className="mt-1 text-xs text-slate-500">필터 기준 평균 CPM {formatDecimal(adsterraTotals.cpm, 3)}</p>
-                </div>
-              </div>
-
-              <div className="overflow-hidden rounded-2xl bg-slate-900/80 ring-1 ring-slate-800/70">
-                <div className="overflow-x-auto">
-                  <table className="min-w-full divide-y divide-slate-800/70 text-sm">
-                    <thead className="bg-slate-900/60 text-left text-xs uppercase tracking-widest text-slate-400">
-                      <tr>
-                        <th className="px-4 py-3 font-semibold">날짜</th>
-                        <th className="px-4 py-3 font-semibold">국가</th>
-                        <th className="px-4 py-3 font-semibold">광고 포맷</th>
-                        <th className="px-4 py-3 font-semibold">OS</th>
-                        <th className="px-4 py-3 font-semibold">디바이스</th>
-                        <th className="px-4 py-3 font-semibold">디바이스 포맷</th>
-                        <th className="px-4 py-3 text-right font-semibold">노출수</th>
-                        <th className="px-4 py-3 text-right font-semibold">클릭수</th>
-                        <th className="px-4 py-3 text-right font-semibold">CTR</th>
-                        <th className="px-4 py-3 text-right font-semibold">CPM (USD)</th>
-                        <th className="px-4 py-3 text-right font-semibold">수익 (USD)</th>
-                      </tr>
-                    </thead>
-                    <tbody className="divide-y divide-slate-800/60">
-                      {filteredAdsterraStats.map((row, index) => {
-                        const impressions = Number(row?.impression ?? row?.impressions ?? 0) || 0;
-                        const clicks = Number(row?.clicks ?? row?.click ?? 0) || 0;
-                        const revenue = Number(row?.revenue ?? 0) || 0;
-                        const ctrRaw = Number(row?.ctr ?? ((impressions > 0 && clicks >= 0) ? (clicks / impressions) * 100 : 0)) || 0;
-                        const cpmRaw = Number(row?.cpm ?? ((impressions > 0 && revenue >= 0) ? (revenue / impressions) * 1000 : 0)) || 0;
-                        const dateLabel = row?.date || row?.day || row?.Day || row?.group || `#${index + 1}`;
-                        const countryLabel = row?.country ?? row?.Country ?? row?.geo ?? row?.Geo ?? '—';
-                        const osLabel = row?.os ?? row?.OS ?? row?.platform ?? row?.Platform ?? '—';
-                        const deviceLabel = row?.device ?? row?.Device ?? row?.device_type ?? row?.deviceType ?? '—';
-                        const deviceFormatLabel = row?.device_format ?? row?.deviceFormat ?? row?.DeviceFormat ?? '—';
-                        const placementIdFromRow = row?.placement_id
-                          ?? row?.placementId
-                          ?? row?.placementID
-                          ?? row?.placementid;
-                        const placementLabelRaw = row?.placement_name
-                          ?? row?.placement
-                          ?? row?.placementName
-                          ?? row?.ad_format
-                          ?? row?.adFormat
-                          ?? '';
-                        const placementResolved = placementLabelRaw
-                          || (placementIdFromRow !== undefined && placementIdFromRow !== null
-                            ? adsterraPlacementLabelMap.get(String(placementIdFromRow)) || ''
-                            : '');
-                        const placementDisplay = placementResolved
-                          || (adsterraAllPlacementsSelected ? '전체 보기' : adsterraPlacementLabelMap.get(adsterraPlacementId))
-                          || '—';
-                        const rowKey = `${dateLabel}-${index}-${placementIdFromRow ?? ''}-${countryLabel}-${osLabel}-${deviceLabel}-${deviceFormatLabel}`;
-                        return (
-                          <tr key={rowKey} className="hover:bg-slate-800/40">
-                            <td className="px-4 py-3 font-semibold text-slate-100">{dateLabel}</td>
-                            <td className="px-4 py-3 text-slate-100">{countryLabel}</td>
-                            <td className="px-4 py-3 text-slate-100">{placementDisplay}</td>
-                            <td className="px-4 py-3 text-slate-100">{osLabel}</td>
-                            <td className="px-4 py-3 text-slate-100">{deviceLabel}</td>
-                            <td className="px-4 py-3 text-slate-100">{deviceFormatLabel}</td>
-                            <td className="px-4 py-3 text-right text-slate-100">{formatNumber(impressions)}</td>
-                            <td className="px-4 py-3 text-right text-slate-100">{formatNumber(clicks)}</td>
-                            <td className="px-4 py-3 text-right text-slate-100">{`${formatDecimal(ctrRaw, 3)}%`}</td>
-                            <td className="px-4 py-3 text-right text-slate-100">{formatDecimal(cpmRaw, 3)}</td>
-                            <td className="px-4 py-3 text-right text-slate-100">{formatDecimal(revenue, 3)}</td>
-                          </tr>
-                        );
-                      })}
-                      {!filteredAdsterraStats.length && !adsterraLoadingStats && (
-                        <tr>
-                          <td colSpan={11} className="px-4 py-12 text-center text-sm text-slate-400">
-                            통계를 불러오면 여기에 표시됩니다.
-                          </td>
-                        </tr>
-                      )}
-                    </tbody>
-                  </table>
-                </div>
-                {adsterraLoadingStats && (
-                  <div className="border-t border-slate-800/70 bg-slate-900/70 px-4 py-3 text-right text-xs text-slate-400">
-                    통계를 불러오는 중입니다…
-                  </div>
-                )}
-              </div>
-            </section>
+        {view === 'analytics' && (
+          <div className="space-y-6">
+            <AnalyticsOverview
+              itemCount={items.length}
+              totals={analytics.analyticsTotals}
+              averageLikeRate={analytics.averageLikeRate}
+              formatNumber={formatNumber}
+              formatPercent={formatPercent}
+            />
+            <AnalyticsToolbar
+              sortKey={analytics.sortKey}
+              sortDirection={analytics.sortDirection}
+              onSortChange={analytics.setSort}
+              visibleColumns={visibleColumns}
+              onToggleColumn={analytics.toggleColumn}
+              onExportCsv={handleExportCsv}
+            />
+            <AnalyticsTable
+              rows={analytics.sortedAnalyticsRows}
+              metricsLoading={analytics.metricsLoading}
+              metricsError={analytics.metricsError}
+              formatNumber={formatNumber}
+              formatPercent={formatPercent}
+              onEdit={analytics.openMetricsEditor}
+              visibleColumns={visibleColumns}
+            />
           </div>
-        </main>
+        )}
+
+        {view === 'adsterra' && (
+          <div className="space-y-6">
+            <AdsterraControls
+              domainName={adsterraDomainNameEnv}
+              domainId={adsterra.domainId}
+              loadingPlacements={adsterra.loadingPlacements}
+              loadingStats={adsterra.loadingStats}
+              status={adsterra.status}
+              error={adsterra.error}
+              placements={adsterra.placements}
+              placementId={adsterra.placementId}
+              onPlacementChange={adsterra.setPlacementId}
+              startDate={adsterra.startDate}
+              endDate={adsterra.endDate}
+              onStartDateChange={adsterra.setStartDate}
+              onEndDateChange={adsterra.setEndDate}
+              onRefreshPlacements={adsterra.fetchPlacements}
+              onFetchStats={adsterra.fetchStats}
+              onResetDates={adsterra.resetDates}
+              canFetchStats={adsterra.canFetchStats}
+              countryFilter={adsterra.countryFilter}
+              onCountryFilterChange={adsterra.setCountryFilter}
+              countryOptions={adsterra.countryOptions}
+              osFilter={adsterra.osFilter}
+              onOsFilterChange={adsterra.setOsFilter}
+              osOptions={adsterra.osOptions}
+              deviceFilter={adsterra.deviceFilter}
+              onDeviceFilterChange={adsterra.setDeviceFilter}
+              deviceOptions={adsterra.deviceOptions}
+              deviceFormatFilter={adsterra.deviceFormatFilter}
+              onDeviceFormatFilterChange={adsterra.setDeviceFormatFilter}
+              deviceFormatOptions={adsterra.deviceFormatOptions}
+              placementLabel={adsterra.placementLabel}
+              presets={adsterraPresets}
+              onSavePreset={handleSavePreset}
+              onApplyPreset={handleApplyPreset}
+            />
+            <AdsterraSummaryCards totals={adsterra.totals} formatNumber={formatNumber} formatDecimal={formatDecimal} />
+            <AdsterraChartPanel rows={adsterra.filteredStats} formatNumber={formatNumber} />
+            <AdsterraStatsTable
+              rows={adsterra.filteredStats}
+              loading={adsterra.loadingStats}
+              formatNumber={formatNumber}
+              formatDecimal={formatDecimal}
+              placementLabelMap={adsterra.placementLabelMap}
+              selectedPlacementId={adsterra.placementId}
+            />
+          </div>
+        )}
       </div>
-      {metricsEditor && (
-        <div className="fixed inset-0 z-40 flex items-center justify-center bg-slate-950/75 backdrop-blur-sm px-4 py-10">
-          <div
-            className="relative w-full max-w-md overflow-hidden rounded-3xl border border-slate-700/60 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 shadow-[0_32px_100px_rgba(15,23,42,0.7)]"
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="admin-metrics-modal-title"
-          >
-            <div className="pointer-events-none absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-emerald-500 via-teal-400 to-cyan-400" />
-            <button
-              type="button"
-              onClick={closeMetricsEditor}
-              className="absolute right-4 top-4 inline-flex h-9 w-9 items-center justify-center rounded-full bg-slate-800/70 text-slate-300 transition hover:bg-slate-700 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300"
-              aria-label="메트릭 편집 닫기"
-            >
-              ✕
-            </button>
-            <div className="space-y-6 p-7 sm:p-9">
-              <header className="space-y-2">
-                <p className="text-xs uppercase tracking-[0.4em] text-slate-400/70">Metrics</p>
-                <h3 id="admin-metrics-modal-title" className="text-xl font-semibold text-white sm:text-2xl">
-                  {metricsEditor.title}
-                </h3>
-                <p className="text-[12px] text-slate-500">Slug · {metricsEditor.slug}</p>
-              </header>
 
-              <div className="grid gap-4">
-                <div className="space-y-2">
-                  <label className="text-xs uppercase tracking-widest text-slate-400">조회수</label>
-                  <input
-                    value={metricsEditor.views}
-                    onChange={(event) => handleMetricsFieldChange('views', event.target.value)}
-                    placeholder="숫자 입력"
-                    inputMode="numeric"
-                    className="w-full rounded-2xl border border-slate-700/60 bg-slate-900/80 px-4 py-3 text-sm text-white shadow-inner shadow-black/40 transition focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
-                  />
-                </div>
-                <div className="space-y-2">
-                  <label className="text-xs uppercase tracking-widest text-slate-400">좋아요</label>
-                  <input
-                    value={metricsEditor.likes}
-                    onChange={(event) => handleMetricsFieldChange('likes', event.target.value)}
-                    placeholder="숫자 입력"
-                    inputMode="numeric"
-                    className="w-full rounded-2xl border border-slate-700/60 bg-slate-900/80 px-4 py-3 text-sm text-white shadow-inner shadow-black/40 transition focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
-                  />
-                </div>
-              </div>
-
-              {metricsEditor.error && (
-                <div className="rounded-2xl border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">
-                  {metricsEditor.error}
-                </div>
-              )}
-
-              <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
-                <button
-                  type="button"
-                  onClick={closeMetricsEditor}
-                  className="inline-flex items-center justify-center rounded-full border border-slate-600/60 px-5 py-2.5 text-sm font-semibold text-slate-200 transition hover:bg-slate-800"
-                >
-                  취소
-                </button>
-                <button
-                  type="button"
-                  onClick={handleMetricsSave}
-                  disabled={metricsSaving}
-                  className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-emerald-500 via-teal-500 to-cyan-500 px-6 py-2.5 text-sm font-semibold text-slate-950 shadow-[0_16px_40px_rgba(16,185,129,0.35)] transition hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-100 disabled:cursor-wait disabled:opacity-70"
-                >
-                  {metricsSaving ? '저장 중…' : metricsSuccess ? '저장 완료!' : '메트릭 저장'}
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
-      {pendingDelete && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 backdrop-blur">
-          <div
-            className="relative w-full max-w-lg overflow-hidden rounded-3xl border border-rose-500/40 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 shadow-[0_40px_120px_rgba(127,29,29,0.55)]"
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="admin-delete-modal-title"
-          >
-            <div className="pointer-events-none absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-rose-500 via-orange-400 to-amber-300" />
-            <button
-              type="button"
-              onClick={closeDeleteModal}
-              className="absolute right-4 top-4 inline-flex h-9 w-9 items-center justify-center rounded-full bg-slate-800/70 text-slate-300 transition hover:bg-slate-700 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-200"
-              aria-label="삭제 확인 창 닫기"
-            >
-              ✕
-            </button>
-            <div className="space-y-6 p-7 sm:p-9">
-              <header className="space-y-2">
-                <p className="text-xs uppercase tracking-[0.4em] text-slate-400/70">Delete Content</p>
-                <h3 id="admin-delete-modal-title" className="text-2xl font-semibold text-white sm:text-3xl">{pendingDelete.title || pendingDelete.slug}</h3>
-                <p className="text-[12px] text-slate-500">Slug · {pendingDelete.slug}</p>
-              </header>
-
-              <div className="space-y-4 text-sm text-slate-200/90">
-                <p>이 콘텐츠의 메타 데이터가 영구 삭제됩니다. 삭제 후 10초 안에 되돌리기가 가능합니다.</p>
-                <div className="space-y-2 rounded-2xl border border-rose-500/20 bg-slate-900/70 p-4 text-xs text-slate-300">
-                  <div className="flex items-center justify-between gap-3">
-                    <span className="uppercase tracking-widest text-slate-500">Slug</span>
-                    <span className="font-mono text-[11px] text-slate-200">{pendingDelete.slug}</span>
-                  </div>
-                  {pendingDelete.routePath && (
-                    <div className="flex items-center justify-between gap-3">
-                      <span className="uppercase tracking-widest text-slate-500">Route</span>
-                      <span className="truncate text-[11px] text-slate-200">{pendingDelete.routePath}</span>
-                    </div>
-                  )}
-                  {pendingDelete.preview && (
-                    <div className="flex items-center justify-between gap-3">
-                      <span className="uppercase tracking-widest text-slate-500">Preview</span>
-                      <span className="truncate text-[11px] text-slate-200">{pendingDelete.preview}</span>
-                    </div>
-                  )}
-                </div>
-                <p className="text-[12px] text-rose-200/80">
-                  이 작업은 메타 파일을 삭제하지만 원본 미디어는 별도 보관됩니다. 필요 시 되돌리기를 눌러 복구할 수 있습니다.
-                </p>
-              </div>
-
-              {deleteError && (
-                <div className="rounded-2xl border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">
-                  {deleteError}
-                </div>
-              )}
-
-              <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
-                <button
-                  type="button"
-                  onClick={closeDeleteModal}
-                  className="inline-flex items-center justify-center rounded-full border border-slate-600/60 px-5 py-2.5 text-sm font-semibold text-slate-200 transition hover:bg-slate-800"
-                >
-                  취소
-                </button>
-                <button
-                  type="button"
-                  onClick={handleConfirmDelete}
-                  disabled={deleteStatus === 'pending'}
-                  className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-rose-500 via-red-500 to-orange-500 px-6 py-2.5 text-sm font-semibold text-white shadow-[0_18px_42px_rgba(248,113,113,0.35)] transition hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-200 disabled:cursor-wait disabled:opacity-70"
-                >
-                  {deleteStatus === 'pending' ? '삭제 중…' : '영구 삭제'}
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
-      {editingItem && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/75 backdrop-blur-sm px-4 py-10">
-          <div
-            className="relative w-full max-w-2xl overflow-hidden rounded-3xl border border-slate-700/60 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 shadow-[0_48px_140px_rgba(15,23,42,0.68)]"
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="admin-edit-modal-title"
-          >
-            <div className="pointer-events-none absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500" />
-            <button
-              type="button"
-              onClick={closeEditModal}
-              className="absolute right-4 top-4 inline-flex h-9 w-9 items-center justify-center rounded-full bg-slate-800/70 text-slate-300 transition hover:bg-slate-700 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-300"
-              aria-label="편집 창 닫기"
-            >
-              ✕
-            </button>
-            <div className="space-y-6 p-7 sm:p-10">
-              <header className="space-y-2">
-                <p className="text-xs uppercase tracking-[0.4em] text-slate-400/70">Edit Content</p>
-                <h3 id="admin-edit-modal-title" className="text-2xl font-semibold text-white sm:text-3xl">{editingItem.title || editingItem.slug}</h3>
-                <p className="text-[12px] text-slate-500">Slug · {editingItem.slug}</p>
-              </header>
-
-              <div className="grid gap-5">
-                <div className="space-y-2">
-                  <label className="text-xs uppercase tracking-widest text-slate-400">Title</label>
-                  <input
-                    value={editForm.title}
-                    onChange={(e) => handleEditFieldChange('title', e.target.value)}
-                    className="w-full rounded-2xl border border-slate-700/60 bg-slate-900/80 px-4 py-3 text-sm text-white shadow-inner shadow-black/40 transition focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
-                    placeholder="콘텐츠 제목"
-                  />
-                </div>
-
-                <div className="space-y-2">
-                  <label className="text-xs uppercase tracking-widest text-slate-400">Description</label>
-                  <textarea
-                    value={editForm.description}
-                    onChange={(e) => handleEditFieldChange('description', e.target.value)}
-                    rows={4}
-                    className="w-full rounded-2xl border border-slate-700/60 bg-slate-900/80 px-4 py-3 text-sm text-white shadow-inner shadow-black/40 transition focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
-                    placeholder="간단한 설명을 입력해 주세요."
-                  />
-                </div>
-
-                <div className="space-y-2">
-                  <label className="text-xs uppercase tracking-widest text-slate-400">Duration (seconds)</label>
-                  <input
-                    type="number"
-                    min="0"
-                    step="1"
-                    inputMode="numeric"
-                    value={editForm.durationSeconds}
-                    onChange={(e) => handleEditFieldChange('durationSeconds', e.target.value)}
-                    className="w-full rounded-2xl border border-slate-700/60 bg-slate-900/80 px-4 py-3 text-sm text-white shadow-inner shadow-black/40 transition focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
-                    placeholder="예: 123"
-                  />
-                  <p className="text-xs text-slate-500">초 단위로 입력해 주세요. 비워두면 기존 값이 유지됩니다.</p>
-                </div>
-
-                <div className="space-y-3">
-                  <label className="text-xs uppercase tracking-widest text-slate-400">대표 이미지</label>
-                  <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
-                    <div className="relative h-36 w-full overflow-hidden rounded-2xl border border-slate-700/60 bg-slate-900/70 sm:h-44 sm:w-44">
-                      {editForm.previewUrl ? (
-                        <img src={editForm.previewUrl} alt={`${editingItem.slug} preview`} className="h-full w-full object-cover" />
-                      ) : (
-                        <div className="grid h-full w-full place-items-center text-xs text-slate-500">이미지가 없습니다</div>
-                      )}
-                      {editUploadState === 'uploading' && (
-                        <div className="absolute inset-0 grid place-items-center bg-slate-950/70 text-xs font-medium text-indigo-200">
-                          업로드 중…
-                        </div>
-                      )}
-                    </div>
-                    <div className="flex-1 space-y-3 text-xs text-slate-300/80">
-                      <p>
-                        새로운 이미지를 업로드하면 즉시 교체됩니다. 이미지 비율은 원본에 맞춰 표시돼요.
-                      </p>
-                      <div className="flex flex-wrap gap-3">
-                        <input
-                          ref={editFileInputRef}
-                          type="file"
-                          accept="image/jpeg,image/png,image/webp"
-                          className="hidden"
-                          onChange={handleEditImageUpload}
-                        />
-                        <button
-                          type="button"
-                          onClick={() => editFileInputRef.current?.click()}
-                          className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 px-4 py-2 text-sm font-semibold text-white shadow-[0_12px_35px_rgba(99,102,241,0.4)] transition hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-200"
-                        >
-                          이미지 교체
-                        </button>
-                        <button
-                          type="button"
-                          onClick={handleRevertImage}
-                          disabled={!editForm.imageUrl}
-                          className="inline-flex items-center justify-center rounded-full border border-slate-600/60 px-4 py-2 text-sm font-semibold text-slate-200 transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-40"
-                        >
-                          원본으로
-                        </button>
-                      </div>
-                      {editUploadMessage && (
-                        <p
-                          className={`text-xs ${editUploadState === 'error' ? 'text-rose-300' : editUploadState === 'success' ? 'text-emerald-300' : 'text-slate-400'}`}
-                        >
-                          {editUploadMessage}
-                        </p>
-                      )}
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              {editError && (
-                <div className="rounded-2xl border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">
-                  {editError}
-                </div>
-              )}
-
-              <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
-                <button
-                  type="button"
-                  onClick={closeEditModal}
-                  className="inline-flex items-center justify-center rounded-full border border-slate-600/60 px-5 py-2.5 text-sm font-semibold text-slate-200 transition hover:bg-slate-800"
-                >
-                  취소
-                </button>
-                <button
-                  type="button"
-                  onClick={handleSaveEdit}
-                  disabled={editStatus === 'saving'}
-                  className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-emerald-500 via-teal-500 to-cyan-500 px-6 py-2.5 text-sm font-semibold text-slate-950 shadow-[0_16px_40px_rgba(16,185,129,0.35)] transition hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-100 disabled:cursor-wait disabled:opacity-70"
-                >
-                  {editStatus === 'saving' ? '저장 중…' : editStatus === 'success' ? '저장 완료!' : '변경사항 저장'}
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
-      {undoInfo && (
-        <div className="fixed bottom-6 left-1/2 z-40 w-[min(90vw,26rem)] -translate-x-1/2">
-          <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-slate-900/90 px-4 py-3 text-sm text-slate-200 shadow-[0_25px_60px_rgba(15,23,42,0.55)] backdrop-blur">
-            <div className="flex-1" role="status" aria-live="polite">
-              {undoStatus === 'error'
-                ? '복원에 실패했어요. 다시 시도해 주세요.'
-                : undoStatus === 'success'
-                  ? '복원이 완료됐어요!'
-                  : `${undoDisplayTitle ? `‘${undoDisplayTitle}’` : '콘텐츠'} 항목을 삭제했어요.`}
-            </div>
-            <button
-              type="button"
-              onClick={handleUndoDelete}
-              disabled={undoStatus === 'pending' || undoStatus === 'success'}
-              className={`inline-flex items-center justify-center rounded-full px-3 py-1 text-sm font-semibold shadow ${undoStatus === 'pending' || undoStatus === 'success' ? 'cursor-default bg-white/40 text-slate-700' : 'bg-white text-slate-900 hover:bg-white/90'}`}
-            >
-              {undoStatus === 'pending'
-                ? '복원 중…'
-                : undoStatus === 'success'
-                  ? '완료'
-                  : '되돌리기'}
-            </button>
-            <button
-              type="button"
-              onClick={handleDismissUndo}
-              className="inline-flex h-8 w-8 items-center justify-center rounded-full text-slate-400 transition hover:bg-slate-800 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-200"
-              aria-label="되돌리기 알림 닫기"
-            >
-              ✕
-            </button>
-          </div>
-        </div>
-      )}
-    </>
+      <MetricsModal
+        editor={analytics.metricsEditor}
+        onClose={analytics.closeMetricsEditor}
+        onChange={analytics.handleMetricsFieldChange}
+        onSave={handleMetricsSave}
+      />
+      <DeleteModal
+        pendingDelete={pendingDelete}
+        status={deleteStatus}
+        error={deleteError}
+        onClose={closeDeleteModal}
+        onConfirm={handleConfirmDelete}
+      />
+      <EditContentModal
+        editingItem={editingItem}
+        editForm={editForm}
+        editStatus={editStatus}
+        editError={editError}
+        editUploadState={editUploadState}
+        editUploadMessage={editUploadMessage}
+        editFileInputRef={editFileInputRef}
+        onClose={closeEditModal}
+        onFieldChange={handleEditFieldChange}
+        onImageUpload={handleEditImageUpload}
+        onRevertImage={handleRevertImage}
+        onOpenTimestamps={openTimestampsEditor}
+        onSave={handleSaveEdit}
+      />
+      <TimestampsEditorModal
+        editor={timestampsEditor}
+        onClose={closeTimestampsEditor}
+        onFieldChange={handleTimestampsFieldChange}
+        onAddTimestamp={handleAddTimestamp}
+        onRemoveTimestamp={handleRemoveTimestamp}
+        onSave={handleSaveTimestamps}
+      />
+      <UndoToast info={undoInfo} status={undoStatus} onUndo={handleUndoDelete} onDismiss={handleDismissUndo} />
+    </AdminPageShell>
   );
 }
 
-Admin.disableAds = true;
+AdminPage.disableAds = true;


### PR DESCRIPTION
## 요약
- 대규모 admin 페이지를 레이아웃, 업로드, 분석, Adsterra, 모달 등 독립 컴포넌트와 커스텀 훅으로 분리하여 상태 및 UI 책임을 모듈화했습니다.
- 업로드 필터, CSV 다운로드, Adsterra 프리셋·차트·필터 칩 등 부가 기능을 추가하고 메트릭·타임스탬프 편집 흐름을 전담 훅으로 재구성했습니다.
- `/api/admin/register`에서 타임스탬프 갱신을 지원하도록 정규화 로직을 추가하고 공용 메타 정규화 유틸을 `lib/admin/normalizeMeta.js`로 이동했습니다.

## 테스트
- `npm run lint` *(globals 패키지 미설치로 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68d6878454608323a530502a30751cac