### PR TITLE
Analytics 일괄 편집 및 감사 로그 기능 추가

### DIFF
--- a/components/admin/analytics/AnalyticsHistoryPanel.jsx
+++ b/components/admin/analytics/AnalyticsHistoryPanel.jsx
@@ -1,0 +1,126 @@
+import { useMemo } from 'react';
+import ModalPortal from '../modals/ModalPortal';
+
+function formatTimestamp(value) {
+  try {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return value;
+    return date.toLocaleString('ko-KR', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+  } catch (error) {
+    return value;
+  }
+}
+
+export default function AnalyticsHistoryPanel({
+  open,
+  onClose,
+  logs,
+  loading,
+  error,
+  onRetry,
+  focusSlugs,
+}) {
+  const targetLabel = useMemo(() => {
+    if (!Array.isArray(focusSlugs) || !focusSlugs.length) return '전체 메트릭 이력';
+    if (focusSlugs.length === 1) return `Slug: ${focusSlugs[0]}`;
+    if (focusSlugs.length <= 3) return focusSlugs.join(', ');
+    return `${focusSlugs.slice(0, 3).join(', ')} 외 ${focusSlugs.length - 3}개`;
+  }, [focusSlugs]);
+
+  if (!open) return null;
+
+  return (
+    <ModalPortal>
+      <div className="fixed inset-0 z-40 flex justify-end bg-slate-950/60 backdrop-blur-sm">
+        <div className="h-full w-full max-w-md border-l border-slate-800/70 bg-slate-900/95 shadow-[0_32px_80px_rgba(15,23,42,0.6)]">
+          <div className="flex items-center justify-between border-b border-slate-800/70 px-6 py-4">
+            <div>
+              <h3 className="text-lg font-semibold text-white">변경 이력</h3>
+              <p className="text-xs text-slate-400">{targetLabel}</p>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-full border border-slate-700/60 px-3 py-1 text-xs font-semibold text-slate-300 transition hover:bg-slate-800"
+            >
+              닫기
+            </button>
+          </div>
+          <div className="flex h-[calc(100%-64px)] flex-col overflow-hidden">
+            {loading && (
+              <div className="flex flex-1 items-center justify-center text-sm text-slate-300">
+                변경 이력을 불러오는 중입니다…
+              </div>
+            )}
+            {!loading && error && (
+              <div className="flex flex-1 flex-col items-center justify-center gap-3 px-6 text-center text-sm text-rose-200">
+                <p>{error}</p>
+                <button
+                  type="button"
+                  onClick={onRetry}
+                  className="rounded-full border border-rose-400/60 px-4 py-2 text-xs font-semibold text-rose-200 transition hover:bg-rose-500/20"
+                >
+                  다시 시도
+                </button>
+              </div>
+            )}
+            {!loading && !error && (
+              <div className="flex-1 overflow-y-auto px-6 py-4">
+                {Array.isArray(logs) && logs.length ? (
+                  <ul className="space-y-4">
+                    {logs.map((log) => {
+                      const viewsChanged = log.before?.views !== log.after?.views;
+                      const likesChanged = log.before?.likes !== log.after?.likes;
+                      return (
+                        <li
+                          key={log.id}
+                          className="rounded-2xl border border-slate-800/70 bg-slate-900/80 px-4 py-3 text-sm text-slate-200 shadow-inner shadow-black/30"
+                        >
+                          <div className="flex items-start justify-between">
+                            <div>
+                              <p className="text-xs uppercase tracking-[0.2em] text-slate-500">{log.slug}</p>
+                              <p className="mt-1 text-[12px] text-slate-400">{formatTimestamp(log.changedAt)}</p>
+                            </div>
+                            <span className="rounded-full bg-slate-800 px-2 py-0.5 text-[11px] text-slate-300">
+                              {log.changedBy || 'unknown'}
+                            </span>
+                          </div>
+                          <div className="mt-3 space-y-2 text-[13px]">
+                            <div className="flex items-center justify-between">
+                              <span className="text-slate-400">조회수</span>
+                              <span className={`font-semibold ${viewsChanged ? 'text-emerald-300' : 'text-slate-200'}`}>
+                                {log.before?.views ?? 0} → {log.after?.views ?? 0}
+                              </span>
+                            </div>
+                            <div className="flex items-center justify-between">
+                              <span className="text-slate-400">좋아요</span>
+                              <span className={`font-semibold ${likesChanged ? 'text-cyan-300' : 'text-slate-200'}`}>
+                                {log.before?.likes ?? 0} → {log.after?.likes ?? 0}
+                              </span>
+                            </div>
+                          </div>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                ) : (
+                  <div className="flex h-full items-center justify-center text-sm text-slate-400">
+                    아직 변경 이력이 없어요.
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </ModalPortal>
+  );
+}
+

--- a/components/admin/analytics/AnalyticsRow.jsx
+++ b/components/admin/analytics/AnalyticsRow.jsx
@@ -6,13 +6,24 @@ export default function AnalyticsRow({
   formatPercent,
   onEdit,
   visibleColumns,
+  selected,
+  onToggleSelect,
 }) {
   const viewsDisplay = metrics ? formatNumber(metrics.views) : metricsLoading ? '불러오는 중…' : '—';
   const likesDisplay = metrics ? formatNumber(metrics.likes) : metricsLoading ? '불러오는 중…' : '—';
   const likeRateDisplay = metrics && metrics.views > 0 ? formatPercent(metrics.likes / metrics.views) : '—';
 
   return (
-    <tr className="hover:bg-slate-800/40">
+    <tr className={`transition hover:bg-slate-800/40 ${selected ? 'bg-slate-800/30' : ''}`}>
+      <td className="px-4 py-3">
+        <input
+          type="checkbox"
+          className="accent-emerald-400"
+          checked={selected}
+          onChange={() => onToggleSelect(row.slug)}
+          aria-label={`${row.title || row.slug} 선택`}
+        />
+      </td>
       <td className="px-4 py-3">
         <div className="font-semibold text-slate-100">{row.title || row.slug}</div>
         <div className="text-xs text-slate-500">{row.slug}</div>

--- a/components/admin/analytics/AnalyticsTable.jsx
+++ b/components/admin/analytics/AnalyticsTable.jsx
@@ -1,3 +1,4 @@
+import { useEffect, useMemo, useRef } from 'react';
 import AnalyticsEmptyState from './AnalyticsEmptyState';
 import AnalyticsRow from './AnalyticsRow';
 
@@ -9,13 +10,42 @@ export default function AnalyticsTable({
   formatPercent,
   onEdit,
   visibleColumns,
+  selectedSlugs,
+  onToggleRow,
+  onToggleAll,
 }) {
+  const headerCheckboxRef = useRef(null);
+  const selectableSlugs = useMemo(() => rows.map((row) => row.slug).filter(Boolean), [rows]);
+  const selectedSet = useMemo(() => new Set(selectedSlugs), [selectedSlugs]);
+  const selectedCount = useMemo(
+    () => selectableSlugs.filter((slug) => selectedSet.has(slug)).length,
+    [selectableSlugs, selectedSet]
+  );
+  const allSelected = selectableSlugs.length > 0 && selectedCount === selectableSlugs.length;
+  const isIndeterminate = selectedCount > 0 && !allSelected;
+
+  useEffect(() => {
+    if (headerCheckboxRef.current) {
+      headerCheckboxRef.current.indeterminate = isIndeterminate;
+    }
+  }, [isIndeterminate]);
+
   return (
     <div className="overflow-hidden rounded-2xl bg-slate-900/80 ring-1 ring-slate-800/70">
       <div className="overflow-x-auto">
         <table className="min-w-full divide-y divide-slate-800/70 text-sm">
           <thead className="bg-slate-900/60 text-left text-xs uppercase tracking-widest text-slate-400">
             <tr>
+              <th className="px-4 py-3">
+                <input
+                  ref={headerCheckboxRef}
+                  type="checkbox"
+                  className="accent-emerald-400"
+                  checked={allSelected}
+                  onChange={() => onToggleAll(!allSelected)}
+                  aria-label="모든 항목 선택"
+                />
+              </th>
               <th className="px-4 py-3 font-semibold">콘텐츠</th>
               <th className="px-4 py-3 font-semibold">타입</th>
               {visibleColumns.views && <th className="px-4 py-3 text-right font-semibold">조회수</th>}
@@ -36,6 +66,8 @@ export default function AnalyticsTable({
                 formatPercent={formatPercent}
                 onEdit={onEdit}
                 visibleColumns={visibleColumns}
+                selected={selectedSet.has(row.slug)}
+                onToggleSelect={onToggleRow}
               />
             ))}
             {!rows.length && <AnalyticsEmptyState />}

--- a/components/admin/analytics/AnalyticsToolbar.jsx
+++ b/components/admin/analytics/AnalyticsToolbar.jsx
@@ -5,9 +5,13 @@ export default function AnalyticsToolbar({
   visibleColumns,
   onToggleColumn,
   onExportCsv,
+  selectedCount,
+  onOpenBulkEditor,
+  onOpenHistory,
+  onOpenCsvUpload,
 }) {
   return (
-    <div className="flex flex-col gap-3 rounded-2xl bg-slate-900/70 p-4 ring-1 ring-slate-800/60 md:flex-row md:items-center md:justify-between">
+    <div className="flex flex-col gap-4 rounded-2xl bg-slate-900/70 p-4 ring-1 ring-slate-800/60">
       <div className="flex flex-wrap items-center gap-2 text-xs">
         <span className="rounded-full bg-slate-950/60 px-3 py-1 text-slate-400">정렬 기준</span>
         <button
@@ -29,7 +33,7 @@ export default function AnalyticsToolbar({
           좋아요 {sortKey === 'likes' ? (sortDirection === 'asc' ? '↑' : '↓') : ''}
         </button>
       </div>
-      <div className="flex flex-wrap items-center gap-3 text-xs text-slate-300">
+      <div className="flex flex-col gap-3 text-xs text-slate-300 md:flex-row md:items-center md:justify-between">
         <div className="flex flex-wrap items-center gap-2">
           {Object.entries(visibleColumns).map(([key, value]) => (
             <label
@@ -46,13 +50,40 @@ export default function AnalyticsToolbar({
             </label>
           ))}
         </div>
-        <button
-          type="button"
-          onClick={onExportCsv}
-          className="rounded-full bg-gradient-to-r from-emerald-400 via-teal-400 to-cyan-400 px-4 py-2 text-xs font-semibold text-slate-950 shadow-lg shadow-emerald-500/30 transition hover:brightness-110"
-        >
-          CSV 다운로드
-        </button>
+        <div className="flex flex-wrap items-center gap-2 text-xs">
+          <span className="rounded-full bg-slate-950/50 px-3 py-1 text-slate-400">
+            선택 {selectedCount}개
+          </span>
+          <button
+            type="button"
+            onClick={onOpenBulkEditor}
+            disabled={!selectedCount}
+            className="rounded-full border border-slate-700/60 px-4 py-2 font-semibold text-slate-200 transition enabled:hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            선택 항목 편집
+          </button>
+          <button
+            type="button"
+            onClick={onOpenHistory}
+            className="rounded-full border border-slate-700/60 px-4 py-2 font-semibold text-slate-200 transition hover:bg-slate-800"
+          >
+            변경 이력
+          </button>
+          <button
+            type="button"
+            onClick={onOpenCsvUpload}
+            className="rounded-full border border-indigo-500/60 px-4 py-2 font-semibold text-indigo-200 transition hover:bg-indigo-500/20"
+          >
+            CSV 업로드
+          </button>
+          <button
+            type="button"
+            onClick={onExportCsv}
+            className="rounded-full bg-gradient-to-r from-emerald-400 via-teal-400 to-cyan-400 px-4 py-2 font-semibold text-slate-950 shadow-lg shadow-emerald-500/30 transition hover:brightness-110"
+          >
+            CSV 다운로드
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/components/admin/modals/AnalyticsCsvUploadModal.jsx
+++ b/components/admin/modals/AnalyticsCsvUploadModal.jsx
@@ -1,0 +1,221 @@
+import { useEffect, useMemo, useState } from 'react';
+import ModalPortal from './ModalPortal';
+
+function parseCsvPreview(text) {
+  if (typeof text !== 'string') {
+    return { rows: [], errors: ['CSV 데이터가 비어 있어요.'] };
+  }
+
+  const lines = text.split(/\r?\n/);
+  if (!lines.length) {
+    return { rows: [], errors: ['CSV 내용이 없습니다.'] };
+  }
+
+  const [headerLine, ...dataLines] = lines;
+  const header = headerLine.split(',').map((value) => value.replace(/^"|"$/g, '').trim().toLowerCase());
+  const slugIndex = header.indexOf('slug');
+  const viewsIndex = header.indexOf('views');
+  const likesIndex = header.indexOf('likes');
+
+  if (slugIndex === -1) {
+    return { rows: [], errors: ['slug 컬럼이 필요합니다.'] };
+  }
+
+  const rows = [];
+  const errors = [];
+
+  dataLines.forEach((line, index) => {
+    if (!line.trim()) return;
+    const cells = [];
+    let current = '';
+    let inQuotes = false;
+    for (let i = 0; i < line.length; i += 1) {
+      const char = line[i];
+      if (char === '"') {
+        if (inQuotes && line[i + 1] === '"') {
+          current += '"';
+          i += 1;
+        } else {
+          inQuotes = !inQuotes;
+        }
+      } else if (char === ',' && !inQuotes) {
+        cells.push(current);
+        current = '';
+      } else {
+        current += char;
+      }
+    }
+    cells.push(current);
+
+    const normalize = (value) => value.replace(/^"|"$/g, '').trim();
+    const slug = normalize(cells[slugIndex] || '');
+    if (!slug) {
+      errors.push(`행 ${index + 2}: slug이 비어 있습니다.`);
+      return;
+    }
+
+    const row = { slug };
+    if (viewsIndex !== -1 && cells.length > viewsIndex) row.views = normalize(cells[viewsIndex]);
+    if (likesIndex !== -1 && cells.length > likesIndex) row.likes = normalize(cells[likesIndex]);
+    rows.push(row);
+  });
+
+  return { rows, errors };
+}
+
+export default function AnalyticsCsvUploadModal({ open, onClose, onUpload }) {
+  const [csvText, setCsvText] = useState('');
+  const [rows, setRows] = useState([]);
+  const [errors, setErrors] = useState([]);
+  const [status, setStatus] = useState('idle');
+  const [serverMessage, setServerMessage] = useState('');
+
+  useEffect(() => {
+    if (!open) {
+      setCsvText('');
+      setRows([]);
+      setErrors([]);
+      setStatus('idle');
+      setServerMessage('');
+    }
+  }, [open]);
+
+  const summary = useMemo(() => {
+    if (!rows.length) return '미리보기 없음';
+    return `${rows.length}개의 행이 준비되었습니다.`;
+  }, [rows.length]);
+
+  const handleFileChange = (event) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const text = typeof reader.result === 'string' ? reader.result : '';
+      const preview = parseCsvPreview(text);
+      setCsvText(text);
+      setRows(preview.rows);
+      setErrors(preview.errors);
+    };
+    reader.readAsText(file, 'utf-8');
+  };
+
+  const handleUpload = async () => {
+    if (!rows.length || typeof onUpload !== 'function') return;
+    try {
+      setStatus('loading');
+      setServerMessage('');
+      const result = await onUpload({ csvText, rows });
+      const updatedCount = Array.isArray(result?.results) ? result.results.length : 0;
+      const skipped = typeof result?.skipped === 'number' ? result.skipped : rows.length - updatedCount;
+      setStatus('success');
+      setServerMessage(`업데이트 완료: ${updatedCount}개 적용, ${Math.max(skipped, 0)}개 건너뜀.`);
+      setTimeout(() => {
+        onClose();
+      }, 900);
+    } catch (error) {
+      console.error('CSV upload failed', error);
+      setStatus('error');
+      setServerMessage(error?.message || '업로드에 실패했어요.');
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <ModalPortal>
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/75 backdrop-blur-sm px-4 py-10">
+        <div className="w-full max-w-2xl rounded-3xl border border-slate-800/70 bg-slate-950/95 shadow-[0_32px_80px_rgba(15,23,42,0.7)]">
+          <div className="flex items-center justify-between border-b border-slate-800/70 px-6 py-4">
+            <div>
+              <h3 className="text-lg font-semibold text-white">CSV 업로드</h3>
+              <p className="text-xs text-slate-400">downloadAnalyticsCsv로 받은 포맷과 동일해야 합니다.</p>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-full border border-slate-700/60 px-3 py-1 text-xs font-semibold text-slate-200 transition hover:bg-slate-800"
+            >
+              닫기
+            </button>
+          </div>
+          <div className="grid gap-4 px-6 py-5">
+            <div>
+              <label className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">CSV 파일 선택</label>
+              <input
+                type="file"
+                accept=".csv,text/csv"
+                onChange={handleFileChange}
+                className="mt-2 w-full rounded-2xl border border-slate-700/60 bg-slate-900/80 px-4 py-2 text-sm text-slate-200"
+              />
+            </div>
+            <div className="rounded-2xl border border-slate-800/70 bg-slate-900/70 px-4 py-3 text-xs text-slate-300">
+              <p className="font-semibold text-slate-200">미리보기</p>
+              <p className="mt-1 text-slate-400">{summary}</p>
+              {errors.length > 0 && (
+                <ul className="mt-2 list-disc space-y-1 pl-4 text-[11px] text-rose-300">
+                  {errors.map((error) => (
+                    <li key={error}>{error}</li>
+                  ))}
+                </ul>
+              )}
+              {rows.length > 0 && (
+                <div className="mt-3 max-h-48 overflow-y-auto rounded-xl border border-slate-800/60">
+                  <table className="min-w-full text-[11px] text-slate-200">
+                    <thead className="bg-slate-900/80 uppercase tracking-[0.2em] text-slate-400">
+                      <tr>
+                        <th className="px-3 py-2 text-left">slug</th>
+                        <th className="px-3 py-2 text-right">views</th>
+                        <th className="px-3 py-2 text-right">likes</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {rows.slice(0, 10).map((row) => (
+                        <tr key={row.slug} className="odd:bg-slate-900/40">
+                          <td className="px-3 py-2 text-left">{row.slug}</td>
+                          <td className="px-3 py-2 text-right">{row.views ?? ''}</td>
+                          <td className="px-3 py-2 text-right">{row.likes ?? ''}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                  {rows.length > 10 && (
+                    <p className="px-3 py-2 text-[10px] text-slate-500">외 {rows.length - 10}개 행…</p>
+                  )}
+                </div>
+              )}
+            </div>
+            {serverMessage && (
+              <div
+                className={`rounded-2xl px-4 py-3 text-xs ${
+                  status === 'error'
+                    ? 'border border-rose-500/40 bg-rose-500/10 text-rose-100'
+                    : 'border border-emerald-500/40 bg-emerald-500/10 text-emerald-100'
+                }`}
+              >
+                {serverMessage}
+              </div>
+            )}
+            <div className="flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-full border border-slate-600/60 px-5 py-2 text-sm font-semibold text-slate-200 transition hover:bg-slate-800"
+              >
+                취소
+              </button>
+              <button
+                type="button"
+                onClick={handleUpload}
+                disabled={!rows.length || errors.length > 0 || status === 'loading'}
+                className="rounded-full bg-gradient-to-r from-emerald-500 via-teal-500 to-cyan-500 px-6 py-2 text-sm font-semibold text-slate-950 shadow-lg shadow-emerald-500/30 transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {status === 'loading' ? '업로드 중…' : '업로드 실행'}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </ModalPortal>
+  );
+}
+

--- a/components/admin/modals/MetricsModal.jsx
+++ b/components/admin/modals/MetricsModal.jsx
@@ -1,9 +1,61 @@
+import { useEffect, useMemo, useState } from 'react';
 import ModalPortal from './ModalPortal';
+
+const numberFormatter = new Intl.NumberFormat('ko-KR');
 
 export default function MetricsModal({ editor, onClose, onChange, onSave }) {
   if (!editor) return null;
   const saving = editor.status === 'saving';
   const success = editor.status === 'success';
+  const isBulk = Boolean(editor.isBulk);
+
+  const [warnings, setWarnings] = useState({ views: '', likes: '' });
+
+  useEffect(() => {
+    setWarnings({ views: '', likes: '' });
+  }, [editor?.slugs?.join(','), editor?.status]);
+
+  const helperText = useMemo(
+    () => ({
+      views:
+        isBulk && editor.placeholders?.views !== null && editor.placeholders?.views !== undefined
+          ? `현재 값: ${numberFormatter.format(editor.placeholders.views)} (모든 항목 동일)`
+          : '숫자만 입력할 수 있어요.',
+      likes:
+        isBulk && editor.placeholders?.likes !== null && editor.placeholders?.likes !== undefined
+          ? `현재 값: ${numberFormatter.format(editor.placeholders.likes)} (모든 항목 동일)`
+          : '숫자만 입력할 수 있어요.',
+    }),
+    [editor.placeholders?.likes, editor.placeholders?.views, isBulk]
+  );
+
+  const handleNumericChange = (field) => (event) => {
+    const raw = event.target.value;
+    const sanitized = raw.replace(/[^0-9]/g, '');
+    let warning = '';
+
+    if (raw && raw !== sanitized) {
+      warning = '숫자 외 문자는 제거되었어요.';
+    }
+
+    if (sanitized) {
+      const num = Number(sanitized);
+      if (!Number.isFinite(num)) {
+        warning = '유효한 숫자를 입력해 주세요.';
+      } else if (num < 0) {
+        warning = '음수 값은 허용되지 않습니다.';
+      } else if (num > 1_000_000_000) {
+        warning = '비정상적으로 큰 값입니다. 다시 확인해 주세요.';
+      }
+    }
+
+    setWarnings((prev) => ({ ...prev, [field]: warning }));
+    onChange(field, sanitized);
+  };
+
+  const selectionPreview = Array.isArray(editor.selectionPreview) ? editor.selectionPreview : [];
+
+  const placeholderText = isBulk ? '공란으로 두면 변경하지 않습니다.' : '숫자 입력';
 
   return (
     <ModalPortal>
@@ -29,29 +81,56 @@ export default function MetricsModal({ editor, onClose, onChange, onSave }) {
               <h3 id="admin-metrics-modal-title" className="text-xl font-semibold text-white sm:text-2xl">
                 {editor.title}
               </h3>
-              <p className="text-[12px] text-slate-500">Slug · {editor.slug}</p>
+              {editor.subtitle && <p className="text-[12px] text-slate-500">{editor.subtitle}</p>}
             </header>
+
+            {isBulk && selectionPreview.length > 0 && (
+              <div className="rounded-2xl border border-slate-700/60 bg-slate-900/60 px-4 py-3 text-xs text-slate-300">
+                <p className="font-semibold text-slate-200">선택된 항목</p>
+                <ul className="mt-2 space-y-1">
+                  {selectionPreview.map((item) => (
+                    <li key={item.slug} className="truncate text-[11px] text-slate-400">
+                      <span className="font-medium text-slate-200">{item.title}</span>
+                      <span className="ml-2 text-slate-500">({item.slug})</span>
+                    </li>
+                  ))}
+                  {editor.slugs.length > selectionPreview.length && (
+                    <li className="text-[11px] text-slate-500">외 {editor.slugs.length - selectionPreview.length}개 항목…</li>
+                  )}
+                </ul>
+              </div>
+            )}
 
             <div className="grid gap-4">
               <div className="space-y-2">
                 <label className="text-xs uppercase tracking-widest text-slate-400">조회수</label>
                 <input
                   value={editor.views}
-                  onChange={(event) => onChange('views', event.target.value)}
-                  placeholder="숫자 입력"
+                  onChange={handleNumericChange('views')}
+                  placeholder={placeholderText}
                   inputMode="numeric"
-                  className="w-full rounded-2xl border border-slate-700/60 bg-slate-900/80 px-4 py-3 text-sm text-white shadow-inner shadow-black/40 transition focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+                  className={`w-full rounded-2xl border bg-slate-900/80 px-4 py-3 text-sm text-white shadow-inner shadow-black/40 transition focus:outline-none focus:ring-2 focus:ring-emerald-500/40 ${
+                    warnings.views ? 'border-rose-500/60 focus:border-rose-400 focus:ring-rose-500/30' : 'border-slate-700/60 focus:border-emerald-400'
+                  }`}
                 />
+                <p className={`text-[11px] ${warnings.views ? 'text-rose-300' : 'text-slate-500'}`}>
+                  {warnings.views || helperText.views}
+                </p>
               </div>
               <div className="space-y-2">
                 <label className="text-xs uppercase tracking-widest text-slate-400">좋아요</label>
                 <input
                   value={editor.likes}
-                  onChange={(event) => onChange('likes', event.target.value)}
-                  placeholder="숫자 입력"
+                  onChange={handleNumericChange('likes')}
+                  placeholder={placeholderText}
                   inputMode="numeric"
-                  className="w-full rounded-2xl border border-slate-700/60 bg-slate-900/80 px-4 py-3 text-sm text-white shadow-inner shadow-black/40 transition focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+                  className={`w-full rounded-2xl border bg-slate-900/80 px-4 py-3 text-sm text-white shadow-inner shadow-black/40 transition focus:outline-none focus:ring-2 focus:ring-emerald-500/40 ${
+                    warnings.likes ? 'border-rose-500/60 focus:border-rose-400 focus:ring-rose-500/30' : 'border-slate-700/60 focus:border-emerald-400'
+                  }`}
                 />
+                <p className={`text-[11px] ${warnings.likes ? 'text-rose-300' : 'text-slate-500'}`}>
+                  {warnings.likes || helperText.likes}
+                </p>
               </div>
             </div>
 

--- a/pages/api/admin/metrics.js
+++ b/pages/api/admin/metrics.js
@@ -1,19 +1,54 @@
 import { assertAdmin } from './_auth';
 
+function resolveActor(req) {
+  const headerActor = typeof req.headers['x-admin-user'] === 'string' ? req.headers['x-admin-user'].trim() : '';
+  const bodyActor = typeof req.body?.actor === 'string' ? req.body.actor.trim() : '';
+  const queryActor = typeof req.query.actor === 'string' ? req.query.actor.trim() : '';
+  return headerActor || bodyActor || queryActor || 'unknown';
+}
+
 export default async function handler(req, res) {
-  if (req.method !== 'POST') return res.status(405).end();
+  if (req.method !== 'POST' && req.method !== 'GET') {
+    return res.status(405).end();
+  }
   if (!assertAdmin(req, res)) return;
 
-  try {
-    const { slug, views, likes } = req.body || {};
-    if (!slug || typeof slug !== 'string') {
-      return res.status(400).json({ error: 'Missing slug' });
+  if (req.method === 'GET') {
+    try {
+      const { limit } = req.query;
+      const querySlugs = [];
+      if (Array.isArray(req.query.slug)) querySlugs.push(...req.query.slug);
+      if (typeof req.query.slug === 'string') querySlugs.push(req.query.slug);
+      if (typeof req.query.slugs === 'string') querySlugs.push(...req.query.slugs.split(','));
+      const slugs = querySlugs.map((slug) => slug.trim()).filter(Boolean);
+      const { listMetricsAudit } = await import('../../../utils/metricsAuditLog');
+      const logs = await listMetricsAudit({ slugs, limit: limit ? Number(limit) : undefined });
+      return res.status(200).json({ logs });
+    } catch (error) {
+      console.error('[admin:metrics] Failed to fetch audit logs', error);
+      return res.status(500).json({ error: 'Failed to load audit log' });
     }
+  }
 
-    const { overwriteMetrics } = await import('../../../utils/metricsStore');
-    const result = await overwriteMetrics(slug.trim(), { views, likes });
-    res.status(200).json({ slug: slug.trim(), ...result });
-  } catch (error) {
-    res.status(500).json({ error: 'Failed to update metrics' });
+  if (req.method === 'POST') {
+    try {
+      const { normalizeMetricUpdates, applyMetricUpdates } = await import('../../../utils/metricsAdminHelpers');
+      const { targets, errors } = normalizeMetricUpdates(req.body || {});
+
+      if (errors.length) {
+        return res.status(400).json({ error: 'Invalid metrics payload', details: errors });
+      }
+
+      if (!targets.length) {
+        return res.status(400).json({ error: '업데이트할 메트릭이 없습니다.' });
+      }
+
+      const actor = resolveActor(req);
+      const { results } = await applyMetricUpdates({ targets, actor });
+      return res.status(200).json({ results });
+    } catch (error) {
+      console.error('[admin:metrics] Failed to update metrics', error);
+      return res.status(500).json({ error: 'Failed to update metrics' });
+    }
   }
 }

--- a/pages/api/admin/metrics/import.js
+++ b/pages/api/admin/metrics/import.js
@@ -1,0 +1,104 @@
+import { assertAdmin } from '../_auth';
+
+function resolveActor(req, body) {
+  const headerActor = typeof req.headers['x-admin-user'] === 'string' ? req.headers['x-admin-user'].trim() : '';
+  const bodyActor = typeof body?.actor === 'string' ? body.actor.trim() : '';
+  const queryActor = typeof req.query.actor === 'string' ? req.query.actor.trim() : '';
+  return headerActor || bodyActor || queryActor || 'unknown';
+}
+
+function parseCsv(csvText) {
+  if (typeof csvText !== 'string') {
+    return { rows: [], errors: [{ code: 'missing_csv', message: 'CSV 데이터가 비어 있어요.' }] };
+  }
+  const lines = csvText
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (!lines.length) {
+    return { rows: [], errors: [{ code: 'empty_csv', message: 'CSV 내용이 없습니다.' }] };
+  }
+
+  const [headerLine, ...dataLines] = lines;
+  const header = headerLine.split(',').map((value) => value.replace(/^"|"$/g, '').trim());
+  const slugIndex = header.findIndex((value) => value.toLowerCase() === 'slug');
+  const viewsIndex = header.findIndex((value) => value.toLowerCase() === 'views');
+  const likesIndex = header.findIndex((value) => value.toLowerCase() === 'likes');
+
+  if (slugIndex === -1) {
+    return { rows: [], errors: [{ code: 'missing_slug_column', message: 'slug 컬럼이 필요합니다.' }] };
+  }
+
+  const rows = [];
+  const errors = [];
+
+  dataLines.forEach((line, index) => {
+    const parts = [];
+    let current = '';
+    let inQuotes = false;
+    for (let i = 0; i < line.length; i += 1) {
+      const char = line[i];
+      if (char === '"') {
+        if (inQuotes && line[i + 1] === '"') {
+          current += '"';
+          i += 1;
+        } else {
+          inQuotes = !inQuotes;
+        }
+      } else if (char === ',' && !inQuotes) {
+        parts.push(current);
+        current = '';
+      } else {
+        current += char;
+      }
+    }
+    parts.push(current);
+
+    const normalize = (value) => value.replace(/^"|"$/g, '').trim();
+    const slug = normalize(parts[slugIndex] || '');
+    if (!slug) {
+      errors.push({ code: 'missing_slug', message: `slug이 비어 있어요. (행 ${index + 2})` });
+      return;
+    }
+
+    const row = { slug };
+    if (viewsIndex !== -1 && parts.length > viewsIndex) row.views = normalize(parts[viewsIndex]);
+    if (likesIndex !== -1 && parts.length > likesIndex) row.likes = normalize(parts[likesIndex]);
+    rows.push(row);
+  });
+
+  return { rows, errors };
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).end();
+  }
+  if (!assertAdmin(req, res)) return;
+
+  try {
+    const body = req.body || {};
+    const { csv } = body;
+    const { rows, errors } = parseCsv(csv);
+
+    if (!rows.length) {
+      return res.status(400).json({ error: '처리할 행이 없습니다.', details: errors });
+    }
+
+    const { normalizeMetricUpdates, applyMetricUpdates } = await import('../../../../utils/metricsAdminHelpers');
+    const { targets, errors: payloadErrors } = normalizeMetricUpdates({ updates: rows });
+
+    const combinedErrors = [...errors, ...payloadErrors];
+    if (!targets.length) {
+      return res.status(400).json({ error: '유효한 업데이트가 없습니다.', details: combinedErrors });
+    }
+
+    const actor = resolveActor(req, body);
+    const { results } = await applyMetricUpdates({ targets, actor });
+    return res.status(200).json({ results, skipped: rows.length - results.length, errors: combinedErrors });
+  } catch (error) {
+    console.error('[admin:metrics:import] Failed to process CSV', error);
+    return res.status(500).json({ error: 'CSV 업로드 처리에 실패했어요.' });
+  }
+}
+

--- a/utils/metricsAdminHelpers.js
+++ b/utils/metricsAdminHelpers.js
@@ -1,0 +1,128 @@
+import { getMetrics, overwriteMetrics } from './metricsStore';
+import { recordMetricsAudit } from './metricsAuditLog';
+
+function parseMetricNumber(raw) {
+  if (raw === null || raw === undefined) {
+    return { provided: false, value: null };
+  }
+  if (typeof raw === 'string' && raw.trim() === '') {
+    return { provided: false, value: null };
+  }
+
+  const num = Number(raw);
+  if (!Number.isFinite(num)) {
+    return {
+      provided: true,
+      error: { code: 'not_a_number', message: '유효한 숫자가 아니에요.' },
+    };
+  }
+
+  if (num < 0) {
+    return {
+      provided: true,
+      error: { code: 'negative', message: '음수 값은 허용되지 않습니다.' },
+    };
+  }
+
+  const value = Math.max(0, Math.round(num));
+  return { provided: true, value };
+}
+
+function normalizeSlug(value) {
+  if (typeof value !== 'string') return '';
+  return value.trim();
+}
+
+export function normalizeMetricUpdates(payload = {}) {
+  const targets = [];
+  const errors = [];
+
+  const pushTarget = (slugValue, metricsSource = {}) => {
+    const slug = normalizeSlug(slugValue);
+    if (!slug) {
+      errors.push({ code: 'missing_slug', message: 'slug이 비어 있어요.' });
+      return;
+    }
+
+    const viewsResult = parseMetricNumber(metricsSource.views);
+    const likesResult = parseMetricNumber(metricsSource.likes);
+
+    if (viewsResult.error) {
+      errors.push({ code: viewsResult.error.code, message: viewsResult.error.message, slug, field: 'views' });
+      return;
+    }
+
+    if (likesResult.error) {
+      errors.push({ code: likesResult.error.code, message: likesResult.error.message, slug, field: 'likes' });
+      return;
+    }
+
+    const provided = { views: viewsResult.provided, likes: likesResult.provided };
+    if (!provided.views && !provided.likes) {
+      // Nothing to update for this slug.
+      return;
+    }
+
+    const metrics = {};
+    if (provided.views) metrics.views = viewsResult.value;
+    if (provided.likes) metrics.likes = likesResult.value;
+
+    targets.push({ slug, metrics, provided });
+  };
+
+  if (Array.isArray(payload.updates) && payload.updates.length) {
+    payload.updates.forEach((update) => {
+      if (!update || typeof update !== 'object') return;
+      pushTarget(update.slug, update);
+    });
+  } else {
+    const slugList = [];
+    if (typeof payload.slug === 'string') slugList.push(payload.slug);
+    if (Array.isArray(payload.slugs)) slugList.push(...payload.slugs);
+    const uniqueSlugs = Array.from(new Set(slugList.map(normalizeSlug).filter(Boolean)));
+    uniqueSlugs.forEach((slug) => {
+      pushTarget(slug, { views: payload.views, likes: payload.likes });
+    });
+  }
+
+  return { targets, errors };
+}
+
+export async function applyMetricUpdates({ targets = [], actor = 'unknown' }) {
+  if (!Array.isArray(targets) || !targets.length) {
+    return { results: [], auditEntries: [] };
+  }
+
+  const results = [];
+  const auditEntries = [];
+
+  for (const target of targets) {
+    if (!target || typeof target !== 'object') continue;
+    const slug = normalizeSlug(target.slug);
+    if (!slug) continue;
+
+    const payload = {};
+    if (target.provided?.views) payload.views = target.metrics.views;
+    if (target.provided?.likes) payload.likes = target.metrics.likes;
+    if (!Object.keys(payload).length) continue;
+
+    const before = await getMetrics(slug);
+    const next = await overwriteMetrics(slug, payload);
+
+    results.push({ slug, views: next.views ?? 0, likes: next.likes ?? 0 });
+    auditEntries.push({
+      slug,
+      changedBy: actor,
+      changedAt: new Date().toISOString(),
+      before: { views: before.views ?? 0, likes: before.likes ?? 0 },
+      after: { views: next.views ?? 0, likes: next.likes ?? 0 },
+    });
+  }
+
+  if (auditEntries.length) {
+    await recordMetricsAudit(auditEntries);
+  }
+
+  return { results, auditEntries };
+}
+

--- a/utils/metricsAuditLog.js
+++ b/utils/metricsAuditLog.js
@@ -1,0 +1,174 @@
+const AUDIT_GLOBAL_KEY = 'metrics:audit-log';
+const AUDIT_BLOB_KEY = 'metrics/audit-log.json';
+const AUDIT_MAX_ENTRIES = 500;
+
+function toNumber(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return 0;
+  return Math.max(0, Math.round(num));
+}
+
+function sanitizeEntry(entry) {
+  if (!entry || typeof entry !== 'object') return null;
+  const slug = typeof entry.slug === 'string' ? entry.slug.trim() : '';
+  if (!slug) return null;
+  const changedAt = typeof entry.changedAt === 'string' ? entry.changedAt : new Date().toISOString();
+  const changedBy = typeof entry.changedBy === 'string' && entry.changedBy.trim() ? entry.changedBy.trim() : 'unknown';
+  const before = {
+    views: toNumber(entry.before?.views),
+    likes: toNumber(entry.before?.likes),
+  };
+  const after = {
+    views: toNumber(entry.after?.views),
+    likes: toNumber(entry.after?.likes),
+  };
+  const id =
+    typeof entry.id === 'string' && entry.id.trim()
+      ? entry.id.trim()
+      : `${slug}:${Date.now()}:${Math.random().toString(16).slice(2, 10)}`;
+  return {
+    id,
+    slug,
+    changedAt,
+    changedBy,
+    before,
+    after,
+  };
+}
+
+function ensureMemoryStore() {
+  if (!global.__metricsAuditLog) {
+    global.__metricsAuditLog = {
+      entries: [],
+    };
+  }
+  return global.__metricsAuditLog;
+}
+
+async function hasUpstash() {
+  const { hasUpstash } = await import('./redisClient');
+  return hasUpstash();
+}
+
+async function memoryRecord(entries) {
+  const store = ensureMemoryStore();
+  entries.forEach((entry) => {
+    store.entries.unshift(entry);
+  });
+  if (store.entries.length > AUDIT_MAX_ENTRIES) {
+    store.entries.length = AUDIT_MAX_ENTRIES;
+  }
+}
+
+async function memoryList({ slugs, limit }) {
+  const store = ensureMemoryStore();
+  const filtered = filterEntries(store.entries, slugs);
+  return filtered.slice(0, limit || AUDIT_MAX_ENTRIES);
+}
+
+async function blobLoadAll(blobClient) {
+  try {
+    const { list } = blobClient;
+    const { blobs } = await list({ prefix: AUDIT_BLOB_KEY });
+    const found = blobs.find((blob) => blob.pathname === AUDIT_BLOB_KEY);
+    if (!found) return [];
+    const res = await fetch(found.url);
+    if (!res.ok) return [];
+    const json = await res.json();
+    if (!json || !Array.isArray(json.entries)) return [];
+    return json.entries
+      .map((entry) => sanitizeEntry(entry))
+      .filter(Boolean);
+  } catch (error) {
+    console.warn('[metrics:audit] Failed to load blob audit log', error);
+    return [];
+  }
+}
+
+async function blobRecord(entries) {
+  const { loadBlob } = await import('./dynamicBlob');
+  const client = await loadBlob();
+  const existing = await blobLoadAll(client);
+  const nextEntries = [...entries, ...existing].slice(0, AUDIT_MAX_ENTRIES);
+  const payload = JSON.stringify({ entries: nextEntries });
+  await client.put(AUDIT_BLOB_KEY, payload, {
+    token: process.env.BLOB_READ_WRITE_TOKEN,
+    contentType: 'application/json',
+    access: 'private',
+  });
+}
+
+async function blobList({ slugs, limit }) {
+  const { loadBlob } = await import('./dynamicBlob');
+  const client = await loadBlob();
+  const entries = await blobLoadAll(client);
+  const filtered = filterEntries(entries, slugs);
+  return filtered.slice(0, limit || AUDIT_MAX_ENTRIES);
+}
+
+function filterEntries(entries, slugs) {
+  if (!Array.isArray(entries)) return [];
+  if (!slugs || !slugs.length) return [...entries];
+  const slugSet = new Set(slugs.map((slug) => slug.trim()).filter(Boolean));
+  return entries.filter((entry) => slugSet.has(entry.slug));
+}
+
+async function redisRecord(entries) {
+  const { redisCommand } = await import('./redisClient');
+  for (const entry of entries) {
+    const payload = JSON.stringify(entry);
+    await redisCommand(['LPUSH', AUDIT_GLOBAL_KEY, payload]);
+  }
+  await redisCommand(['LTRIM', AUDIT_GLOBAL_KEY, 0, AUDIT_MAX_ENTRIES - 1]);
+}
+
+async function redisList({ slugs, limit }) {
+  const { redisCommand } = await import('./redisClient');
+  const rangeEnd = Math.max((limit || AUDIT_MAX_ENTRIES) * 4 - 1, AUDIT_MAX_ENTRIES - 1);
+  const rawEntries = await redisCommand(['LRANGE', AUDIT_GLOBAL_KEY, 0, rangeEnd]);
+  const parsed = (rawEntries || [])
+    .map((value) => {
+      try {
+        return sanitizeEntry(JSON.parse(value));
+      } catch (error) {
+        return null;
+      }
+    })
+    .filter(Boolean);
+  const filtered = filterEntries(parsed, slugs);
+  return filtered.slice(0, limit || AUDIT_MAX_ENTRIES);
+}
+
+export async function recordMetricsAudit(entries) {
+  if (!Array.isArray(entries) || !entries.length) return;
+  const sanitized = entries.map(sanitizeEntry).filter(Boolean);
+  if (!sanitized.length) return;
+
+  if (await hasUpstash()) {
+    await redisRecord(sanitized);
+    return;
+  }
+
+  if (process.env.BLOB_READ_WRITE_TOKEN) {
+    await blobRecord(sanitized);
+    return;
+  }
+
+  await memoryRecord(sanitized);
+}
+
+export async function listMetricsAudit({ slugs = [], limit = 50 } = {}) {
+  const normalizedLimit = Number(limit);
+  const safeLimit = Number.isFinite(normalizedLimit) && normalizedLimit > 0 ? Math.min(normalizedLimit, AUDIT_MAX_ENTRIES) : 50;
+
+  if (await hasUpstash()) {
+    return redisList({ slugs, limit: safeLimit });
+  }
+
+  if (process.env.BLOB_READ_WRITE_TOKEN) {
+    return blobList({ slugs, limit: safeLimit });
+  }
+
+  return memoryList({ slugs, limit: safeLimit });
+}
+


### PR DESCRIPTION
## 요약
- Analytics 테이블에 다중 선택, 일괄 편집, 변경 이력 패널, CSV 업로드 UI를 추가했습니다.
- metrics API를 다중 슬러그 및 감사 로그 저장을 지원하도록 확장하고 CSV 업로드 전용 엔드포인트를 구현했습니다.
- 메트릭 모달에 실시간 검증 메시지와 숫자 입력 제한을 도입하고 관련 훅과 유틸리티를 개선했습니다.

## 테스트
- `npm run lint` *(프로젝트 전반의 React in scope 규칙 등 기존 규칙 충돌로 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a826d6a08323a7be20d6b6d165ef