### PR TITLE
fix: admin analytics 빌드 오류 수정

### DIFF
--- a/pages/admin.js
+++ b/pages/admin.js
@@ -108,6 +108,22 @@ export default function AdminPage() {
   const [isHistoryOpen, setHistoryOpen] = useState(false);
   const [isCsvModalOpen, setCsvModalOpen] = useState(false);
 
+  const [analyticsStartDate, setAnalyticsStartDate] = useState('');
+  const [analyticsEndDate, setAnalyticsEndDate] = useState('');
+
+  const analyticsInitialFilters = useMemo(
+    () => ({ type: '', orientation: '', query: '' }),
+    []
+  );
+
+  const analytics = useAnalyticsMetrics({
+    items,
+    enabled: hasToken && view === 'analytics',
+    initialFilters: analyticsInitialFilters,
+    startDate: analyticsStartDate,
+    endDate: analyticsEndDate,
+  });
+
   const fetchHistory = useCallback(
     async (options = {}) => {
       if (!hasToken) return;
@@ -140,20 +156,6 @@ export default function AdminPage() {
       }
     },
     [analytics.selectedSlugs, hasToken, token]
-  );
-  const [analyticsStartDate, setAnalyticsStartDate] = useState('');
-  const [analyticsEndDate, setAnalyticsEndDate] = useState('');
-
-  const analytics = useAnalyticsMetrics({
-    items,
-    enabled: hasToken && view === 'analytics',
-    initialFilters: analyticsInitialFilters,
-    startDate: analyticsStartDate,
-    endDate: analyticsEndDate,
-  });
-  const analyticsInitialFilters = useMemo(
-    () => ({ type: '', orientation: '', query: '' }),
-    []
   );
 
   const defaultAdsterraRange = useMemo(() => getDefaultAdsterraDateRange(), []);


### PR DESCRIPTION
## 개요
- analytics 메트릭 훅의 중복 변수와 누락된 상수를 정리하고 초기 필터 처리 로직을 안정화했습니다.
- 메트릭 업데이트 로직을 보완해 API 응답을 안전하게 병합하도록 했습니다.
- admin 페이지에서 초기 필터 정의와 히스토리 조회 훅 순서를 조정해 빌드 시 참조 오류를 방지했습니다.

## 테스트
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d6b61a9b548323bc2c087a0edc652c