### PR TITLE
feat: 내부 이벤트 분석 및 광고 인사이트 통합

### DIFF
--- a/components/admin/events/EventFilters.jsx
+++ b/components/admin/events/EventFilters.jsx
@@ -1,0 +1,87 @@
+export default function EventFilters({
+  startDate,
+  endDate,
+  onDateChange,
+  filters,
+  onFilterChange,
+  catalog,
+  loading,
+  onRefresh,
+}) {
+  const events = Array.isArray(catalog?.events) ? catalog.events : [];
+  const slugsByEvent = catalog?.slugsByEvent && typeof catalog.slugsByEvent === 'object' ? catalog.slugsByEvent : {};
+  const eventValue = filters?.eventName || '';
+  const slugOptions = Array.isArray(slugsByEvent[eventValue]) ? slugsByEvent[eventValue] : [];
+  const slugValue = filters?.slug || '';
+
+  return (
+    <div className="flex flex-col gap-4 rounded-2xl bg-slate-900/70 p-4 ring-1 ring-slate-800/60">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <label className="flex flex-col gap-1 text-xs text-slate-300">
+          <span className="font-semibold uppercase tracking-[0.3em] text-slate-400">시작일</span>
+          <input
+            type="date"
+            value={startDate || ''}
+            onChange={(event) => onDateChange?.('start', event.target.value)}
+            className="rounded-lg border border-slate-700/60 bg-slate-950/70 px-3 py-2 text-sm text-white focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400/60"
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-xs text-slate-300">
+          <span className="font-semibold uppercase tracking-[0.3em] text-slate-400">종료일</span>
+          <input
+            type="date"
+            value={endDate || ''}
+            onChange={(event) => onDateChange?.('end', event.target.value)}
+            className="rounded-lg border border-slate-700/60 bg-slate-950/70 px-3 py-2 text-sm text-white focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400/60"
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-xs text-slate-300">
+          <span className="font-semibold uppercase tracking-[0.3em] text-slate-400">이벤트명</span>
+          <select
+            value={eventValue}
+            onChange={(event) => onFilterChange?.({ eventName: event.target.value, slug: '' })}
+            className="rounded-lg border border-slate-700/60 bg-slate-950/70 px-3 py-2 text-sm text-white focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400/60"
+          >
+            <option value="">전체</option>
+            {events.map((eventName) => (
+              <option key={eventName} value={eventName}>
+                {eventName}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1 text-xs text-slate-300">
+          <span className="font-semibold uppercase tracking-[0.3em] text-slate-400">슬러그</span>
+          <select
+            value={slugValue}
+            onChange={(event) => onFilterChange?.({ slug: event.target.value })}
+            className="rounded-lg border border-slate-700/60 bg-slate-950/70 px-3 py-2 text-sm text-white focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400/60"
+            disabled={!eventValue}
+          >
+            <option value="">전체</option>
+            {slugOptions.map((slug) => (
+              <option key={slug} value={slug}>
+                {slug}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-slate-300">
+        <div className="flex items-center gap-2">
+          <span className="rounded-full bg-slate-950/60 px-3 py-1 text-slate-400">
+            {eventValue ? `${eventValue}${slugValue ? ` · ${slugValue}` : ''}` : '전체 이벤트'}
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={() => onRefresh?.()}
+          disabled={loading}
+          className="rounded-full bg-gradient-to-r from-sky-500 via-indigo-500 to-purple-500 px-4 py-2 text-xs font-semibold text-white shadow-lg shadow-sky-500/30 transition enabled:hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {loading ? '갱신 중…' : '데이터 새로고침'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/admin/events/EventSummaryCards.jsx
+++ b/components/admin/events/EventSummaryCards.jsx
@@ -1,0 +1,25 @@
+export default function EventSummaryCards({ totals, formatNumber }) {
+  const totalCount = Number(totals?.count) || 0;
+  const uniqueSessions = Number(totals?.uniqueSessions) || 0;
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <div className="rounded-2xl border border-slate-800/70 bg-slate-900/80 p-4 shadow-inner shadow-black/40">
+        <p className="text-xs uppercase tracking-[0.3em] text-slate-400">총 이벤트 수</p>
+        <p className="mt-2 text-3xl font-bold text-white">{formatNumber(totalCount)}</p>
+        <p className="mt-1 text-xs text-slate-500">선택한 기간 동안 수집된 이벤트 합계</p>
+      </div>
+      <div className="rounded-2xl border border-slate-800/70 bg-slate-900/80 p-4 shadow-inner shadow-black/40">
+        <p className="text-xs uppercase tracking-[0.3em] text-slate-400">고유 세션</p>
+        <p className="mt-2 text-3xl font-bold text-white">{formatNumber(uniqueSessions)}</p>
+        <p className="mt-1 text-xs text-slate-500">동일 기간 내 이벤트를 발생시킨 고유 세션 수</p>
+      </div>
+      <div className="rounded-2xl border border-emerald-500/40 bg-gradient-to-br from-emerald-500/10 via-teal-500/5 to-transparent p-4 shadow-lg shadow-emerald-500/20">
+        <p className="text-xs uppercase tracking-[0.3em] text-emerald-200">평균 이벤트 수/세션</p>
+        <p className="mt-2 text-3xl font-bold text-emerald-100">
+          {uniqueSessions > 0 ? (totalCount / uniqueSessions).toFixed(2) : '0.00'}
+        </p>
+        <p className="mt-1 text-xs text-emerald-200/80">고유 세션 대비 이벤트 발생량</p>
+      </div>
+    </div>
+  );
+}

--- a/components/admin/events/EventTable.jsx
+++ b/components/admin/events/EventTable.jsx
@@ -1,0 +1,68 @@
+function formatDateTime(value) {
+  if (!value) return '-';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '-';
+  return `${date.toISOString().slice(0, 10)} ${date.toISOString().slice(11, 19)}`;
+}
+
+export default function EventTable({ rows, loading, error, formatNumber }) {
+  const safeRows = Array.isArray(rows) ? rows : [];
+
+  return (
+    <div className="overflow-hidden rounded-2xl border border-slate-800/60 bg-slate-950/40">
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-slate-800/60 text-sm">
+          <thead className="bg-slate-900/80 text-xs uppercase tracking-[0.2em] text-slate-400">
+            <tr>
+              <th scope="col" className="px-4 py-3 text-left">이벤트명</th>
+              <th scope="col" className="px-4 py-3 text-left">슬러그</th>
+              <th scope="col" className="px-4 py-3 text-right">총 발생 수</th>
+              <th scope="col" className="px-4 py-3 text-right">고유 세션</th>
+              <th scope="col" className="px-4 py-3 text-right">평균/세션</th>
+              <th scope="col" className="px-4 py-3 text-right">마지막 발생</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-800/40 bg-slate-950/20 text-slate-200">
+            {loading && (
+              <tr>
+                <td colSpan={6} className="px-4 py-6 text-center text-xs text-slate-400">
+                  이벤트 데이터를 불러오는 중이에요…
+                </td>
+              </tr>
+            )}
+            {!loading && error && (
+              <tr>
+                <td colSpan={6} className="px-4 py-6 text-center text-xs text-rose-300">
+                  {error}
+                </td>
+              </tr>
+            )}
+            {!loading && !error && !safeRows.length && (
+              <tr>
+                <td colSpan={6} className="px-4 py-6 text-center text-xs text-slate-400">
+                  조건에 맞는 이벤트가 없어요. 기간이나 필터를 조정해 보세요.
+                </td>
+              </tr>
+            )}
+            {!loading && !error &&
+              safeRows.map((row) => {
+                const count = Number(row?.count) || 0;
+                const unique = Number(row?.uniqueSessions) || 0;
+                const avg = unique > 0 ? count / unique : 0;
+                return (
+                  <tr key={`${row.eventName || 'unknown'}::${row.slug || 'all'}`} className="hover:bg-slate-900/50">
+                    <td className="px-4 py-3 font-semibold text-white">{row.eventName}</td>
+                    <td className="px-4 py-3 text-slate-400">{row.slug || '-'}</td>
+                    <td className="px-4 py-3 text-right font-semibold text-slate-100">{formatNumber(count)}</td>
+                    <td className="px-4 py-3 text-right text-slate-200">{formatNumber(unique)}</td>
+                    <td className="px-4 py-3 text-right text-slate-200">{avg.toFixed(2)}</td>
+                    <td className="px-4 py-3 text-right text-slate-300">{formatDateTime(row.lastTimestamp || row.lastDate)}</td>
+                  </tr>
+                );
+              })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/components/admin/events/EventTrendChart.jsx
+++ b/components/admin/events/EventTrendChart.jsx
@@ -1,0 +1,96 @@
+import { useMemo } from 'react';
+
+function buildPoints(series, width, height, padding) {
+  if (!Array.isArray(series) || !series.length) return '';
+  const max = Math.max(...series.map((entry) => Number(entry.count) || 0), 0);
+  if (max <= 0) {
+    return series
+      .map((_, index) => {
+        const x = padding + (index / Math.max(series.length - 1, 1)) * (width - padding * 2);
+        const y = height - padding;
+        return `${x},${y}`;
+      })
+      .join(' ');
+  }
+  return series
+    .map((entry, index) => {
+      const value = Math.max(0, Number(entry.count) || 0);
+      const x = padding + (index / Math.max(series.length - 1, 1)) * (width - padding * 2);
+      const y = padding + (1 - value / max) * (height - padding * 2);
+      return `${x},${y}`;
+    })
+    .join(' ');
+}
+
+export default function EventTrendChart({ series, formatNumber }) {
+  const sanitized = useMemo(() => {
+    if (!Array.isArray(series)) return [];
+    return series
+      .map((entry) => ({
+        date: entry?.date || '',
+        count: Number(entry?.count) || 0,
+      }))
+      .filter((entry) => Boolean(entry.date));
+  }, [series]);
+
+  if (!sanitized.length) {
+    return null;
+  }
+
+  const width = 720;
+  const height = 240;
+  const padding = 32;
+  const points = buildPoints(sanitized, width, height, padding);
+  const maxValue = Math.max(...sanitized.map((entry) => entry.count), 0);
+
+  return (
+    <div className="rounded-2xl border border-slate-800/70 bg-slate-900/80 p-4 shadow-inner shadow-black/40">
+      <div className="mb-4 flex items-center justify-between text-xs uppercase tracking-[0.3em] text-slate-400">
+        <span>기간별 이벤트 추이</span>
+        <span className="text-[11px] text-slate-300">최대 {formatNumber(maxValue)}건</span>
+      </div>
+      <svg viewBox={`0 0 ${width} ${height}`} className="w-full">
+        <defs>
+          <linearGradient id="eventTrend" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stopColor="rgba(129, 140, 248, 0.6)" />
+            <stop offset="100%" stopColor="rgba(129, 140, 248, 0)" />
+          </linearGradient>
+        </defs>
+        <rect
+          x={padding}
+          y={padding}
+          width={width - padding * 2}
+          height={height - padding * 2}
+          fill="transparent"
+          stroke="rgba(148, 163, 184, 0.25)"
+          strokeDasharray="4 4"
+        />
+        {points && (
+          <>
+            <polyline
+              points={points}
+              fill="none"
+              stroke="rgb(129, 140, 248)"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <polygon
+              points={`${points} ${padding + (width - padding * 2)},${height - padding} ${padding},${height - padding}`}
+              fill="url(#eventTrend)"
+              opacity="0.4"
+            />
+          </>
+        )}
+      </svg>
+      <div className="mt-4 grid grid-cols-2 gap-2 text-[11px] text-slate-400 sm:grid-cols-4">
+        {sanitized.map((entry) => (
+          <div key={entry.date} className="rounded-lg bg-slate-950/40 px-3 py-2">
+            <p className="font-semibold text-slate-200">{entry.date}</p>
+            <p className="text-[10px] text-slate-400">{formatNumber(entry.count)}회</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/admin/insights/EventAdCorrelation.jsx
+++ b/components/admin/insights/EventAdCorrelation.jsx
@@ -1,0 +1,128 @@
+import { useMemo } from 'react';
+
+function normalizeSeries(series) {
+  if (!Array.isArray(series)) return [];
+  return series
+    .map((entry) => ({
+      date: entry?.date || '',
+      count: Number(entry?.count) || 0,
+      impressions: Number(entry?.impressions) || 0,
+      clicks: Number(entry?.clicks) || 0,
+      revenue: Number(entry?.revenue) || 0,
+    }))
+    .filter((entry) => Boolean(entry.date));
+}
+
+function pearsonCorrelation(pairs) {
+  if (!pairs.length) return 0;
+  const n = pairs.length;
+  const sumX = pairs.reduce((acc, pair) => acc + pair.x, 0);
+  const sumY = pairs.reduce((acc, pair) => acc + pair.y, 0);
+  const sumXY = pairs.reduce((acc, pair) => acc + pair.x * pair.y, 0);
+  const sumX2 = pairs.reduce((acc, pair) => acc + pair.x * pair.x, 0);
+  const sumY2 = pairs.reduce((acc, pair) => acc + pair.y * pair.y, 0);
+  const numerator = n * sumXY - sumX * sumY;
+  const denominator = Math.sqrt((n * sumX2 - sumX * sumX) * (n * sumY2 - sumY * sumY));
+  if (!Number.isFinite(denominator) || denominator === 0) return 0;
+  const value = numerator / denominator;
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(-1, Math.min(1, value));
+}
+
+function combineSeries(eventSeries, adSeries) {
+  const eventMap = new Map();
+  eventSeries.forEach((entry) => {
+    eventMap.set(entry.date, { eventCount: entry.count, valueSum: Number(entry.valueSum) || 0 });
+  });
+  const adMap = new Map();
+  adSeries.forEach((entry) => {
+    adMap.set(entry.date, {
+      impressions: entry.impressions,
+      clicks: entry.clicks,
+      revenue: entry.revenue,
+    });
+  });
+  const dates = new Set([...eventMap.keys(), ...adMap.keys()]);
+  return Array.from(dates)
+    .sort((a, b) => a.localeCompare(b))
+    .map((date) => {
+      const eventInfo = eventMap.get(date) || { eventCount: 0, valueSum: 0 };
+      const adInfo = adMap.get(date) || { impressions: 0, clicks: 0, revenue: 0 };
+      return {
+        date,
+        eventCount: eventInfo.eventCount,
+        valueSum: eventInfo.valueSum,
+        impressions: adInfo.impressions,
+        clicks: adInfo.clicks,
+        revenue: adInfo.revenue,
+      };
+    });
+}
+
+export default function EventAdCorrelation({ eventSeries, adSeries, formatNumber, formatDecimal }) {
+  const normalizedEvents = useMemo(() => normalizeSeries(eventSeries), [eventSeries]);
+  const normalizedAds = useMemo(() => normalizeSeries(adSeries), [adSeries]);
+
+  const combined = useMemo(() => combineSeries(normalizedEvents, normalizedAds), [normalizedAds, normalizedEvents]);
+
+  const revenueCorrelation = useMemo(() => {
+    const pairs = combined
+      .filter((row) => row.eventCount > 0 && row.revenue > 0)
+      .map((row) => ({ x: row.eventCount, y: row.revenue }));
+    return pearsonCorrelation(pairs);
+  }, [combined]);
+
+  const clickCorrelation = useMemo(() => {
+    const pairs = combined
+      .filter((row) => row.eventCount > 0 && row.clicks > 0)
+      .map((row) => ({ x: row.eventCount, y: row.clicks }));
+    return pearsonCorrelation(pairs);
+  }, [combined]);
+
+  if (!combined.length) {
+    return (
+      <div className="rounded-2xl border border-slate-800/60 bg-slate-900/70 p-6 text-sm text-slate-400">
+        기간 내 광고 데이터와 이벤트 데이터를 모두 불러오면 상관관계를 분석할 수 있어요.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 rounded-2xl border border-slate-800/60 bg-slate-900/70 p-6 shadow-inner shadow-black/30">
+      <div className="flex flex-col gap-2 text-sm text-slate-200 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-[0.3em] text-slate-400">이벤트-광고 상관분석</p>
+          <p className="text-lg font-semibold text-white">일자별 이벤트 수와 광고 지표 비교</p>
+        </div>
+        <div className="flex gap-3 text-xs text-slate-300">
+          <span className="rounded-full bg-slate-950/60 px-3 py-1">수익 상관계수 {formatDecimal(revenueCorrelation, 3)}</span>
+          <span className="rounded-full bg-slate-950/60 px-3 py-1">클릭 상관계수 {formatDecimal(clickCorrelation, 3)}</span>
+        </div>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-slate-800/60 text-xs">
+          <thead className="bg-slate-900/60 uppercase tracking-[0.2em] text-slate-400">
+            <tr>
+              <th className="px-3 py-2 text-left">날짜</th>
+              <th className="px-3 py-2 text-right">이벤트 수</th>
+              <th className="px-3 py-2 text-right">광고 노출</th>
+              <th className="px-3 py-2 text-right">광고 클릭</th>
+              <th className="px-3 py-2 text-right">광고 수익</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-800/40 text-slate-200">
+            {combined.map((row) => (
+              <tr key={row.date} className="hover:bg-slate-900/50">
+                <td className="px-3 py-2 font-semibold text-white">{row.date}</td>
+                <td className="px-3 py-2 text-right">{formatNumber(row.eventCount)}</td>
+                <td className="px-3 py-2 text-right">{formatNumber(row.impressions)}</td>
+                <td className="px-3 py-2 text-right">{formatNumber(row.clicks)}</td>
+                <td className="px-3 py-2 text-right">{formatDecimal(row.revenue, 3)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/hooks/admin/useEventAnalytics.js
+++ b/hooks/admin/useEventAnalytics.js
@@ -1,0 +1,87 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+const EMPTY_SUMMARY = Object.freeze({
+  items: [],
+  totals: { count: 0, uniqueSessions: 0 },
+  timeseries: [],
+  catalog: { events: [], slugsByEvent: {} },
+});
+
+function sanitizeFilters(filters = {}) {
+  return {
+    eventName: typeof filters.eventName === 'string' ? filters.eventName.trim() : '',
+    slug: typeof filters.slug === 'string' ? filters.slug.trim() : '',
+    limit: typeof filters.limit === 'number' ? filters.limit : undefined,
+  };
+}
+
+export default function useEventAnalytics({
+  enabled,
+  token,
+  startDate,
+  endDate,
+  filters = {},
+}) {
+  const [data, setData] = useState(EMPTY_SUMMARY);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [version, setVersion] = useState(0);
+
+  const normalizedFilters = useMemo(() => sanitizeFilters(filters), [filters]);
+
+  const refresh = useCallback(() => {
+    setVersion((prev) => prev + 1);
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return undefined;
+
+    const controller = new AbortController();
+    const run = async () => {
+      setLoading(true);
+      setError('');
+      try {
+        const params = new URLSearchParams();
+        if (token) params.set('token', token);
+        if (startDate) params.set('start', startDate);
+        if (endDate) params.set('end', endDate);
+        if (normalizedFilters.eventName) params.set('event', normalizedFilters.eventName);
+        if (normalizedFilters.slug) params.set('slug', normalizedFilters.slug);
+        if (normalizedFilters.limit) params.set('limit', String(normalizedFilters.limit));
+
+        const res = await fetch(`/api/admin/events/summary?${params.toString()}`, {
+          signal: controller.signal,
+        });
+        const json = await res.json().catch(() => ({}));
+        if (!res.ok) {
+          throw new Error(json?.error || '이벤트 데이터를 불러오지 못했어요.');
+        }
+        setData({
+          items: Array.isArray(json.items) ? json.items : [],
+          totals: json.totals || { count: 0, uniqueSessions: 0 },
+          timeseries: Array.isArray(json.timeseries) ? json.timeseries : [],
+          catalog: json.catalog || { events: [], slugsByEvent: {} },
+        });
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        setError(err?.message || '이벤트 데이터를 불러오지 못했어요.');
+        setData(EMPTY_SUMMARY);
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    run();
+    return () => controller.abort();
+  }, [enabled, endDate, normalizedFilters.eventName, normalizedFilters.limit, normalizedFilters.slug, startDate, token, version]);
+
+  return {
+    data,
+    loading,
+    error,
+    refresh,
+    setError,
+  };
+}

--- a/lib/va.js
+++ b/lib/va.js
@@ -1,6 +1,171 @@
 // Vercel Analytics helper (safe wrapper)
 import { track } from '@vercel/analytics';
 
+const INTERNAL_ENDPOINT = '/api/events/log';
+const INTERNAL_BATCH_SIZE = 12;
+const INTERNAL_FLUSH_MS = 2000;
+const INTERNAL_MAX_QUEUE = 120;
+
+function getInternalState() {
+  if (typeof window === 'undefined') return null;
+  if (!window.__vaInternal) {
+    window.__vaInternal = {
+      queue: [],
+      timer: null,
+      pending: false,
+    };
+  }
+  return window.__vaInternal;
+}
+
+function ensureSessionId() {
+  if (typeof window === 'undefined') return '';
+  try {
+    const storage = window.sessionStorage || window.localStorage;
+    if (!storage) throw new Error('no storage');
+    const key = 'va:eventSessionId';
+    let sessionId = storage.getItem(key);
+    if (!sessionId) {
+      const generator =
+        (globalThis.crypto && typeof globalThis.crypto.randomUUID === 'function')
+          ? globalThis.crypto.randomUUID()
+          : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+      sessionId = generator.replace(/[^a-zA-Z0-9-]/g, '').slice(0, 36);
+      storage.setItem(key, sessionId);
+    }
+    return sessionId;
+  } catch (error) {
+    console.warn('[events] failed to persist session id', error);
+    return '';
+  }
+}
+
+function sanitizeProps(props) {
+  if (!props || typeof props !== 'object') return {};
+  const sanitized = {};
+  Object.entries(props).forEach(([key, value]) => {
+    if (typeof key !== 'string') return;
+    const trimmedKey = key.trim();
+    if (!trimmedKey) return;
+    if (value === null || value === undefined) return;
+    if (typeof value === 'string') {
+      sanitized[trimmedKey] = value.slice(0, 500);
+      return;
+    }
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      sanitized[trimmedKey] = value;
+      return;
+    }
+    if (typeof value === 'boolean') {
+      sanitized[trimmedKey] = value;
+    }
+  });
+  return sanitized;
+}
+
+function flushInternalQueue(reason = 'timer') {
+  const state = getInternalState();
+  if (!state || !state.queue.length || state.pending) return;
+  const batch = state.queue.splice(0, INTERNAL_BATCH_SIZE);
+  if (!batch.length) return;
+
+  const payload = {
+    sessionId: ensureSessionId(),
+    events: batch,
+    sentAt: Date.now(),
+    reason,
+  };
+
+  state.pending = true;
+
+  const serialized = JSON.stringify(payload);
+  const finalize = () => {
+    state.pending = false;
+    if (state.queue.length) {
+      flushInternalQueue('drain');
+    }
+  };
+
+  try {
+    if (typeof navigator !== 'undefined' && typeof navigator.sendBeacon === 'function') {
+      const blob = new Blob([serialized], { type: 'application/json' });
+      const ok = navigator.sendBeacon(INTERNAL_ENDPOINT, blob);
+      if (ok) {
+        finalize();
+        return;
+      }
+    }
+  } catch (error) {
+    console.warn('[events] sendBeacon failed', error);
+  }
+
+  try {
+    fetch(INTERNAL_ENDPOINT, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: serialized,
+      keepalive: true,
+    })
+      .catch(() => {})
+      .finally(finalize);
+  } catch (error) {
+    console.warn('[events] fetch failed', error);
+    finalize();
+  }
+}
+
+function scheduleInternalFlush() {
+  const state = getInternalState();
+  if (!state) return;
+  if (state.timer) clearTimeout(state.timer);
+  state.timer = setTimeout(() => {
+    state.timer = null;
+    flushInternalQueue('interval');
+  }, INTERNAL_FLUSH_MS);
+}
+
+function queueInternalEvent(name, props) {
+  if (typeof window === 'undefined') return;
+  const trimmedName = typeof name === 'string' ? name.trim() : '';
+  if (!trimmedName) return;
+  const state = getInternalState();
+  if (!state) return;
+
+  const sanitizedProps = sanitizeProps(props);
+  const slugValue = typeof sanitizedProps.slug === 'string' ? sanitizedProps.slug.trim() : '';
+  const event = {
+    name: trimmedName,
+    props: sanitizedProps,
+    slug: slugValue || undefined,
+    ts: Date.now(),
+  };
+
+  state.queue.push(event);
+  if (state.queue.length >= INTERNAL_MAX_QUEUE) {
+    state.queue.splice(0, state.queue.length - INTERNAL_MAX_QUEUE);
+  }
+
+  if (state.queue.length >= INTERNAL_BATCH_SIZE) {
+    flushInternalQueue('batch');
+  } else {
+    scheduleInternalFlush();
+  }
+}
+
+function setupVisibilityHandler() {
+  if (typeof window === 'undefined') return;
+  if (window.__vaInternalVisibilityHooked) return;
+  window.__vaInternalVisibilityHooked = true;
+  window.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') {
+      flushInternalQueue('hidden');
+    }
+  });
+  window.addEventListener('beforeunload', () => {
+    flushInternalQueue('unload');
+  });
+}
+
 // Simple client-side queue to avoid early-call loss before <Analytics /> hydrates
 function getQueue() {
   if (typeof window === 'undefined') return null;
@@ -33,6 +198,8 @@ export function vaTrack(name, props = {}) {
         setTimeout(flushQueue, 100);
       }
     }
+    queueInternalEvent(name, props);
+    setupVisibilityHandler();
   } catch (e) {
     // no-op in SSR or if analytics is unavailable
   }

--- a/pages/api/admin/events/summary.js
+++ b/pages/api/admin/events/summary.js
@@ -1,0 +1,37 @@
+import { assertAdmin } from '../_auth';
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  if (!assertAdmin(req, res)) return;
+
+  try {
+    const startDate = typeof req.query.start === 'string' ? req.query.start : undefined;
+    const endDate = typeof req.query.end === 'string' ? req.query.end : undefined;
+    const eventName = typeof req.query.event === 'string' ? req.query.event.trim() : '';
+    const slug = typeof req.query.slug === 'string' ? req.query.slug.trim() : '';
+    const limitRaw = typeof req.query.limit === 'string' ? req.query.limit : undefined;
+
+    const { getEventSummary } = await import('../../../../utils/eventsStore');
+    const summary = await getEventSummary({
+      startDate,
+      endDate,
+      eventName,
+      slug,
+      limit: limitRaw,
+    });
+
+    return res.status(200).json({
+      items: Array.isArray(summary.items) ? summary.items : [],
+      totals: summary.totals || { count: 0, uniqueSessions: 0 },
+      timeseries: Array.isArray(summary.timeseries) ? summary.timeseries : [],
+      catalog: summary.catalog || { events: [], slugsByEvent: {} },
+    });
+  } catch (error) {
+    console.error('[admin/events] summary failed', error);
+    return res.status(500).json({ error: '이벤트 요약을 불러오지 못했어요.' });
+  }
+}

--- a/pages/api/events/log.js
+++ b/pages/api/events/log.js
@@ -1,0 +1,86 @@
+async function parseBody(req) {
+  if (req.body && typeof req.body === 'object') {
+    return req.body;
+  }
+  const chunks = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.from(chunk));
+  }
+  if (!chunks.length) return null;
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString('utf8'));
+  } catch (error) {
+    return null;
+  }
+}
+
+function normalizeEvents(rawEvents) {
+  if (!Array.isArray(rawEvents)) return [];
+  return rawEvents
+    .slice(0, 100)
+    .map((event) => {
+      if (!event || typeof event !== 'object') return null;
+      const name = typeof event.name === 'string' ? event.name.trim() : '';
+      if (!name) return null;
+      const props = event.props && typeof event.props === 'object' ? event.props : {};
+      const slug = typeof event.slug === 'string' ? event.slug.trim() : '';
+      const ts = Number(event.ts);
+      const timestamp = Number.isFinite(ts) ? ts : Date.now();
+      return {
+        name,
+        props,
+        slug,
+        ts: timestamp,
+        sessionId: typeof event.sessionId === 'string' ? event.sessionId.trim() : '',
+        value: Number.isFinite(Number(event.value)) ? Number(event.value) : undefined,
+      };
+    })
+    .filter(Boolean);
+}
+
+function extractContext(req) {
+  const forwarded = typeof req.headers['x-forwarded-for'] === 'string' ? req.headers['x-forwarded-for'] : '';
+  const ip = forwarded ? forwarded.split(',')[0].trim() : req.socket?.remoteAddress || '';
+  const userAgent = typeof req.headers['user-agent'] === 'string' ? req.headers['user-agent'] : '';
+  const referer = typeof req.headers.referer === 'string' ? req.headers.referer : '';
+  const origin = typeof req.headers.origin === 'string' ? req.headers.origin : '';
+  return { ip, userAgent, referer, origin };
+}
+
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: '256kb',
+    },
+  },
+};
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  try {
+    const body = await parseBody(req);
+    if (!body) {
+      return res.status(400).json({ error: '잘못된 요청 본문입니다.' });
+    }
+
+    const events = normalizeEvents(body.events);
+    if (!events.length) {
+      return res.status(200).json({ ok: true, ingested: 0 });
+    }
+
+    const sessionId = typeof body.sessionId === 'string' ? body.sessionId.trim() : '';
+    const context = { ...extractContext(req), sessionId, receivedAt: Date.now() };
+
+    const { ingestEvents } = await import('../../../utils/eventsStore');
+    const result = await ingestEvents(events, context);
+
+    return res.status(200).json({ ok: true, ingested: result.ingested || 0 });
+  } catch (error) {
+    console.error('[events] ingest failed', error);
+    return res.status(500).json({ error: '이벤트를 저장하지 못했어요.' });
+  }
+}


### PR DESCRIPTION
## 요약
- 클라이언트 이벤트를 내부 API로 배치 전송하도록 vaTrack 파이프라인을 확장하고 이벤트 저장/요약 유틸을 추가했습니다.
- `/api/events/log`, `/api/admin/events/summary` 엔드포인트를 도입해 내부 이벤트를 수집하고 기간/필터별로 집계할 수 있게 했습니다.
- 관리자 페이지에 커스텀 이벤트 분석 섹션과 광고 통합 인사이트 화면을 추가해 이벤트-광고 상관분석과 지표 비교가 가능하도록 구성했습니다.

## 테스트
- npm run lint (실패, 기존 eslint 설정에서 React in scope 및 PropTypes 규칙 관련 다수 경고/에러 발생)


------
https://chatgpt.com/codex/tasks/task_e_68d6a94954548323be301ccc0386d067