### PR TITLE
관리자 분석 기간 필터 및 추세 그래프 추가

### DIFF
--- a/components/admin/analytics/AnalyticsTable.jsx
+++ b/components/admin/analytics/AnalyticsTable.jsx
@@ -30,7 +30,7 @@ export default function AnalyticsTable({
               <AnalyticsRow
                 key={row.slug}
                 row={row}
-                metrics={row.metrics}
+                metrics={row.displayMetrics || row.metrics}
                 metricsLoading={metricsLoading}
                 formatNumber={formatNumber}
                 formatPercent={formatPercent}

--- a/components/admin/analytics/AnalyticsToolbar.jsx
+++ b/components/admin/analytics/AnalyticsToolbar.jsx
@@ -5,6 +5,9 @@ export default function AnalyticsToolbar({
   visibleColumns,
   onToggleColumn,
   onExportCsv,
+  startDate,
+  endDate,
+  onDateChange,
 }) {
   return (
     <div className="flex flex-col gap-3 rounded-2xl bg-slate-900/70 p-4 ring-1 ring-slate-800/60 md:flex-row md:items-center md:justify-between">
@@ -29,7 +32,7 @@ export default function AnalyticsToolbar({
           좋아요 {sortKey === 'likes' ? (sortDirection === 'asc' ? '↑' : '↓') : ''}
         </button>
       </div>
-      <div className="flex flex-wrap items-center gap-3 text-xs text-slate-300">
+      <div className="flex flex-col gap-3 text-xs text-slate-300 md:flex-row md:items-center md:justify-end">
         <div className="flex flex-wrap items-center gap-2">
           {Object.entries(visibleColumns).map(([key, value]) => (
             <label
@@ -45,6 +48,26 @@ export default function AnalyticsToolbar({
               {key}
             </label>
           ))}
+        </div>
+        <div className="flex flex-wrap items-center gap-2 text-slate-200">
+          <label className="flex items-center gap-1 rounded-full bg-slate-950/60 px-3 py-1">
+            <span className="text-[11px] uppercase tracking-widest text-slate-400">시작</span>
+            <input
+              type="date"
+              value={startDate || ''}
+              onChange={(event) => onDateChange?.('start', event.target.value)}
+              className="rounded bg-slate-800/80 px-2 py-1 text-xs text-slate-100 outline-none"
+            />
+          </label>
+          <label className="flex items-center gap-1 rounded-full bg-slate-950/60 px-3 py-1">
+            <span className="text-[11px] uppercase tracking-widest text-slate-400">종료</span>
+            <input
+              type="date"
+              value={endDate || ''}
+              onChange={(event) => onDateChange?.('end', event.target.value)}
+              className="rounded bg-slate-800/80 px-2 py-1 text-xs text-slate-100 outline-none"
+            />
+          </label>
         </div>
         <button
           type="button"

--- a/components/admin/analytics/AnalyticsTrendChart.jsx
+++ b/components/admin/analytics/AnalyticsTrendChart.jsx
@@ -1,0 +1,139 @@
+import { useMemo } from 'react';
+
+function buildPolylinePoints(history, key, width, height, padding) {
+  if (!history.length) return '';
+  const maxValue = Math.max(...history.map((entry) => Math.max(0, Number(entry[key]) || 0)));
+  if (maxValue === 0) {
+    const baselineY = height - padding;
+    return history
+      .map((entry, index) => {
+        const x = padding + (index / Math.max(1, history.length - 1)) * (width - padding * 2);
+        return `${x},${baselineY}`;
+      })
+      .join(' ');
+  }
+  return history
+    .map((entry, index) => {
+      const value = Math.max(0, Number(entry[key]) || 0);
+      const x = padding + (index / Math.max(1, history.length - 1)) * (width - padding * 2);
+      const y = padding + (1 - value / maxValue) * (height - padding * 2);
+      return `${x},${y}`;
+    })
+    .join(' ');
+}
+
+export default function AnalyticsTrendChart({ history, formatNumber }) {
+  const sanitizedHistory = useMemo(
+    () =>
+      Array.isArray(history)
+        ? history
+            .map((entry) => ({
+              date: entry?.date || '',
+              views: Number(entry?.views) || 0,
+              likes: Number(entry?.likes) || 0,
+            }))
+            .filter((entry) => entry.date)
+        : [],
+    [history]
+  );
+
+  if (!sanitizedHistory.length) {
+    return null;
+  }
+
+  const width = 720;
+  const height = 280;
+  const padding = 32;
+
+  const viewsPoints = buildPolylinePoints(sanitizedHistory, 'views', width, height, padding);
+  const likesPoints = buildPolylinePoints(sanitizedHistory, 'likes', width, height, padding);
+  const maxValue = Math.max(
+    ...sanitizedHistory.map((entry) => Math.max(entry.views, entry.likes)),
+    0
+  );
+
+  return (
+    <div className="rounded-2xl border border-slate-800/60 bg-slate-900/70 p-4 shadow-inner shadow-black/30">
+      <div className="mb-4 flex items-center justify-between text-xs uppercase tracking-[0.3em] text-slate-400">
+        <span>기간별 추이</span>
+        <div className="flex items-center gap-3 text-[11px] tracking-normal text-slate-300">
+          <span className="flex items-center gap-1">
+            <span className="inline-block h-2 w-2 rounded-full bg-indigo-400" /> 조회수
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="inline-block h-2 w-2 rounded-full bg-rose-400" /> 좋아요
+          </span>
+        </div>
+      </div>
+      <div className="relative">
+        <svg viewBox={`0 0 ${width} ${height}`} className="w-full">
+          <defs>
+            <linearGradient id="trendViews" x1="0%" y1="0%" x2="0%" y2="100%">
+              <stop offset="0%" stopColor="rgba(99, 102, 241, 0.35)" />
+              <stop offset="100%" stopColor="rgba(99, 102, 241, 0)" />
+            </linearGradient>
+            <linearGradient id="trendLikes" x1="0%" y1="0%" x2="0%" y2="100%">
+              <stop offset="0%" stopColor="rgba(244, 114, 182, 0.4)" />
+              <stop offset="100%" stopColor="rgba(244, 114, 182, 0)" />
+            </linearGradient>
+          </defs>
+          <rect
+            x={padding}
+            y={padding}
+            width={width - padding * 2}
+            height={height - padding * 2}
+            fill="transparent"
+            stroke="rgba(148, 163, 184, 0.2)"
+            strokeDasharray="4 4"
+          />
+          {viewsPoints && (
+            <>
+              <polyline
+                points={viewsPoints}
+                fill="none"
+                stroke="rgb(99, 102, 241)"
+                strokeWidth="2"
+                strokeLinejoin="round"
+                strokeLinecap="round"
+              />
+              <polygon
+                points={`${viewsPoints} ${padding + (width - padding * 2)},${height - padding} ${padding},${height - padding}`}
+                fill="url(#trendViews)"
+                opacity="0.4"
+              />
+            </>
+          )}
+          {likesPoints && (
+            <>
+              <polyline
+                points={likesPoints}
+                fill="none"
+                stroke="rgb(244, 114, 182)"
+                strokeWidth="2"
+                strokeLinejoin="round"
+                strokeLinecap="round"
+              />
+              <polygon
+                points={`${likesPoints} ${padding + (width - padding * 2)},${height - padding} ${padding},${height - padding}`}
+                fill="url(#trendLikes)"
+                opacity="0.35"
+              />
+            </>
+          )}
+        </svg>
+        <div className="mt-4 grid grid-cols-2 gap-2 text-[11px] text-slate-400 sm:grid-cols-4">
+          {sanitizedHistory.map((entry) => (
+            <div key={entry.date} className="flex flex-col rounded-lg bg-slate-950/40 px-2 py-1">
+              <span className="text-slate-300">{entry.date}</span>
+              <span className="text-[10px] text-slate-500">조회수 {formatNumber(entry.views)}</span>
+              <span className="text-[10px] text-slate-500">좋아요 {formatNumber(entry.likes)}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="mt-4 text-right text-[11px] uppercase tracking-[0.3em] text-slate-500">
+        최대값 {formatNumber(maxValue)}
+      </div>
+    </div>
+  );
+}

--- a/components/admin/analytics/export/AnalyticsCsvExporter.js
+++ b/components/admin/analytics/export/AnalyticsCsvExporter.js
@@ -11,7 +11,7 @@ export function buildAnalyticsCsv(rows) {
   const header = ['slug', 'title', 'type', 'views', 'likes', 'like_rate'];
   const lines = [header.join(',')];
   rows.forEach((row) => {
-    const metrics = row.metrics || { views: 0, likes: 0 };
+    const metrics = row.displayMetrics || row.metrics || { views: 0, likes: 0 };
     const likeRate = metrics.views > 0 ? metrics.likes / metrics.views : 0;
     lines.push(
       [

--- a/hooks/admin/useAnalyticsMetrics.js
+++ b/hooks/admin/useAnalyticsMetrics.js
@@ -9,7 +9,18 @@ const DEFAULT_COLUMNS = {
   edit: true,
 };
 
-export default function useAnalyticsMetrics({ items, enabled }) {
+function normalizeHistory(entries) {
+  if (!Array.isArray(entries)) return [];
+  return entries
+    .map((entry) => ({
+      date: typeof entry?.date === 'string' ? entry.date : null,
+      views: Number(entry?.views) || 0,
+      likes: Math.max(0, Number(entry?.likes) || 0),
+    }))
+    .filter((entry) => Boolean(entry.date));
+}
+
+export default function useAnalyticsMetrics({ items, enabled, startDate, endDate }) {
   const [metricsBySlug, setMetricsBySlug] = useState({});
   const [metricsLoading, setMetricsLoading] = useState(false);
   const [metricsError, setMetricsError] = useState(null);
@@ -19,6 +30,7 @@ export default function useAnalyticsMetrics({ items, enabled }) {
   const [metricsEditor, setMetricsEditor] = useState(null);
 
   const pendingMetricsRef = useRef(new Set());
+  const rangeActive = Boolean(startDate && endDate);
 
   useEffect(() => {
     setMetricsBySlug((prev) => {
@@ -32,7 +44,13 @@ export default function useAnalyticsMetrics({ items, enabled }) {
   }, [items]);
 
   useEffect(() => {
+    pendingMetricsRef.current = new Set();
+    setMetricsBySlug({});
+  }, [startDate, endDate]);
+
+  useEffect(() => {
     if (!enabled) return undefined;
+
     const slugs = items.map((item) => item.slug).filter(Boolean);
     const pendingSet = pendingMetricsRef.current;
     const fetchTargets = slugs.filter((slug) => !metricsBySlug[slug] && !pendingSet.has(slug));
@@ -52,16 +70,35 @@ export default function useAnalyticsMetrics({ items, enabled }) {
       try {
         const results = await Promise.all(
           fetchTargets.map(async (slug) => {
-            const res = await fetch(`/api/metrics/get?slug=${encodeURIComponent(slug)}`);
+            const params = new URLSearchParams();
+            params.set('slug', slug);
+            if (startDate) params.set('start', startDate);
+            if (endDate) params.set('end', endDate);
+            const res = await fetch(`/api/metrics/get?${params.toString()}`);
             if (!res.ok) {
               throw new Error('metrics_error');
             }
             const data = await res.json();
+            const totalViews = Number(data?.views) || 0;
+            const totalLikes = Math.max(0, Number(data?.likes) || 0);
+            const history = normalizeHistory(data?.history);
+            const rawRangeTotals = data?.rangeTotals;
+            const rangeTotals =
+              rawRangeTotals && typeof rawRangeTotals === 'object'
+                ? {
+                    views: Number(rawRangeTotals.views) || 0,
+                    likes: Math.max(0, Number(rawRangeTotals.likes) || 0),
+                  }
+                : null;
+            const liked = typeof data?.liked === 'boolean' ? data.liked : undefined;
             return {
               slug,
               metrics: {
-                views: Number(data?.views) || 0,
-                likes: Math.max(0, Number(data?.likes) || 0),
+                views: totalViews,
+                likes: totalLikes,
+                liked,
+                history,
+                rangeTotals,
               },
             };
           })
@@ -90,7 +127,7 @@ export default function useAnalyticsMetrics({ items, enabled }) {
       fetchTargets.forEach((slug) => pendingSet.delete(slug));
       setMetricsLoading(false);
     };
-  }, [enabled, items, metricsBySlug]);
+  }, [enabled, items, metricsBySlug, startDate, endDate]);
 
   const analyticsRows = useMemo(
     () =>
@@ -103,43 +140,103 @@ export default function useAnalyticsMetrics({ items, enabled }) {
     [items, metricsBySlug]
   );
 
+  const hasRangeData = useMemo(() => analyticsRows.some((row) => row.metrics?.rangeTotals), [analyticsRows]);
+
+  const rowsWithDisplayMetrics = useMemo(
+    () =>
+      analyticsRows.map((row) => {
+        const metrics = row.metrics;
+        if (!metrics) return { ...row, displayMetrics: null };
+        const useRangeTotals = rangeActive && hasRangeData && metrics.rangeTotals;
+        const viewsForDisplay = useRangeTotals ? metrics.rangeTotals.views ?? metrics.views : metrics.views;
+        const likesForDisplay = useRangeTotals ? metrics.rangeTotals.likes ?? metrics.likes : metrics.likes;
+        return {
+          ...row,
+          displayMetrics: {
+            ...metrics,
+            views: Number(viewsForDisplay) || 0,
+            likes: Math.max(0, Number(likesForDisplay) || 0),
+          },
+        };
+      }),
+    [analyticsRows, hasRangeData, rangeActive]
+  );
+
   const sortedAnalyticsRows = useMemo(() => {
-    const rows = [...analyticsRows];
+    const rows = [...rowsWithDisplayMetrics];
     const directionMultiplier = sortDirection === 'asc' ? 1 : -1;
     rows.sort((a, b) => {
-      const metricsA = a.metrics || {};
-      const metricsB = b.metrics || {};
+      const metricsA = a.displayMetrics || {};
+      const metricsB = b.displayMetrics || {};
       const aValue = sortKey === 'likes' ? metricsA.likes ?? 0 : metricsA.views ?? 0;
       const bValue = sortKey === 'likes' ? metricsB.likes ?? 0 : metricsB.views ?? 0;
       return (bValue - aValue) * directionMultiplier;
     });
     return rows;
-  }, [analyticsRows, sortDirection, sortKey]);
+  }, [rowsWithDisplayMetrics, sortDirection, sortKey]);
 
   const analyticsTotals = useMemo(
     () =>
-      analyticsRows.reduce(
+      rowsWithDisplayMetrics.reduce(
         (acc, row) => {
-          if (!row.metrics) return acc;
+          if (!row.displayMetrics) return acc;
           return {
-            views: acc.views + (row.metrics.views || 0),
-            likes: acc.likes + (row.metrics.likes || 0),
+            views: acc.views + (row.displayMetrics.views || 0),
+            likes: acc.likes + (row.displayMetrics.likes || 0),
           };
         },
         { views: 0, likes: 0 }
       ),
-    [analyticsRows]
+    [rowsWithDisplayMetrics]
   );
 
   const averageLikeRate = useMemo(() => {
-    const withViews = analyticsRows.filter((row) => row.metrics && row.metrics.views > 0);
+    const withViews = rowsWithDisplayMetrics.filter((row) => row.displayMetrics && row.displayMetrics.views > 0);
     if (!withViews.length) return 0;
-    const totalRate = withViews.reduce(
-      (acc, row) => acc + row.metrics.likes / row.metrics.views,
-      0
-    );
+    const totalRate = withViews.reduce((acc, row) => acc + row.displayMetrics.likes / row.displayMetrics.views, 0);
     return totalRate / withViews.length;
+  }, [rowsWithDisplayMetrics]);
+
+  const aggregatedRangeTotals = useMemo(() => {
+    let hasRangeTotals = false;
+    const totals = analyticsRows.reduce(
+      (acc, row) => {
+        if (!row.metrics?.rangeTotals) return acc;
+        hasRangeTotals = true;
+        return {
+          views: acc.views + (row.metrics.rangeTotals.views || 0),
+          likes: acc.likes + (row.metrics.rangeTotals.likes || 0),
+        };
+      },
+      { views: 0, likes: 0 }
+    );
+    return { totals, hasRangeTotals };
   }, [analyticsRows]);
+
+  const trendHistory = useMemo(() => {
+    const buckets = new Map();
+    analyticsRows.forEach((row) => {
+      const history = row.metrics?.history;
+      if (!Array.isArray(history)) return;
+      history.forEach((entry) => {
+        if (!entry?.date) return;
+        const existing = buckets.get(entry.date) || { date: entry.date, views: 0, likes: 0 };
+        existing.views += Number(entry.views) || 0;
+        existing.likes += Math.max(0, Number(entry.likes) || 0);
+        buckets.set(entry.date, existing);
+      });
+    });
+    return Array.from(buckets.values()).sort((a, b) => new Date(a.date) - new Date(b.date));
+  }, [analyticsRows]);
+
+  const exportRows = useMemo(
+    () =>
+      sortedAnalyticsRows.map((row) => ({
+        ...row,
+        metrics: row.displayMetrics || row.metrics || { views: 0, likes: 0 },
+      })),
+    [sortedAnalyticsRows]
+  );
 
   const toggleColumn = useCallback((column) => {
     setVisibleColumns((prev) => ({
@@ -202,18 +299,25 @@ export default function useAnalyticsMetrics({ items, enabled }) {
   }, []);
 
   const updateMetricsForSlug = useCallback((slug, views, likes) => {
-    setMetricsBySlug((prev) => ({
-      ...prev,
-      [slug]: { views, likes },
-    }));
+    setMetricsBySlug((prev) => {
+      const next = { ...prev };
+      const existing = next[slug] || {};
+      next[slug] = { ...existing, views, likes };
+      return next;
+    });
   }, []);
 
-  const buildCsv = useCallback(() => buildAnalyticsCsv(sortedAnalyticsRows), [sortedAnalyticsRows]);
+  const buildCsv = useCallback(() => buildAnalyticsCsv(exportRows), [exportRows]);
 
   return {
     analyticsRows,
     sortedAnalyticsRows,
     analyticsTotals,
+    rangeTotals: aggregatedRangeTotals.hasRangeTotals ? aggregatedRangeTotals.totals : null,
+    hasRangeTotals: aggregatedRangeTotals.hasRangeTotals,
+    isRangeActive: rangeActive,
+    trendHistory,
+    exportRows,
     averageLikeRate,
     metricsBySlug,
     metricsLoading,

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -7,6 +7,7 @@ import UploadsSection from '../components/admin/uploads/UploadsSection';
 import AnalyticsOverview from '../components/admin/analytics/AnalyticsOverview';
 import AnalyticsToolbar from '../components/admin/analytics/AnalyticsToolbar';
 import AnalyticsTable from '../components/admin/analytics/AnalyticsTable';
+import AnalyticsTrendChart from '../components/admin/analytics/AnalyticsTrendChart';
 import AdsterraControls from '../components/admin/adsterra/AdsterraControls';
 import AdsterraSummaryCards from '../components/admin/adsterra/AdsterraSummaryCards';
 import AdsterraStatsTable from '../components/admin/adsterra/AdsterraStatsTable';
@@ -101,7 +102,15 @@ export default function AdminPage() {
     error: itemsError,
   } = useAdminItems({ enabled: hasToken, queryString: uploadsQueryString, pageSize: 6 });
   const { copiedSlug, copy } = useClipboard();
-  const analytics = useAnalyticsMetrics({ items, enabled: hasToken && view === 'analytics' });
+  const [analyticsStartDate, setAnalyticsStartDate] = useState('');
+  const [analyticsEndDate, setAnalyticsEndDate] = useState('');
+
+  const analytics = useAnalyticsMetrics({
+    items,
+    enabled: hasToken && view === 'analytics',
+    startDate: analyticsStartDate,
+    endDate: analyticsEndDate,
+  });
 
   const defaultAdsterraRange = useMemo(() => getDefaultAdsterraDateRange(), []);
   const adsterraEnvToken = useMemo(
@@ -415,9 +424,17 @@ export default function AdminPage() {
     [adsterra]
   );
 
+  const handleAnalyticsDateChange = useCallback((field, value) => {
+    if (field === 'start') {
+      setAnalyticsStartDate(value);
+    } else if (field === 'end') {
+      setAnalyticsEndDate(value);
+    }
+  }, []);
+
   const handleExportCsv = useCallback(() => {
-    downloadAnalyticsCsv(analytics.sortedAnalyticsRows);
-  }, [analytics.sortedAnalyticsRows]);
+    downloadAnalyticsCsv(analytics.exportRows);
+  }, [analytics.exportRows]);
 
   const visibleColumns = analytics.visibleColumns;
 
@@ -480,7 +497,13 @@ export default function AdminPage() {
               visibleColumns={visibleColumns}
               onToggleColumn={analytics.toggleColumn}
               onExportCsv={handleExportCsv}
+              startDate={analyticsStartDate}
+              endDate={analyticsEndDate}
+              onDateChange={handleAnalyticsDateChange}
             />
+            {analytics.isRangeActive && analytics.trendHistory.length > 0 && (
+              <AnalyticsTrendChart history={analytics.trendHistory} formatNumber={formatNumber} />
+            )}
             <AnalyticsTable
               rows={analytics.sortedAnalyticsRows}
               metricsLoading={analytics.metricsLoading}

--- a/pages/api/metrics/get.js
+++ b/pages/api/metrics/get.js
@@ -1,6 +1,6 @@
 export default async function handler(req, res) {
   if (req.method !== 'GET') return res.status(405).end();
-  const { slug, withSession } = req.query;
+  const { slug, withSession, start, end } = req.query;
   if (!slug) return res.status(400).json({ error: 'Missing slug' });
 
   const sessionRequested = typeof withSession !== 'undefined';
@@ -8,6 +8,15 @@ export default async function handler(req, res) {
   const viewerId = sessionRequested ? ensureViewerId(req, res) : getViewerId(req);
 
   const { getMetrics } = await import('../../../utils/metricsStore');
-  const data = await getMetrics(slug, { viewerId });
+  const startDate = parseDateParam(start);
+  const endDate = parseDateParam(end);
+  const data = await getMetrics(slug, { viewerId, startDate, endDate });
   res.status(200).json({ slug, ...data });
+}
+
+function parseDateParam(value) {
+  if (typeof value !== 'string' || !value.trim()) return null;
+  const parsed = new Date(`${value}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed;
 }


### PR DESCRIPTION
## 요약
- 관리자 분석 툴바에 날짜 범위 입력을 추가하고 상태를 연동했습니다.
- 기간별 합계와 히스토리 응답을 제공하도록 메트릭 훅, API, 저장소 로직을 보강했습니다.
- 기간이 지정된 경우 추세 그래프 컴포넌트를 렌더링해 기간 기반 데이터를 시각화했습니다.

## 테스트
- npm run lint *(react/react-in-jsx-scope 등 기존 린트 규칙 미충족으로 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a82528688323aad1d7b32d8f93dc