### PR TITLE
관리자 메트릭 로딩 오류 수정

### DIFF
--- a/hooks/admin/useAnalyticsMetrics.js
+++ b/hooks/admin/useAnalyticsMetrics.js
@@ -146,7 +146,7 @@ export default function useAnalyticsMetrics({
 
       while (hasMore) {
         const params = new URLSearchParams();
-        chunkSlugs.forEach((slug) => params.append('slugs[]', slug));
+        chunkSlugs.forEach((slug) => params.append('slugs', slug));
         params.set('limit', String(BATCH_FETCH_LIMIT));
         if (cursor > 0) params.set('cursor', String(cursor));
         const res = await fetch(`/api/metrics/batch?${params.toString()}`);
@@ -231,11 +231,27 @@ export default function useAnalyticsMetrics({
         if (cancelled) return;
         setMetricsBySlug((prev) => {
           const next = { ...prev };
+
+          results.forEach(({ slug, metrics }) => {
+            if (!slug || !metrics) return;
+            const existing = next[slug] && typeof next[slug] === 'object' ? next[slug] : {};
+            next[slug] = {
+              ...existing,
+              ...metrics,
+            };
+          });
+
           batchResults.forEach((batch) => {
             Object.entries(batch).forEach(([slug, metrics]) => {
-              next[slug] = metrics;
+              if (!slug || !metrics) return;
+              const existing = next[slug] && typeof next[slug] === 'object' ? next[slug] : {};
+              next[slug] = {
+                ...existing,
+                ...metrics,
+              };
             });
           });
+
           return next;
         });
       } catch (error) {


### PR DESCRIPTION
## Summary
- 메트릭 배치 API 요청 시 쿼리 파라미터 이름을 수정하여 400 오류를 방지했습니다.
- 단건 메트릭 응답의 상세 데이터(히스토리·범위 합계 등)를 상태에 병합해 관리자 대시보드에 노출되도록 했습니다.

## Testing
- npm run lint (기존 규칙 문제로 실패)


------
https://chatgpt.com/codex/tasks/task_e_68d6bf490e50832397b6b0aa9e032a6e