### PR TITLE
내부 이벤트 파이프라인과 광고 통합 인사이트 화면 추가

### DIFF
--- a/components/admin/events/EventAnalyticsToolbar.jsx
+++ b/components/admin/events/EventAnalyticsToolbar.jsx
@@ -1,0 +1,100 @@
+import { useMemo } from 'react';
+
+export default function EventAnalyticsToolbar({
+  startDate,
+  endDate,
+  onDateChange,
+  eventNames,
+  selectedEvent,
+  onSelectEvent,
+  slugFilter,
+  onSlugChange,
+  onRefresh,
+  onDownloadCsv,
+  loading,
+}) {
+  const options = useMemo(() => {
+    const items = Array.isArray(eventNames) ? eventNames : [];
+    return [''].concat(items.filter((name) => typeof name === 'string' && name));
+  }, [eventNames]);
+
+  const handleStartChange = (event) => {
+    onDateChange?.({ start: event.target.value, end: endDate });
+  };
+
+  const handleEndChange = (event) => {
+    onDateChange?.({ start: startDate, end: event.target.value });
+  };
+
+  return (
+    <div className="flex flex-col gap-4 rounded-2xl bg-slate-900/70 p-4 ring-1 ring-slate-800/60">
+      <div className="flex flex-col gap-3 text-xs text-slate-200 md:flex-row md:items-center md:justify-between">
+        <div className="flex flex-wrap items-center gap-3">
+          <label className="flex flex-col text-[11px] uppercase tracking-[0.25em] text-slate-400">
+            시작일
+            <input
+              type="date"
+              value={startDate || ''}
+              onChange={handleStartChange}
+              className="mt-1 rounded-md border border-slate-700/60 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-indigo-400 focus:outline-none"
+            />
+          </label>
+          <label className="flex flex-col text-[11px] uppercase tracking-[0.25em] text-slate-400">
+            종료일
+            <input
+              type="date"
+              value={endDate || ''}
+              onChange={handleEndChange}
+              className="mt-1 rounded-md border border-slate-700/60 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-indigo-400 focus:outline-none"
+            />
+          </label>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <label className="flex items-center gap-2 rounded-full bg-slate-950/50 px-3 py-1 text-xs text-slate-200">
+            <span className="text-slate-400">이벤트</span>
+            <select
+              value={selectedEvent || ''}
+              onChange={(event) => onSelectEvent?.(event.target.value)}
+              className="rounded-md border border-slate-700/60 bg-slate-950 px-2 py-1 text-sm text-slate-100 focus:border-indigo-400 focus:outline-none"
+            >
+              {options.map((name) => (
+                <option key={name || 'all'} value={name}>
+                  {name ? name : '전체 이벤트'}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex items-center gap-2 rounded-full bg-slate-950/50 px-3 py-1 text-xs text-slate-200">
+            <span className="text-slate-400">슬러그</span>
+            <input
+              type="text"
+              value={slugFilter || ''}
+              onChange={(event) => onSlugChange?.(event.target.value)}
+              placeholder="예: funny-meme"
+              className="rounded-md border border-slate-700/60 bg-slate-950 px-2 py-1 text-sm text-slate-100 focus:border-indigo-400 focus:outline-none"
+            />
+          </label>
+          <button
+            type="button"
+            onClick={onRefresh}
+            className="rounded-full border border-slate-700/60 px-4 py-2 text-xs font-semibold text-slate-100 transition hover:bg-slate-800"
+          >
+            새로고침
+          </button>
+          <button
+            type="button"
+            onClick={onDownloadCsv}
+            className="rounded-full bg-gradient-to-r from-emerald-400 via-teal-400 to-cyan-400 px-4 py-2 text-xs font-semibold text-slate-950 shadow-lg shadow-emerald-500/30 transition hover:brightness-110"
+          >
+            CSV 다운로드
+          </button>
+        </div>
+      </div>
+      {loading && (
+        <div className="rounded-xl border border-slate-800/60 bg-slate-950/40 px-3 py-2 text-xs text-slate-400">
+          이벤트 데이터를 불러오는 중입니다…
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/admin/events/EventSummaryCards.jsx
+++ b/components/admin/events/EventSummaryCards.jsx
@@ -1,0 +1,50 @@
+import { formatRelativeTime } from '../../../lib/formatters';
+
+function formatNumber(value) {
+  try {
+    return new Intl.NumberFormat('ko-KR').format(Number(value) || 0);
+  } catch (error) {
+    return String(value || 0);
+  }
+}
+
+export default function EventSummaryCards({ totals, topEvent, range, generatedAt }) {
+  const totalEvents = Number(totals?.totalEvents) || 0;
+  const totalUnique = Number(totals?.totalUnique) || 0;
+  const lastGenerated = generatedAt ? formatRelativeTime(generatedAt, 'ko') : null;
+  const topTitle = topEvent?.lastTitle || '';
+  const topName = topEvent?.name || '';
+  const topCount = Number(topEvent?.totalCount) || 0;
+  const topSlug = topEvent?.slug || '';
+  const topUpdated = topEvent?.lastSeenAt ? formatRelativeTime(topEvent.lastSeenAt, 'ko') : null;
+
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+      <div className="rounded-2xl border border-slate-800/60 bg-slate-900/70 p-6 shadow-inner shadow-black/30">
+        <div className="text-xs uppercase tracking-[0.3em] text-slate-400">이벤트 총합</div>
+        <div className="mt-2 text-3xl font-bold text-slate-50">{formatNumber(totalEvents)}</div>
+        <p className="mt-3 text-sm text-slate-400">
+          {range?.start || '?'} ~ {range?.end || '?'} 동안 수집된 커스텀 이벤트 총합입니다.
+        </p>
+        {lastGenerated && (
+          <p className="mt-4 text-xs text-slate-500">최근 갱신 {lastGenerated}</p>
+        )}
+      </div>
+      <div className="rounded-2xl border border-slate-800/60 bg-slate-900/70 p-6 shadow-inner shadow-black/30">
+        <div className="text-xs uppercase tracking-[0.3em] text-slate-400">고유 세션</div>
+        <div className="mt-2 text-3xl font-bold text-slate-50">{formatNumber(totalUnique)}</div>
+        <p className="mt-3 text-sm text-slate-400">
+          동일한 viewerId를 기준으로 근사치로 계산된 참여 세션 수입니다.
+        </p>
+      </div>
+      <div className="rounded-2xl border border-emerald-500/40 bg-emerald-500/10 p-6 shadow-lg shadow-emerald-500/20">
+        <div className="text-xs uppercase tracking-[0.3em] text-emerald-200">상위 이벤트</div>
+        <div className="mt-2 text-lg font-bold text-emerald-100">{topName || '데이터 없음'}</div>
+        <div className="mt-1 text-sm text-emerald-200">{topSlug ? `슬러그 ${topSlug}` : '글로벌 이벤트'}</div>
+        <div className="mt-3 text-2xl font-semibold text-emerald-100">{formatNumber(topCount)}</div>
+        {topTitle && <div className="mt-2 text-xs text-emerald-200/80">최근 제목: {topTitle}</div>}
+        {topUpdated && <div className="mt-2 text-[11px] text-emerald-300/70">최근 발생 {topUpdated}</div>}
+      </div>
+    </div>
+  );
+}

--- a/components/admin/events/EventTable.jsx
+++ b/components/admin/events/EventTable.jsx
@@ -1,0 +1,71 @@
+import { formatRelativeTime } from '../../../lib/formatters';
+
+function formatNumber(value) {
+  try {
+    return new Intl.NumberFormat('ko-KR').format(Number(value) || 0);
+  } catch (error) {
+    return String(value || 0);
+  }
+}
+
+function renderMeta(metaSummary) {
+  if (!metaSummary) return '—';
+  const source = metaSummary.utm_sources?.[0];
+  const medium = metaSummary.utm_mediums?.[0];
+  const campaign = metaSummary.utm_campaigns?.[0];
+  if (!source && !medium && !campaign) return '—';
+  return [source || '소스 미지정', medium || '미디어 미지정', campaign || '캠페인 미지정'].join(' · ');
+}
+
+export default function EventTable({ events, loading }) {
+  const items = Array.isArray(events) ? events : [];
+
+  return (
+    <div className="overflow-hidden rounded-2xl bg-slate-900/80 ring-1 ring-slate-800/70">
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-slate-800/70 text-sm">
+          <thead className="bg-slate-900/60 text-left text-xs uppercase tracking-widest text-slate-400">
+            <tr>
+              <th className="px-4 py-3 font-semibold">이벤트명</th>
+              <th className="px-4 py-3 font-semibold">슬러그</th>
+              <th className="px-4 py-3 text-right font-semibold">발생 수</th>
+              <th className="px-4 py-3 text-right font-semibold">고유 세션</th>
+              <th className="px-4 py-3 font-semibold">대표 UTM</th>
+              <th className="px-4 py-3 font-semibold">최근 발생</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-800/60">
+            {items.map((event) => {
+              const lastSeen = event.lastSeenAt ? formatRelativeTime(event.lastSeenAt, 'ko') : '—';
+              return (
+                <tr key={event.id} className="hover:bg-slate-800/40">
+                  <td className="px-4 py-3 font-semibold text-slate-100">
+                    <div>{event.name}</div>
+                    {event.lastTitle && <div className="text-xs text-slate-400">{event.lastTitle}</div>}
+                  </td>
+                  <td className="px-4 py-3 text-slate-200">{event.slug || '—'}</td>
+                  <td className="px-4 py-3 text-right text-slate-100">{formatNumber(event.totalCount)}</td>
+                  <td className="px-4 py-3 text-right text-slate-100">{formatNumber(event.uniqueCount || 0)}</td>
+                  <td className="px-4 py-3 text-slate-200">{renderMeta(event.metaSummary)}</td>
+                  <td className="px-4 py-3 text-slate-200">{lastSeen}</td>
+                </tr>
+              );
+            })}
+            {!items.length && !loading && (
+              <tr>
+                <td colSpan={6} className="px-4 py-12 text-center text-sm text-slate-400">
+                  선택한 조건에 해당하는 이벤트가 없습니다.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+      {loading && (
+        <div className="border-t border-slate-800/70 bg-slate-900/70 px-4 py-3 text-right text-xs text-slate-400">
+          불러오는 중…
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/admin/insights/AdEventInsightsPanel.jsx
+++ b/components/admin/insights/AdEventInsightsPanel.jsx
@@ -1,0 +1,220 @@
+import { useMemo } from 'react';
+
+function normalizeDate(value) {
+  if (!value) return '';
+  const str = String(value).trim();
+  if (!str) return '';
+  if (/^\d{4}-\d{2}-\d{2}$/.test(str)) return str;
+  const parsed = new Date(str);
+  if (Number.isNaN(parsed.getTime())) return '';
+  return parsed.toISOString().slice(0, 10);
+}
+
+function aggregateAdStats(stats) {
+  const map = new Map();
+  if (!Array.isArray(stats)) return map;
+  stats.forEach((row) => {
+    const dateKey = normalizeDate(row?.date || row?.day || row?.Day || row?.group);
+    if (!dateKey) return;
+    const impressions = Number(row?.impression ?? row?.impressions ?? 0) || 0;
+    const clicks = Number(row?.clicks ?? row?.click ?? 0) || 0;
+    const revenue = Number(row?.revenue ?? 0) || 0;
+    const current = map.get(dateKey) || { impressions: 0, clicks: 0, revenue: 0 };
+    current.impressions += impressions;
+    current.clicks += clicks;
+    current.revenue += revenue;
+    map.set(dateKey, current);
+  });
+  return map;
+}
+
+function computeCorrelation(pairs) {
+  if (!Array.isArray(pairs) || pairs.length < 2) return null;
+  let sumX = 0;
+  let sumY = 0;
+  let sumXY = 0;
+  let sumX2 = 0;
+  let sumY2 = 0;
+  pairs.forEach(([x, y]) => {
+    sumX += x;
+    sumY += y;
+    sumXY += x * y;
+    sumX2 += x * x;
+    sumY2 += y * y;
+  });
+  const n = pairs.length;
+  const numerator = n * sumXY - sumX * sumY;
+  const denominator = Math.sqrt((n * sumX2 - sumX * sumX) * (n * sumY2 - sumY * sumY));
+  if (!denominator || Number.isNaN(denominator)) return null;
+  const value = numerator / denominator;
+  if (Number.isNaN(value)) return null;
+  return Math.max(-1, Math.min(1, value));
+}
+
+function formatNumber(value, fraction = 0) {
+  try {
+    return new Intl.NumberFormat('ko-KR', { maximumFractionDigits: fraction }).format(Number(value) || 0);
+  } catch (error) {
+    return String(value || 0);
+  }
+}
+
+export default function AdEventInsightsPanel({
+  events,
+  selectedEventId,
+  onSelectEvent,
+  adStats,
+  loadingEvents,
+  loadingAds,
+}) {
+  const eventOptions = useMemo(() => {
+    if (!Array.isArray(events)) return [];
+    return events.map((event) => ({
+      id: event.id,
+      label: event.slug ? `${event.name} · ${event.slug}` : event.name,
+    }));
+  }, [events]);
+
+  const selectedEvent = useMemo(() => {
+    if (!Array.isArray(events)) return null;
+    if (!selectedEventId) return events[0] || null;
+    return events.find((event) => event.id === selectedEventId) || events[0] || null;
+  }, [events, selectedEventId]);
+
+  const adDaily = useMemo(() => aggregateAdStats(adStats), [adStats]);
+
+  const correlationData = useMemo(() => {
+    if (!selectedEvent) return { pairs: [], totals: { events: 0, revenue: 0, impressions: 0 } };
+    const pairs = [];
+    let totalEvents = 0;
+    let totalRevenue = 0;
+    let totalImpressions = 0;
+    const history = Array.isArray(selectedEvent.history) ? selectedEvent.history : [];
+    history.forEach((entry) => {
+      const dateKey = normalizeDate(entry.date);
+      if (!dateKey) return;
+      const eventCount = Number(entry.count) || 0;
+      const adEntry = adDaily.get(dateKey);
+      if (adEntry) {
+        pairs.push([eventCount, adEntry.revenue]);
+        totalRevenue += adEntry.revenue;
+        totalImpressions += adEntry.impressions;
+      }
+      totalEvents += eventCount;
+    });
+    return { pairs, totals: { events: totalEvents, revenue: totalRevenue, impressions: totalImpressions } };
+  }, [selectedEvent, adDaily]);
+
+  const correlation = useMemo(() => computeCorrelation(correlationData.pairs), [correlationData.pairs]);
+
+  const tableRows = useMemo(() => {
+    if (!selectedEvent) return [];
+    const history = Array.isArray(selectedEvent.history) ? selectedEvent.history : [];
+    return history.map((entry, index) => {
+      const dateKey = normalizeDate(entry.date);
+      const adEntry = adDaily.get(dateKey) || { impressions: 0, clicks: 0, revenue: 0 };
+      const eventCount = Number(entry.count) || 0;
+      const ctr = adEntry.impressions > 0 ? (adEntry.clicks / adEntry.impressions) * 100 : 0;
+      return {
+        id: `${dateKey || 'unknown'}-${index}`,
+        date: dateKey,
+        events: eventCount,
+        revenue: adEntry.revenue,
+        impressions: adEntry.impressions,
+        ctr,
+      };
+    });
+  }, [selectedEvent, adDaily]);
+
+  const loading = loadingEvents || loadingAds;
+
+  return (
+    <div className="flex flex-col gap-4 rounded-2xl bg-slate-900/70 p-6 ring-1 ring-slate-800/60">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h3 className="text-lg font-semibold text-slate-100">광고 · 이벤트 상관 분석</h3>
+          <p className="text-sm text-slate-400">
+            일별 광고 수익과 선택한 이벤트 발생 수의 상관성을 확인할 수 있어요.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-xs uppercase tracking-[0.25em] text-slate-400">이벤트 선택</span>
+          <select
+            value={selectedEvent?.id || ''}
+            onChange={(event) => onSelectEvent?.(event.target.value)}
+            className="rounded-md border border-slate-700/60 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-indigo-400 focus:outline-none"
+          >
+            {eventOptions.map((option) => (
+              <option key={option.id} value={option.id}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <div className="rounded-xl border border-slate-800/60 bg-slate-950/60 p-4">
+          <div className="text-xs uppercase tracking-[0.3em] text-slate-400">이벤트 발생</div>
+          <div className="mt-2 text-2xl font-bold text-slate-50">
+            {formatNumber(correlationData.totals.events)}
+          </div>
+        </div>
+        <div className="rounded-xl border border-slate-800/60 bg-slate-950/60 p-4">
+          <div className="text-xs uppercase tracking-[0.3em] text-slate-400">광고 수익 (USD)</div>
+          <div className="mt-2 text-2xl font-bold text-slate-50">
+            {formatNumber(correlationData.totals.revenue, 2)}
+          </div>
+        </div>
+        <div className="rounded-xl border border-emerald-500/50 bg-emerald-500/10 p-4">
+          <div className="text-xs uppercase tracking-[0.3em] text-emerald-200">상관계수</div>
+          <div className="mt-2 text-2xl font-bold text-emerald-100">
+            {correlation !== null ? formatNumber(correlation, 3) : '데이터 부족'}
+          </div>
+          <p className="mt-2 text-xs text-emerald-200/70">
+            1에 가까울수록 양의 상관, -1에 가까울수록 음의 상관입니다.
+          </p>
+        </div>
+      </div>
+
+      <div className="overflow-hidden rounded-xl border border-slate-800/60">
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-slate-800/60 text-sm">
+            <thead className="bg-slate-900/60 text-left text-xs uppercase tracking-widest text-slate-400">
+              <tr>
+                <th className="px-4 py-3 font-semibold">날짜</th>
+                <th className="px-4 py-3 text-right font-semibold">이벤트</th>
+                <th className="px-4 py-3 text-right font-semibold">광고 수익 (USD)</th>
+                <th className="px-4 py-3 text-right font-semibold">노출수</th>
+                <th className="px-4 py-3 text-right font-semibold">CTR</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-800/50">
+              {tableRows.map((row) => (
+                <tr key={row.id} className="hover:bg-slate-800/40">
+                  <td className="px-4 py-3 font-semibold text-slate-100">{row.date || '—'}</td>
+                  <td className="px-4 py-3 text-right text-slate-100">{formatNumber(row.events)}</td>
+                  <td className="px-4 py-3 text-right text-slate-100">{formatNumber(row.revenue, 3)}</td>
+                  <td className="px-4 py-3 text-right text-slate-100">{formatNumber(row.impressions)}</td>
+                  <td className="px-4 py-3 text-right text-slate-100">{formatNumber(row.ctr, 3)}%</td>
+                </tr>
+              ))}
+              {!tableRows.length && !loading && (
+                <tr>
+                  <td colSpan={5} className="px-4 py-12 text-center text-sm text-slate-400">
+                    겹치는 날짜 구간이 없어 상관 데이터를 계산할 수 없어요.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+        {loading && (
+          <div className="border-t border-slate-800/60 bg-slate-900/70 px-4 py-3 text-right text-xs text-slate-400">
+            데이터를 불러오는 중입니다…
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/hooks/admin/useEventAnalytics.js
+++ b/hooks/admin/useEventAnalytics.js
@@ -1,0 +1,148 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+const DEFAULT_LIMIT = 200;
+
+function buildQueryParams({ token, startDate, endDate, eventName, slug }) {
+  const params = new URLSearchParams();
+  if (token) params.set('token', token);
+  if (startDate) params.set('start', startDate);
+  if (endDate) params.set('end', endDate);
+  if (eventName) params.append('event', eventName);
+  if (slug) params.set('slug', slug);
+  params.set('limit', String(DEFAULT_LIMIT));
+  return params;
+}
+
+export default function useEventAnalytics({ enabled, token, startDate, endDate }) {
+  const [eventNameFilter, setEventNameFilter] = useState('');
+  const [slugFilter, setSlugFilter] = useState('');
+  const [events, setEvents] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [totals, setTotals] = useState({ totalEvents: 0, totalUnique: 0 });
+  const [availableNames, setAvailableNames] = useState([]);
+  const [availableSlugs, setAvailableSlugs] = useState([]);
+  const [range, setRange] = useState({ start: '', end: '' });
+  const [generatedAt, setGeneratedAt] = useState('');
+  const [refreshIndex, setRefreshIndex] = useState(0);
+
+  const refresh = useCallback(() => {
+    setRefreshIndex((index) => index + 1);
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return undefined;
+    const controller = new AbortController();
+    const params = buildQueryParams({
+      token,
+      startDate,
+      endDate,
+      eventName: eventNameFilter,
+      slug: slugFilter,
+    });
+
+    setLoading(true);
+    setError('');
+
+    fetch(`/api/admin/events/summary?${params.toString()}`, {
+      signal: controller.signal,
+      headers: { 'cache-control': 'no-store' },
+    })
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error('이벤트 요약을 불러오지 못했어요.');
+        }
+        return res.json();
+      })
+      .then((data) => {
+        if (controller.signal.aborted) return;
+        setEvents(Array.isArray(data?.events) ? data.events : []);
+        setTotals({
+          totalEvents: Number(data?.totals?.totalEvents) || 0,
+          totalUnique: Number(data?.totals?.totalUnique) || 0,
+        });
+        setAvailableNames(Array.isArray(data?.meta?.eventNames) ? data.meta.eventNames : []);
+        setAvailableSlugs(Array.isArray(data?.meta?.slugs) ? data.meta.slugs : []);
+        setRange({
+          start: typeof data?.range?.start === 'string' ? data.range.start : '',
+          end: typeof data?.range?.end === 'string' ? data.range.end : '',
+        });
+        setGeneratedAt(typeof data?.generatedAt === 'string' ? data.generatedAt : new Date().toISOString());
+      })
+      .catch((err) => {
+        if (controller.signal.aborted) return;
+        setEvents([]);
+        setTotals({ totalEvents: 0, totalUnique: 0 });
+        setAvailableNames([]);
+        setAvailableSlugs([]);
+        setRange({ start: '', end: '' });
+        setGeneratedAt('');
+        setError(err.message || '이벤트 요약을 불러오지 못했어요.');
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [enabled, token, startDate, endDate, eventNameFilter, slugFilter, refreshIndex]);
+
+  useEffect(() => {
+    if (!enabled) {
+      setEvents([]);
+      setTotals({ totalEvents: 0, totalUnique: 0 });
+      setAvailableNames([]);
+      setAvailableSlugs([]);
+      setRange({ start: '', end: '' });
+      setGeneratedAt('');
+      setError('');
+    }
+  }, [enabled]);
+
+  const downloadCsv = useCallback(() => {
+    const params = buildQueryParams({
+      token,
+      startDate,
+      endDate,
+      eventName: eventNameFilter,
+      slug: slugFilter,
+    });
+    params.set('format', 'csv');
+    const url = `/api/admin/events/summary?${params.toString()}`;
+    const link = document.createElement('a');
+    link.href = url;
+    link.rel = 'noopener noreferrer';
+    link.target = '_blank';
+    link.download = 'event-summary.csv';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  }, [token, startDate, endDate, eventNameFilter, slugFilter]);
+
+  const derived = useMemo(
+    () => ({
+      events,
+      totals,
+      range,
+      availableNames,
+      availableSlugs,
+      generatedAt,
+    }),
+    [events, totals, range, availableNames, availableSlugs, generatedAt]
+  );
+
+  return {
+    ...derived,
+    loading,
+    error,
+    eventNameFilter,
+    setEventNameFilter,
+    slugFilter,
+    setSlugFilter,
+    refresh,
+    downloadCsv,
+  };
+}

--- a/lib/internalEventsClient.js
+++ b/lib/internalEventsClient.js
@@ -1,0 +1,202 @@
+const MAX_BATCH_SIZE = 10;
+const FLUSH_INTERVAL_MS = 4000;
+const MAX_QUEUE_SIZE = 200;
+const EVENT_ENDPOINT = '/api/events/ingest';
+
+function ensureState() {
+  if (typeof window === 'undefined') return null;
+  if (!window.__laffyInternalEvents) {
+    window.__laffyInternalEvents = {
+      queue: [],
+      timer: null,
+      inflight: null,
+      lastFlush: 0,
+    };
+  }
+  return window.__laffyInternalEvents;
+}
+
+function sanitizeValue(value, depth = 0) {
+  if (depth > 3) return undefined;
+  if (value === null) return null;
+  const type = typeof value;
+  if (type === 'string' || type === 'number' || type === 'boolean') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    const arr = value
+      .map((item) => sanitizeValue(item, depth + 1))
+      .filter((item) => item !== undefined);
+    return arr.length ? arr : undefined;
+  }
+  if (type === 'object') {
+    const entries = Object.entries(value);
+    if (!entries.length) return undefined;
+    const result = {};
+    entries.forEach(([key, val]) => {
+      if (typeof key !== 'string' || !key) return;
+      const sanitized = sanitizeValue(val, depth + 1);
+      if (sanitized !== undefined) {
+        result[key] = sanitized;
+      }
+    });
+    return Object.keys(result).length ? result : undefined;
+  }
+  return undefined;
+}
+
+function sanitizeProps(props) {
+  if (!props || typeof props !== 'object') return {};
+  const sanitized = sanitizeValue(props, 0);
+  if (!sanitized || typeof sanitized !== 'object') return {};
+  return sanitized;
+}
+
+function encodePayload(events) {
+  try {
+    return JSON.stringify({
+      sentAt: new Date().toISOString(),
+      events,
+    });
+  } catch (error) {
+    return null;
+  }
+}
+
+function trySendBeacon(body) {
+  try {
+    if (typeof navigator === 'undefined' || typeof navigator.sendBeacon !== 'function') {
+      return false;
+    }
+    const blob = new Blob([body], { type: 'application/json' });
+    return navigator.sendBeacon(EVENT_ENDPOINT, blob);
+  } catch (error) {
+    return false;
+  }
+}
+
+async function sendBatch(batch) {
+  const payload = batch.map((event) => ({
+    name: event.name,
+    props: event.props,
+    timestamp: event.timestamp,
+  }));
+  const body = encodePayload(payload);
+  if (!body) return false;
+
+  if (trySendBeacon(body)) {
+    return true;
+  }
+
+  try {
+    const controller = typeof AbortController !== 'undefined' ? new AbortController() : null;
+    const timeoutId = controller
+      ? setTimeout(() => {
+          try {
+            controller.abort();
+          } catch (error) {
+            // ignore abort errors
+          }
+        }, 5000)
+      : null;
+
+    const res = await fetch(EVENT_ENDPOINT, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body,
+      keepalive: true,
+      signal: controller ? controller.signal : undefined,
+    });
+
+    if (timeoutId) clearTimeout(timeoutId);
+    return res.ok;
+  } catch (error) {
+    return false;
+  }
+}
+
+function scheduleFlush() {
+  const state = ensureState();
+  if (!state) return;
+  if (state.timer) return;
+  state.timer = setTimeout(() => {
+    state.timer = null;
+    flushQueue();
+  }, FLUSH_INTERVAL_MS);
+}
+
+function requeueEvents(events) {
+  const state = ensureState();
+  if (!state) return;
+  if (!Array.isArray(events) || !events.length) return;
+  const queue = state.queue;
+  const combined = events.concat(queue);
+  state.queue = combined.slice(0, MAX_QUEUE_SIZE);
+  if (state.queue.length) {
+    scheduleFlush();
+  }
+}
+
+function flushQueue(force = false) {
+  const state = ensureState();
+  if (!state) return;
+  if (state.inflight) return;
+
+  const now = Date.now();
+  if (!force && state.queue.length === 0) {
+    return;
+  }
+  if (!force && now - state.lastFlush < 500 && state.queue.length < MAX_BATCH_SIZE) {
+    scheduleFlush();
+    return;
+  }
+
+  const batch = state.queue.splice(0, MAX_BATCH_SIZE);
+  if (!batch.length) return;
+  state.lastFlush = now;
+  const pending = batch.map((item) => ({ ...item }));
+  const promise = sendBatch(pending)
+    .catch(() => false)
+    .then((ok) => {
+      if (!ok) {
+        requeueEvents(pending);
+      }
+    })
+    .finally(() => {
+      state.inflight = null;
+      if (state.queue.length) {
+        scheduleFlush();
+      }
+    });
+  state.inflight = promise;
+}
+
+export function dispatchInternalEvent(name, props = {}) {
+  if (typeof window === 'undefined') return;
+  const normalizedName = typeof name === 'string' ? name.trim() : '';
+  if (!normalizedName) return;
+
+  const state = ensureState();
+  if (!state) return;
+  const sanitizedProps = sanitizeProps(props);
+  const event = {
+    name: normalizedName,
+    props: sanitizedProps,
+    timestamp: Date.now(),
+  };
+
+  state.queue.push(event);
+  if (state.queue.length > MAX_QUEUE_SIZE) {
+    state.queue.splice(0, state.queue.length - MAX_QUEUE_SIZE);
+  }
+
+  if (state.queue.length >= MAX_BATCH_SIZE) {
+    flushQueue(true);
+  } else {
+    scheduleFlush();
+  }
+}
+
+export function flushInternalEventQueue() {
+  flushQueue(true);
+}

--- a/lib/va.js
+++ b/lib/va.js
@@ -1,5 +1,6 @@
 // Vercel Analytics helper (safe wrapper)
 import { track } from '@vercel/analytics';
+import { dispatchInternalEvent } from './internalEventsClient';
 
 // Simple client-side queue to avoid early-call loss before <Analytics /> hydrates
 function getQueue() {
@@ -22,6 +23,11 @@ function flushQueue() {
 }
 
 export function vaTrack(name, props = {}) {
+  try {
+    dispatchInternalEvent(name, props);
+  } catch (error) {
+    // internal event tracking failures must not block page interactions
+  }
   try {
     if (isTrackReady()) {
       track(name, props);

--- a/pages/api/admin/events/summary.js
+++ b/pages/api/admin/events/summary.js
@@ -1,0 +1,127 @@
+import { assertAdmin } from '../_auth';
+import { getEventSummary } from '../../../../utils/eventsStore';
+
+function parseEventNames(query) {
+  const results = [];
+  const value = query.event;
+  if (Array.isArray(value)) {
+    value.forEach((item) => {
+      if (typeof item === 'string' && item.trim()) results.push(item.trim());
+    });
+  } else if (typeof value === 'string' && value.trim()) {
+    results.push(value.trim());
+  }
+  return results;
+}
+
+function escapeCsv(value) {
+  if (value === null || value === undefined) return '';
+  const text = typeof value === 'string' ? value : String(value);
+  if (text.includes('"') || text.includes(',') || text.includes('\n')) {
+    return `"${text.replace(/"/g, '""')}"`;
+  }
+  return text;
+}
+
+function buildCsv(entries, range) {
+  const header = [
+    'event_name',
+    'slug',
+    'total_count',
+    'unique_count',
+    'total_value',
+    'last_seen_at',
+    'last_title',
+    'utm_sources',
+    'utm_mediums',
+    'utm_campaigns',
+    'utm_contents',
+    'utm_terms',
+    'referrers',
+    'history',
+    'range_start',
+    'range_end',
+  ];
+
+  const rows = entries.map((entry) => {
+    const sources = entry.metaSummary?.utm_sources?.join(';') || '';
+    const mediums = entry.metaSummary?.utm_mediums?.join(';') || '';
+    const campaigns = entry.metaSummary?.utm_campaigns?.join(';') || '';
+    const contents = entry.metaSummary?.utm_contents?.join(';') || '';
+    const terms = entry.metaSummary?.utm_terms?.join(';') || '';
+    const referrers = entry.metaSummary?.referrers?.join(';') || '';
+    const history = Array.isArray(entry.history)
+      ? entry.history.map((item) => `${item.date}:${item.count}`).join('|')
+      : '';
+    const lastSeen = entry.lastSeenAt ? new Date(entry.lastSeenAt).toISOString() : '';
+
+    return [
+      escapeCsv(entry.name),
+      escapeCsv(entry.slug || ''),
+      escapeCsv(entry.totalCount || 0),
+      escapeCsv(entry.uniqueCount || 0),
+      escapeCsv(entry.totalValue || 0),
+      escapeCsv(lastSeen),
+      escapeCsv(entry.lastTitle || ''),
+      escapeCsv(sources),
+      escapeCsv(mediums),
+      escapeCsv(campaigns),
+      escapeCsv(contents),
+      escapeCsv(terms),
+      escapeCsv(referrers),
+      escapeCsv(history),
+      escapeCsv(range?.start || ''),
+      escapeCsv(range?.end || ''),
+    ].join(',');
+  });
+
+  return [header.join(','), ...rows].join('\n');
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  if (!assertAdmin(req, res)) return;
+
+  try {
+    const eventNames = parseEventNames(req.query);
+    const slug = typeof req.query.slug === 'string' ? req.query.slug.trim() : '';
+    const startDate = typeof req.query.start === 'string' ? req.query.start : undefined;
+    const endDate = typeof req.query.end === 'string' ? req.query.end : undefined;
+    const limit = req.query.limit ? Number(req.query.limit) : undefined;
+
+    const summary = await getEventSummary({
+      eventNames,
+      slug,
+      startDate,
+      endDate,
+      limit,
+    });
+
+    const payload = {
+      events: summary.entries,
+      totals: summary.totals,
+      range: summary.range,
+      meta: {
+        eventNames: summary.eventNames,
+        slugs: summary.slugs,
+      },
+      generatedAt: new Date().toISOString(),
+    };
+
+    if (req.query.format === 'csv') {
+      const csv = buildCsv(summary.entries, summary.range);
+      res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+      res.setHeader('Content-Disposition', 'attachment; filename="event-summary.csv"');
+      return res.status(200).send(csv);
+    }
+
+    return res.status(200).json(payload);
+  } catch (error) {
+    console.error('[admin:events] Failed to load summary', error);
+    return res.status(500).json({ error: '이벤트 요약을 불러오지 못했어요.' });
+  }
+}

--- a/pages/api/events/ingest.js
+++ b/pages/api/events/ingest.js
@@ -1,0 +1,61 @@
+import { ensureViewerId } from '../../../utils/viewerSession';
+import { logEvents } from '../../../utils/eventsStore';
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+async function readBody(req) {
+  const chunks = [];
+  for await (const chunk of req) {
+    chunks.push(chunk);
+  }
+  const buffer = Buffer.concat(chunks);
+  if (!buffer.length) return null;
+  const text = buffer.toString('utf8');
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    return null;
+  }
+}
+
+function normalizeEvents(payload) {
+  if (!payload) return [];
+  if (Array.isArray(payload.events)) {
+    return payload.events;
+  }
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+  if (payload.name) {
+    return [payload];
+  }
+  return [];
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    const body = await readBody(req);
+    const events = normalizeEvents(body);
+    if (!events.length) {
+      return res.status(400).json({ error: '이벤트 페이로드가 비어있어요.' });
+    }
+
+    const viewerId = ensureViewerId(req, res);
+    await logEvents(events, { viewerId });
+
+    return res.status(204).end();
+  } catch (error) {
+    console.error('[events:ingest] Failed to log events', error);
+    return res.status(500).json({ error: '이벤트를 기록하는 중 오류가 발생했어요.' });
+  }
+}

--- a/utils/eventsStore.js
+++ b/utils/eventsStore.js
@@ -1,0 +1,522 @@
+const DEFAULT_LOOKBACK_DAYS = 7;
+const MAX_RANGE_DAYS = 60;
+const ENTRY_LIMIT = 200;
+const REDIS_TTL_SECONDS = 60 * 60 * 24 * 90; // 90 days
+
+function normalizeDateInput(value) {
+  if (!value) return null;
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const iso = trimmed.includes('T') ? trimmed : `${trimmed}T00:00:00Z`;
+    const parsed = new Date(iso);
+    if (!Number.isNaN(parsed.getTime())) return parsed;
+  }
+  return null;
+}
+
+function clampRangeDays(days) {
+  if (!Number.isFinite(days) || days <= 0) return DEFAULT_LOOKBACK_DAYS;
+  return Math.min(MAX_RANGE_DAYS, Math.max(1, Math.floor(days)));
+}
+
+function formatDateKey(date) {
+  return date.toISOString().slice(0, 10);
+}
+
+function getDefaultRange() {
+  const end = new Date();
+  end.setUTCHours(0, 0, 0, 0);
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - (DEFAULT_LOOKBACK_DAYS - 1));
+  return { start, end };
+}
+
+function eachDateBetween(start, end) {
+  const dates = [];
+  const cursor = new Date(start);
+  cursor.setUTCHours(0, 0, 0, 0);
+  const limit = new Date(end);
+  limit.setUTCHours(0, 0, 0, 0);
+  while (cursor <= limit) {
+    dates.push(formatDateKey(cursor));
+    cursor.setUTCDate(cursor.getUTCDate() + 1);
+  }
+  return dates;
+}
+
+function sanitizeEvent(rawEvent) {
+  if (!rawEvent || typeof rawEvent !== 'object') return null;
+  const name = typeof rawEvent.name === 'string' ? rawEvent.name.trim() : '';
+  if (!name) return null;
+  const props = rawEvent.props && typeof rawEvent.props === 'object' ? rawEvent.props : {};
+  const slug = typeof props.slug === 'string' ? props.slug.trim() : '';
+  const title = typeof props.title === 'string' ? props.title.trim() : '';
+  const timestamp = Number(rawEvent.timestamp);
+  const ts = Number.isFinite(timestamp) && timestamp > 0 ? timestamp : Date.now();
+  const referrer = typeof props.referrer === 'string' ? props.referrer.slice(0, 512) : '';
+  const value = Number.isFinite(props.value) ? Number(props.value) : null;
+
+  const utm = {
+    utm_source: typeof props.utm_source === 'string' ? props.utm_source.trim() : '',
+    utm_medium: typeof props.utm_medium === 'string' ? props.utm_medium.trim() : '',
+    utm_campaign: typeof props.utm_campaign === 'string' ? props.utm_campaign.trim() : '',
+    utm_content: typeof props.utm_content === 'string' ? props.utm_content.trim() : '',
+    utm_term: typeof props.utm_term === 'string' ? props.utm_term.trim() : '',
+  };
+
+  if (props.utm && typeof props.utm === 'object') {
+    Object.assign(utm, {
+      utm_source: typeof props.utm.utm_source === 'string' ? props.utm.utm_source.trim() : utm.utm_source,
+      utm_medium: typeof props.utm.utm_medium === 'string' ? props.utm.utm_medium.trim() : utm.utm_medium,
+      utm_campaign: typeof props.utm.utm_campaign === 'string' ? props.utm.utm_campaign.trim() : utm.utm_campaign,
+      utm_content: typeof props.utm.utm_content === 'string' ? props.utm.utm_content.trim() : utm.utm_content,
+      utm_term: typeof props.utm.utm_term === 'string' ? props.utm.utm_term.trim() : utm.utm_term,
+    });
+  }
+
+  return {
+    name,
+    slug,
+    title,
+    timestamp: ts,
+    referrer,
+    value,
+    utm,
+  };
+}
+
+function ensureMemoryStore() {
+  if (!global.__laffyEventsStore) {
+    global.__laffyEventsStore = {
+      byKey: new Map(),
+    };
+  }
+  return global.__laffyEventsStore;
+}
+
+function buildCompositeKey(name, slug) {
+  return `${name}::${slug || ''}`;
+}
+
+function recordEventInMemory(event, { viewerId }) {
+  const store = ensureMemoryStore();
+  const key = buildCompositeKey(event.name, event.slug);
+  const entry = store.byKey.get(key) || {
+    name: event.name,
+    slug: event.slug,
+    history: new Map(),
+    lastTimestamp: 0,
+    lastTitle: '',
+    lastMeta: null,
+    metaSets: {
+      sources: new Set(),
+      mediums: new Set(),
+      campaigns: new Set(),
+      contents: new Set(),
+      terms: new Set(),
+      referrers: new Set(),
+    },
+    viewersByDate: new Map(),
+    totalCount: 0,
+    totalValue: 0,
+  };
+
+  entry.totalCount += 1;
+  if (Number.isFinite(event.value)) {
+    entry.totalValue += event.value;
+  }
+
+  const dateKey = formatDateKey(new Date(event.timestamp));
+  const day = entry.history.get(dateKey) || { count: 0, value: 0 };
+  day.count += 1;
+  if (Number.isFinite(event.value)) {
+    day.value += event.value;
+  }
+  entry.history.set(dateKey, day);
+
+  if (viewerId) {
+    const viewers = entry.viewersByDate.get(dateKey) || new Set();
+    viewers.add(viewerId);
+    entry.viewersByDate.set(dateKey, viewers);
+  }
+
+  if (event.timestamp > entry.lastTimestamp) {
+    entry.lastTimestamp = event.timestamp;
+    entry.lastTitle = event.title;
+    entry.lastMeta = { ...event.utm, referrer: event.referrer };
+  }
+
+  if (event.utm.utm_source) entry.metaSets.sources.add(event.utm.utm_source);
+  if (event.utm.utm_medium) entry.metaSets.mediums.add(event.utm.utm_medium);
+  if (event.utm.utm_campaign) entry.metaSets.campaigns.add(event.utm.utm_campaign);
+  if (event.utm.utm_content) entry.metaSets.contents.add(event.utm.utm_content);
+  if (event.utm.utm_term) entry.metaSets.terms.add(event.utm.utm_term);
+  if (event.referrer) entry.metaSets.referrers.add(event.referrer);
+
+  store.byKey.set(key, entry);
+}
+
+async function logEventsInMemory(events, options = {}) {
+  events.forEach((event) => recordEventInMemory(event, options));
+}
+
+function encodePart(value) {
+  return encodeURIComponent(value || '');
+}
+
+function decodePart(value) {
+  try {
+    return decodeURIComponent(value || '');
+  } catch (error) {
+    return value || '';
+  }
+}
+
+async function logEventsWithRedis(events, { viewerId }) {
+  const { redisCommand } = await import('./redisClient');
+  for (const event of events) {
+    const dateKey = formatDateKey(new Date(event.timestamp));
+    const encodedName = encodePart(event.name);
+    const encodedSlug = encodePart(event.slug || '_');
+    const baseKey = `events:agg:${dateKey}:${encodedName}:${encodedSlug}`;
+    const indexKey = `events:index:${dateKey}`;
+    const uniqueKey = `${baseKey}:uniq`;
+
+    await redisCommand(['HINCRBY', baseKey, 'count', '1']);
+    await redisCommand(['HSET', baseKey, 'name', event.name]);
+    await redisCommand(['HSET', baseKey, 'slug', event.slug || '']);
+    if (event.title) {
+      await redisCommand(['HSET', baseKey, 'last_title', event.title]);
+    }
+    await redisCommand(['HSET', baseKey, 'last_ts', String(event.timestamp)]);
+    const metaPayload = JSON.stringify({
+      ...event.utm,
+      referrer: event.referrer,
+      value: event.value,
+    });
+    await redisCommand(['HSET', baseKey, 'last_meta', metaPayload]);
+    await redisCommand(['EXPIRE', baseKey, String(REDIS_TTL_SECONDS)]);
+    await redisCommand(['SADD', indexKey, baseKey]);
+    await redisCommand(['EXPIRE', indexKey, String(REDIS_TTL_SECONDS)]);
+    if (viewerId) {
+      await redisCommand(['PFADD', uniqueKey, viewerId]);
+      await redisCommand(['EXPIRE', uniqueKey, String(REDIS_TTL_SECONDS)]);
+    }
+  }
+}
+
+function summarizeMetaSets(entry) {
+  const mapSetToArray = (set) => Array.from(set).slice(0, 10);
+  return {
+    utm_sources: mapSetToArray(entry.metaSets?.sources || new Set()),
+    utm_mediums: mapSetToArray(entry.metaSets?.mediums || new Set()),
+    utm_campaigns: mapSetToArray(entry.metaSets?.campaigns || new Set()),
+    utm_contents: mapSetToArray(entry.metaSets?.contents || new Set()),
+    utm_terms: mapSetToArray(entry.metaSets?.terms || new Set()),
+    referrers: mapSetToArray(entry.metaSets?.referrers || new Set()),
+  };
+}
+
+function buildMemorySummary(range, filters = {}) {
+  const store = ensureMemoryStore();
+  const start = range.start;
+  const end = range.end;
+  const eventFilterSet = filters.names && filters.names.size ? filters.names : null;
+  const slugFilter = filters.slug || '';
+  const results = [];
+
+  for (const entry of store.byKey.values()) {
+    if (eventFilterSet && !eventFilterSet.has(entry.name)) continue;
+    if (slugFilter && entry.slug !== slugFilter) continue;
+
+    const history = [];
+    let total = 0;
+    let totalValue = 0;
+    const uniqueViewers = new Set();
+
+    for (const [dateKey, stats] of entry.history.entries()) {
+      const date = new Date(`${dateKey}T00:00:00Z`);
+      if (date < start || date > end) continue;
+      total += Number(stats.count) || 0;
+      totalValue += Number(stats.value) || 0;
+      history.push({ date: dateKey, count: Number(stats.count) || 0, value: Number(stats.value) || 0 });
+      const viewers = entry.viewersByDate.get(dateKey);
+      if (viewers && viewers.size) {
+        viewers.forEach((viewer) => uniqueViewers.add(viewer));
+      }
+    }
+
+    if (!total) continue;
+
+    history.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+
+    results.push({
+      id: buildCompositeKey(entry.name, entry.slug),
+      name: entry.name,
+      slug: entry.slug || '',
+      totalCount: total,
+      totalValue,
+      history,
+      lastSeenAt: entry.lastTimestamp || null,
+      lastTitle: entry.lastTitle || '',
+      lastMeta: entry.lastMeta || null,
+      uniqueCount: uniqueViewers.size,
+      metaSummary: summarizeMetaSets(entry),
+    });
+  }
+
+  results.sort((a, b) => b.totalCount - a.totalCount);
+  return results;
+}
+
+async function getSummaryFromRedis(range, filters = {}) {
+  const { redisCommand } = await import('./redisClient');
+  const start = range.start;
+  const end = range.end;
+  const eventFilterSet = filters.names && filters.names.size ? filters.names : null;
+  const slugFilter = filters.slug || '';
+  const aggregated = new Map();
+
+  const dates = eachDateBetween(start, end);
+
+  for (const dateKey of dates) {
+    let members = [];
+    try {
+      const raw = await redisCommand(['SMEMBERS', `events:index:${dateKey}`], { allowReadOnly: true });
+      members = Array.isArray(raw) ? raw : [];
+    } catch (error) {
+      members = [];
+    }
+
+    for (const memberKey of members) {
+      if (typeof memberKey !== 'string' || !memberKey.startsWith('events:agg:')) continue;
+      const parts = memberKey.split(':');
+      if (parts.length < 5) continue;
+      const encodedName = parts[3];
+      const encodedSlug = parts.slice(4).join(':');
+      const eventName = decodePart(encodedName);
+      const slug = decodePart(encodedSlug);
+      if (eventFilterSet && !eventFilterSet.has(eventName)) continue;
+      if (slugFilter && slug !== slugFilter) continue;
+
+      let count = 0;
+      let lastTs = 0;
+      let lastTitle = '';
+      let meta = null;
+      try {
+        const payload = await redisCommand(['HMGET', memberKey, 'count', 'last_ts', 'last_title', 'last_meta'], {
+          allowReadOnly: true,
+        });
+        if (Array.isArray(payload)) {
+          count = Number(payload[0]) || 0;
+          lastTs = Number(payload[1]) || 0;
+          lastTitle = typeof payload[2] === 'string' ? payload[2] : '';
+          if (typeof payload[3] === 'string' && payload[3]) {
+            try {
+              meta = JSON.parse(payload[3]);
+            } catch (error) {
+              meta = null;
+            }
+          }
+        }
+      } catch (error) {
+        count = 0;
+      }
+
+      if (!count) continue;
+
+      const composite = buildCompositeKey(eventName, slug === '_' ? '' : slug);
+      const entry = aggregated.get(composite) || {
+        id: composite,
+        name: eventName,
+        slug: slug === '_' ? '' : slug,
+        totalCount: 0,
+        totalValue: 0,
+        history: [],
+        lastSeenAt: 0,
+        lastTitle: '',
+        lastMeta: null,
+        uniqueKeys: new Set(),
+        metaSets: {
+          sources: new Set(),
+          mediums: new Set(),
+          campaigns: new Set(),
+          contents: new Set(),
+          terms: new Set(),
+          referrers: new Set(),
+        },
+      };
+
+      entry.totalCount += count;
+      if (meta && Number.isFinite(meta.value)) {
+        entry.totalValue += Number(meta.value);
+      }
+      entry.history.push({ date: dateKey, count, value: Number(meta?.value) || 0 });
+      if (lastTs && lastTs > entry.lastSeenAt) {
+        entry.lastSeenAt = lastTs;
+        entry.lastTitle = lastTitle || entry.lastTitle;
+        entry.lastMeta = meta;
+      }
+      if (meta?.utm_source) entry.metaSets.sources.add(meta.utm_source);
+      if (meta?.utm_medium) entry.metaSets.mediums.add(meta.utm_medium);
+      if (meta?.utm_campaign) entry.metaSets.campaigns.add(meta.utm_campaign);
+      if (meta?.utm_content) entry.metaSets.contents.add(meta.utm_content);
+      if (meta?.utm_term) entry.metaSets.terms.add(meta.utm_term);
+      if (meta?.referrer) entry.metaSets.referrers.add(meta.referrer);
+      entry.uniqueKeys.add(`${memberKey}:uniq`);
+      aggregated.set(composite, entry);
+    }
+  }
+
+  const entries = Array.from(aggregated.values());
+  entries.forEach((entry) => {
+    entry.history.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+  });
+  entries.sort((a, b) => b.totalCount - a.totalCount);
+
+  const limited = entries.slice(0, filters.limit || ENTRY_LIMIT);
+
+  for (const entry of limited) {
+    const uniqueKeys = Array.from(entry.uniqueKeys);
+    let uniqueCount = 0;
+    if (uniqueKeys.length === 1) {
+      try {
+        const result = await redisCommand(['PFCOUNT', uniqueKeys[0]], { allowReadOnly: true });
+        uniqueCount = Number(result) || 0;
+      } catch (error) {
+        uniqueCount = 0;
+      }
+    } else if (uniqueKeys.length > 1) {
+      const tempKey = `events:tmp:${Date.now()}:${Math.random().toString(16).slice(2)}`;
+      try {
+        await redisCommand(['PFMERGE', tempKey, ...uniqueKeys]);
+        const result = await redisCommand(['PFCOUNT', tempKey]);
+        uniqueCount = Number(result) || 0;
+      } catch (error) {
+        uniqueCount = 0;
+      } finally {
+        try {
+          await redisCommand(['DEL', tempKey]);
+        } catch (error) {
+          // ignore cleanup errors
+        }
+      }
+    }
+    entry.uniqueCount = uniqueCount;
+    entry.metaSummary = summarizeMetaSets(entry);
+  }
+
+  return limited.map((entry) => ({
+    id: entry.id,
+    name: entry.name,
+    slug: entry.slug,
+    totalCount: entry.totalCount,
+    totalValue: entry.totalValue,
+    history: entry.history,
+    lastSeenAt: entry.lastSeenAt || null,
+    lastTitle: entry.lastTitle || '',
+    lastMeta: entry.lastMeta || null,
+    uniqueCount: entry.uniqueCount || 0,
+    metaSummary: entry.metaSummary,
+  }));
+}
+
+export async function logEvents(rawEvents, options = {}) {
+  const events = Array.isArray(rawEvents)
+    ? rawEvents.map(sanitizeEvent).filter(Boolean)
+    : [];
+  if (!events.length) return;
+  const viewerId = typeof options.viewerId === 'string' ? options.viewerId : '';
+
+  const { hasUpstash } = await import('./redisClient');
+  if (hasUpstash()) {
+    try {
+      await logEventsWithRedis(events, { viewerId });
+      return;
+    } catch (error) {
+      console.warn('[events] Redis log failed, falling back to in-memory store', error);
+    }
+  }
+  await logEventsInMemory(events, { viewerId });
+}
+
+function resolveRange(options = {}) {
+  const startDate = normalizeDateInput(options.startDate);
+  const endDate = normalizeDateInput(options.endDate);
+  if (startDate && endDate && startDate <= endDate) {
+    const diffDays = Math.round((endDate - startDate) / (1000 * 60 * 60 * 24)) + 1;
+    const clamped = clampRangeDays(diffDays);
+    const adjustedEnd = new Date(startDate);
+    adjustedEnd.setUTCDate(startDate.getUTCDate() + (clamped - 1));
+    if (adjustedEnd < endDate) {
+      return { start: startDate, end: adjustedEnd };
+    }
+    return { start: startDate, end: endDate };
+  }
+  if (endDate && !startDate) {
+    const clamped = clampRangeDays(MAX_RANGE_DAYS);
+    const start = new Date(endDate);
+    start.setUTCDate(start.getUTCDate() - (clamped - 1));
+    return { start, end: endDate };
+  }
+  if (startDate && !endDate) {
+    const clamped = clampRangeDays(MAX_RANGE_DAYS);
+    const end = new Date(startDate);
+    end.setUTCDate(end.getUTCDate() + (clamped - 1));
+    return { start: startDate, end };
+  }
+  return getDefaultRange();
+}
+
+export async function getEventSummary(options = {}) {
+  const range = resolveRange(options);
+  const filters = {
+    names: Array.isArray(options.eventNames)
+      ? new Set(options.eventNames.filter((name) => typeof name === 'string' && name.trim()))
+      : options.eventName
+      ? new Set([options.eventName].filter((name) => typeof name === 'string' && name.trim()))
+      : new Set(),
+    slug: typeof options.slug === 'string' ? options.slug.trim() : '',
+    limit: Number.isFinite(options.limit) ? Math.max(1, Math.min(ENTRY_LIMIT, options.limit)) : ENTRY_LIMIT,
+  };
+
+  const { hasUpstash } = await import('./redisClient');
+  let entries = [];
+  if (hasUpstash()) {
+    try {
+      entries = await getSummaryFromRedis(range, filters);
+    } catch (error) {
+      console.warn('[events] Redis summary failed, falling back to in-memory data', error);
+      entries = buildMemorySummary(range, filters);
+    }
+  } else {
+    entries = buildMemorySummary(range, filters);
+  }
+
+  const limited = entries.slice(0, filters.limit);
+  const totals = limited.reduce(
+    (acc, entry) => ({
+      totalEvents: acc.totalEvents + (Number(entry.totalCount) || 0),
+      totalUnique: acc.totalUnique + (Number(entry.uniqueCount) || 0),
+    }),
+    { totalEvents: 0, totalUnique: 0 }
+  );
+
+  const eventNames = Array.from(new Set(limited.map((entry) => entry.name))).sort((a, b) => a.localeCompare(b));
+  const slugs = Array.from(new Set(limited.map((entry) => entry.slug).filter(Boolean))).sort((a, b) => a.localeCompare(b));
+
+  return {
+    entries: limited,
+    totals,
+    range: {
+      start: formatDateKey(range.start),
+      end: formatDateKey(range.end),
+    },
+    eventNames,
+    slugs,
+  };
+}


### PR DESCRIPTION
## 변경 사항
- Vercel Analytics 이벤트를 내부 수집 API로 동시에 전송하는 클라이언트 파이프라인과 큐를 추가했습니다.
- Redis/메모리 기반 이벤트 저장소와 관리자용 요약 API를 구현해 CSV 다운로드를 지원합니다.
- 관리자 분석/인사이트 화면에 이벤트 요약 카드, 테이블, 광고-이벤트 상관 분석 패널을 추가했습니다.

## 테스트
- `npm run lint` *(실패: 기존 코드 전반의 React import/PropTypes 규칙 위반 다수로 인해 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a94954548323be301ccc0386d067