### PR TITLE
feat: 분석 대시보드 필터 추가

### DIFF
--- a/components/admin/analytics/AnalyticsToolbar.jsx
+++ b/components/admin/analytics/AnalyticsToolbar.jsx
@@ -5,29 +5,86 @@ export default function AnalyticsToolbar({
   visibleColumns,
   onToggleColumn,
   onExportCsv,
+  filters,
+  onFilterChange,
 }) {
+  const resolvedFilters = filters || {};
+  const typeValue = resolvedFilters.type || '';
+  const orientationValue = resolvedFilters.orientation || '';
+  const queryValue = resolvedFilters.query || '';
+
+  const handleQueryChange = (event) => {
+    onFilterChange?.({ query: event.target.value });
+  };
+
+  const handleTypeChange = (event) => {
+    onFilterChange?.({ type: event.target.value });
+  };
+
+  const handleOrientationChange = (event) => {
+    onFilterChange?.({ orientation: event.target.value });
+  };
+
   return (
     <div className="flex flex-col gap-3 rounded-2xl bg-slate-900/70 p-4 ring-1 ring-slate-800/60 md:flex-row md:items-center md:justify-between">
-      <div className="flex flex-wrap items-center gap-2 text-xs">
-        <span className="rounded-full bg-slate-950/60 px-3 py-1 text-slate-400">정렬 기준</span>
-        <button
-          type="button"
-          onClick={() => onSortChange('views')}
-          className={`rounded-full px-3 py-1 font-semibold transition ${
-            sortKey === 'views' ? 'bg-indigo-500 text-white' : 'bg-slate-800 text-slate-300'
-          }`}
-        >
-          조회수 {sortKey === 'views' ? (sortDirection === 'asc' ? '↑' : '↓') : ''}
-        </button>
-        <button
-          type="button"
-          onClick={() => onSortChange('likes')}
-          className={`rounded-full px-3 py-1 font-semibold transition ${
-            sortKey === 'likes' ? 'bg-indigo-500 text-white' : 'bg-slate-800 text-slate-300'
-          }`}
-        >
-          좋아요 {sortKey === 'likes' ? (sortDirection === 'asc' ? '↑' : '↓') : ''}
-        </button>
+      <div className="flex flex-1 flex-wrap items-center gap-3 text-xs">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="rounded-full bg-slate-950/60 px-3 py-1 text-slate-400">정렬 기준</span>
+          <button
+            type="button"
+            onClick={() => onSortChange('views')}
+            className={`rounded-full px-3 py-1 font-semibold transition ${
+              sortKey === 'views' ? 'bg-indigo-500 text-white' : 'bg-slate-800 text-slate-300'
+            }`}
+          >
+            조회수 {sortKey === 'views' ? (sortDirection === 'asc' ? '↑' : '↓') : ''}
+          </button>
+          <button
+            type="button"
+            onClick={() => onSortChange('likes')}
+            className={`rounded-full px-3 py-1 font-semibold transition ${
+              sortKey === 'likes' ? 'bg-indigo-500 text-white' : 'bg-slate-800 text-slate-300'
+            }`}
+          >
+            좋아요 {sortKey === 'likes' ? (sortDirection === 'asc' ? '↑' : '↓') : ''}
+          </button>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="flex items-center gap-2 rounded-full bg-slate-950/50 px-3 py-1">
+            <span className="text-xs text-slate-500">검색</span>
+            <input
+              value={queryValue}
+              onChange={handleQueryChange}
+              placeholder="제목·슬러그"
+              className="w-28 bg-transparent text-sm text-slate-200 outline-none sm:w-40"
+            />
+          </div>
+          <div className="flex items-center gap-2 rounded-full bg-slate-950/50 px-3 py-1">
+            <span className="text-xs text-slate-500">타입</span>
+            <select
+              value={typeValue}
+              onChange={handleTypeChange}
+              className="bg-transparent text-xs text-slate-200 outline-none"
+            >
+              <option value="">전체</option>
+              <option value="video">영상</option>
+              <option value="image">이미지</option>
+            </select>
+          </div>
+          <div className="flex items-center gap-2 rounded-full bg-slate-950/50 px-3 py-1">
+            <span className="text-xs text-slate-500">방향</span>
+            <select
+              value={orientationValue}
+              onChange={handleOrientationChange}
+              className="bg-transparent text-xs text-slate-200 outline-none"
+            >
+              <option value="">전체</option>
+              <option value="landscape">가로</option>
+              <option value="portrait">세로</option>
+              <option value="square">정사각형</option>
+            </select>
+          </div>
+        </div>
       </div>
       <div className="flex flex-wrap items-center gap-3 text-xs text-slate-300">
         <div className="flex flex-wrap items-center gap-2">

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -101,7 +101,15 @@ export default function AdminPage() {
     error: itemsError,
   } = useAdminItems({ enabled: hasToken, queryString: uploadsQueryString, pageSize: 6 });
   const { copiedSlug, copy } = useClipboard();
-  const analytics = useAnalyticsMetrics({ items, enabled: hasToken && view === 'analytics' });
+  const analyticsInitialFilters = useMemo(
+    () => ({ type: '', orientation: '', query: '' }),
+    []
+  );
+  const analytics = useAnalyticsMetrics({
+    items,
+    enabled: hasToken && view === 'analytics',
+    initialFilters: analyticsInitialFilters,
+  });
 
   const defaultAdsterraRange = useMemo(() => getDefaultAdsterraDateRange(), []);
   const adsterraEnvToken = useMemo(
@@ -480,6 +488,8 @@ export default function AdminPage() {
               visibleColumns={visibleColumns}
               onToggleColumn={analytics.toggleColumn}
               onExportCsv={handleExportCsv}
+              filters={analytics.filters}
+              onFilterChange={analytics.updateFilters}
             />
             <AnalyticsTable
               rows={analytics.sortedAnalyticsRows}


### PR DESCRIPTION
## 요약
- useAnalyticsMetrics 훅에 필터 상태를 추가하고 행/집계 계산 시 조건을 반영했습니다.
- AnalyticsToolbar에 검색/타입/방향 컨트롤을 추가하여 필터 변경을 상위로 전달합니다.
- admin 페이지에서 필터 초기값을 주입하고 툴바에 필터 상태와 변경 핸들러를 전달합니다.

## 테스트
- npm run lint *(기존 규칙으로 인한 react/react-in-jsx-scope 등 오류 발생)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a8262eb083238291abf9978b153b