### PR TITLE
feat: 히트맵 트래킹 파이프라인 초기 구현

### DIFF
--- a/components/x/slug/ContentDetailPage.jsx
+++ b/components/x/slug/ContentDetailPage.jsx
@@ -3,6 +3,7 @@ import { useTranslation } from "next-i18next";
 
 import { LikeButton, ShareButton, BookmarkButton } from "@/components/x/button";
 import { useLikes } from "@/hooks/useLikes";
+import useHeatmapTracker from "@/hooks/useHeatmapTracker";
 import { formatCount, formatRelativeTime, getOrientationClass } from "@/lib/formatters";
 import { loadFavorites } from "@/utils/storage";
 import VideoCard from "@/components/x/video/VideoCard";
@@ -37,6 +38,10 @@ export default function ContentDetailPage({
   const [serverCounts, setServerCounts] = useState({ views: null, likes: null });
   const [ctaHref, setCtaHref] = useState(SPONSOR_SMART_LINK_URL);
   const ctaRef = useRef(null);
+  const { containerRef: heatmapContainerRef } = useHeatmapTracker({
+    slug: meme?.slug,
+    enabled: Boolean(meme?.slug),
+  });
 
   if (!meme) return null;
 
@@ -191,17 +196,23 @@ export default function ContentDetailPage({
       )}
 
       <div className="min-h-screen bg-gradient-to-b from-slate-950 via-slate-900 to-slate-950">
-        <main className="mx-auto w-full max-w-3xl px-4 pb-20 pt-10 sm:px-6">
+        <main
+          ref={heatmapContainerRef}
+          className="mx-auto w-full max-w-3xl px-4 pb-20 pt-10 sm:px-6"
+          data-heatmap-section="root"
+        >
           <div className="mt-6 mb-6 text-center">
             <LogoText size={"4xl"}/>
           </div>
 
-          <CategoryNavigation
-            items={navItems}
-            activeKey={activeCategoryKey}
-            onItemClick={openSmartLink}
-            ariaLabel={t("nav.label", "navigation")}
-          />
+          <div data-heatmap-section="nav">
+            <CategoryNavigation
+              items={navItems}
+              activeKey={activeCategoryKey}
+              onItemClick={openSmartLink}
+              ariaLabel={t("nav.label", "navigation")}
+            />
+          </div>
 
           <article className="mt-6 space-y-7 rounded-3xl bg-slate-900/80 p-6 shadow-[0_30px_80px_-40px_rgba(15,23,42,0.9)] ring-1 ring-slate-800/70 sm:p-9">
             <header className="space-y-4">
@@ -214,16 +225,18 @@ export default function ContentDetailPage({
             </header>
 
             <div>
-              <VideoCard
-                poster={meme.poster}
-                title={meme.description}
-                aspect={mediaAspect}
-                slug={meme.slug}
-                disablePlay={disableVideo}
-                onEngagement={onPreviewEngaged}
-                durationSeconds={meme.durationSeconds}
-              />
-              <div className="mt-8 flex w-full justify-center">
+              <div data-heatmap-section="video">
+                <VideoCard
+                  poster={meme.poster}
+                  title={meme.description}
+                  aspect={mediaAspect}
+                  slug={meme.slug}
+                  disablePlay={disableVideo}
+                  onEngagement={onPreviewEngaged}
+                  durationSeconds={meme.durationSeconds}
+                />
+              </div>
+              <div className="mt-8 flex w-full justify-center" data-heatmap-section="cta">
                 <a
                   ref={ctaRef}
                   href={ctaHref}
@@ -238,7 +251,7 @@ export default function ContentDetailPage({
               </div>
             </div>
 
-            <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-4" data-heatmap-section="social">
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2">
                   <LikeButton

--- a/hooks/useHeatmapTracker.js
+++ b/hooks/useHeatmapTracker.js
@@ -1,0 +1,234 @@
+import { useEffect, useMemo, useRef } from 'react';
+
+const GRID_COLUMNS = 12;
+const GRID_ROWS = 8;
+const MAX_BUFFER_SAMPLES = 8;
+const FLUSH_INTERVAL_MS = 10000;
+const SCROLL_SAMPLE_INTERVAL_MS = 500;
+
+function clampRatio(value) {
+  if (!Number.isFinite(value)) return null;
+  const clamped = Math.max(0, Math.min(0.9999, value));
+  return clamped;
+}
+
+function computeCellIndex(xRatio, yRatio) {
+  const clampedX = clampRatio(xRatio);
+  const clampedY = clampRatio(yRatio);
+  if (clampedX === null || clampedY === null) return null;
+  const column = Math.min(GRID_COLUMNS - 1, Math.floor(clampedX * GRID_COLUMNS));
+  const row = Math.min(GRID_ROWS - 1, Math.floor(clampedY * GRID_ROWS));
+  return row * GRID_COLUMNS + column;
+}
+
+function resolveSectionId(target) {
+  if (!target || typeof target.closest !== 'function') return 'root';
+  const element = target.closest('[data-heatmap-section]');
+  if (!element) return 'root';
+  const value = element.getAttribute('data-heatmap-section');
+  return typeof value === 'string' && value.trim() ? value.trim() : 'root';
+}
+
+function bucketForDimension(value) {
+  if (!Number.isFinite(value) || value <= 0) return 'xs';
+  if (value < 480) return 'xs';
+  if (value < 768) return 'sm';
+  if (value < 1024) return 'md';
+  if (value < 1440) return 'lg';
+  return 'xl';
+}
+
+function getViewportBucket() {
+  if (typeof window === 'undefined') return 'unknown';
+  const width = Math.round(window.innerWidth || 0);
+  const height = Math.round(window.innerHeight || 0);
+  const dpr = window.devicePixelRatio || 1;
+  const widthBucket = bucketForDimension(width);
+  const heightBucket = bucketForDimension(height);
+  const roundedDpr = Math.max(1, Math.round(dpr * 10) / 10);
+  return `${widthBucket}x${heightBucket}@${roundedDpr}`;
+}
+
+function sendPayload(body) {
+  if (!body) return;
+  try {
+    const json = JSON.stringify(body);
+    const url = '/api/heatmap/record';
+    if (typeof navigator !== 'undefined' && typeof navigator.sendBeacon === 'function') {
+      const blob = new Blob([json], { type: 'application/json' });
+      if (navigator.sendBeacon(url, blob)) return;
+    }
+    if (typeof fetch === 'function') {
+      fetch(url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: json,
+        keepalive: true,
+      }).catch(() => {});
+    }
+  } catch {
+    // swallow
+  }
+}
+
+function normalizeSlug(slug) {
+  if (typeof slug !== 'string') return '';
+  const trimmed = slug.trim();
+  return trimmed || '';
+}
+
+export default function useHeatmapTracker({ slug, enabled = true } = {}) {
+  const containerRef = useRef(null);
+  const stateRef = useRef({
+    cells: new Map(),
+    sampleCount: 0,
+    lastFlushAt: 0,
+  });
+  const scrollTimerRef = useRef(null);
+
+  const normalizedSlug = useMemo(() => normalizeSlug(slug), [slug]);
+  const isActive = Boolean(enabled && normalizedSlug);
+
+  useEffect(() => {
+    stateRef.current.cells.clear();
+    stateRef.current.sampleCount = 0;
+    stateRef.current.lastFlushAt = 0;
+  }, [normalizedSlug]);
+
+  useEffect(() => {
+    if (!isActive) return undefined;
+    const container = containerRef.current;
+    if (!container) return undefined;
+
+    const state = stateRef.current;
+
+    const flush = (reason = 'interval') => {
+      if (!state.cells.size) return;
+      const payload = {
+        slug: normalizedSlug,
+        viewportBucket: getViewportBucket(),
+        reason,
+        cells: Array.from(state.cells.entries()).map(([key, count]) => {
+          const [eventType, sectionId, cellIndex] = key.split('|');
+          return {
+            eventType,
+            sectionId,
+            cell: Number(cellIndex),
+            count,
+          };
+        }),
+      };
+      state.cells.clear();
+      state.sampleCount = 0;
+      state.lastFlushAt = Date.now();
+      sendPayload(payload);
+    };
+
+    const queueSample = ({ eventType, sectionId, xRatio, yRatio }) => {
+      if (!normalizedSlug) return;
+      const cellIndex = computeCellIndex(xRatio, yRatio);
+      if (cellIndex === null) return;
+      const key = `${eventType}|${sectionId}|${cellIndex}`;
+      const prev = state.cells.get(key) || 0;
+      state.cells.set(key, prev + 1);
+      state.sampleCount += 1;
+      if (state.sampleCount >= MAX_BUFFER_SAMPLES) {
+        flush('threshold');
+      }
+    };
+
+    let pointerRaf = null;
+    let pendingPointerEvent = null;
+
+    const processPointerEvent = () => {
+      if (!pendingPointerEvent) return;
+      const event = pendingPointerEvent;
+      pendingPointerEvent = null;
+      const rect = container.getBoundingClientRect();
+      const width = rect.width;
+      const height = rect.height;
+      if (!width || !height) return;
+      const x = (event.clientX - rect.left) / width;
+      const y = (event.clientY - rect.top) / height;
+      if (!Number.isFinite(x) || !Number.isFinite(y)) return;
+      const sectionId = resolveSectionId(event.target);
+      queueSample({
+        eventType: event.type === 'pointerdown' ? 'pointerdown' : 'pointermove',
+        sectionId,
+        xRatio: x,
+        yRatio: y,
+      });
+    };
+
+    const handlePointer = (event) => {
+      pendingPointerEvent = event;
+      if (pointerRaf) return;
+      pointerRaf = window.requestAnimationFrame(() => {
+        pointerRaf = null;
+        processPointerEvent();
+      });
+    };
+
+    const processScroll = () => {
+      scrollTimerRef.current = null;
+      if (typeof window === 'undefined' || typeof document === 'undefined') return;
+      const doc = document.documentElement;
+      if (!doc) return;
+      const scrollY = window.scrollY || window.pageYOffset || 0;
+      const maxScroll = Math.max(1, doc.scrollHeight - window.innerHeight);
+      const yRatio = clampRatio(scrollY / maxScroll);
+      if (yRatio === null) return;
+      queueSample({
+        eventType: 'scroll',
+        sectionId: 'scroll',
+        xRatio: 0.5,
+        yRatio,
+      });
+    };
+
+    const handleScroll = () => {
+      if (scrollTimerRef.current) return;
+      scrollTimerRef.current = window.setTimeout(processScroll, SCROLL_SAMPLE_INTERVAL_MS);
+    };
+
+    const handleVisibility = () => {
+      if (document.visibilityState === 'hidden') {
+        flush('hidden');
+      }
+    };
+
+    const handlePageHide = () => {
+      flush('pagehide');
+    };
+
+    const intervalId = window.setInterval(() => flush('interval'), FLUSH_INTERVAL_MS);
+
+    container.addEventListener('pointermove', handlePointer, { passive: true });
+    container.addEventListener('pointerdown', handlePointer, { passive: true });
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    window.addEventListener('visibilitychange', handleVisibility);
+    window.addEventListener('pagehide', handlePageHide);
+    window.addEventListener('beforeunload', handlePageHide);
+
+    return () => {
+      if (pointerRaf) {
+        window.cancelAnimationFrame(pointerRaf);
+        pointerRaf = null;
+      }
+      if (scrollTimerRef.current) {
+        window.clearTimeout(scrollTimerRef.current);
+        scrollTimerRef.current = null;
+      }
+      window.clearInterval(intervalId);
+      container.removeEventListener('pointermove', handlePointer);
+      container.removeEventListener('pointerdown', handlePointer);
+      window.removeEventListener('scroll', handleScroll);
+      window.removeEventListener('visibilitychange', handleVisibility);
+      window.removeEventListener('pagehide', handlePageHide);
+      window.removeEventListener('beforeunload', handlePageHide);
+      flush('cleanup');
+    };
+  }, [isActive, normalizedSlug]);
+
+  return { containerRef };
+}

--- a/pages/api/heatmap/record.js
+++ b/pages/api/heatmap/record.js
@@ -1,0 +1,37 @@
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).end();
+  }
+
+  try {
+    const { slug, viewportBucket, cells } = req.body || {};
+    const { ensureViewerId } = await import('../../../utils/viewerSession');
+    const sessionId = ensureViewerId(req, res);
+
+    const normalizedSlug = typeof slug === 'string' ? slug.trim() : '';
+    if (!normalizedSlug) {
+      return res.status(400).json({ error: 'Missing slug' });
+    }
+
+    const payloadCells = Array.isArray(cells) ? cells : [];
+    const { recordHeatmapSamples } = await import('../../../utils/heatmapStore');
+    const result = await recordHeatmapSamples({
+      slug: normalizedSlug,
+      viewportBucket,
+      cells: payloadCells,
+      sessionId,
+    });
+
+    return res.status(200).json({
+      ok: true,
+      slug: normalizedSlug,
+      stored: Boolean(result?.stored),
+      backend: result?.backend || null,
+      count: result?.count || 0,
+    });
+  } catch (error) {
+    console.error('[heatmap] record handler failed', error);
+    return res.status(500).json({ error: 'Failed to record heatmap samples' });
+  }
+}

--- a/utils/heatmapStore.js
+++ b/utils/heatmapStore.js
@@ -1,0 +1,189 @@
+const HEATMAP_KEY_PREFIX = 'heatmap:';
+
+function normalizeSlug(slug) {
+  if (typeof slug !== 'string') return '';
+  const trimmed = slug.trim();
+  return trimmed || '';
+}
+
+function normalizeBucket(bucket) {
+  if (typeof bucket !== 'string') return '';
+  const trimmed = bucket.trim();
+  return trimmed || '';
+}
+
+function normalizeSectionId(value) {
+  if (typeof value !== 'string') return 'root';
+  const trimmed = value.trim();
+  if (!trimmed) return 'root';
+  return trimmed.slice(0, 64);
+}
+
+function normalizeEventType(value) {
+  if (typeof value !== 'string') return 'pointer';
+  const trimmed = value.trim();
+  if (!trimmed) return 'pointer';
+  return trimmed.slice(0, 32);
+}
+
+function normalizeCellIndex(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num) || num < 0) return null;
+  return Math.round(num);
+}
+
+function normalizeCount(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num) || num <= 0) return null;
+  return Math.max(1, Math.round(num));
+}
+
+function redisKeyForSlug(slug) {
+  return `${HEATMAP_KEY_PREFIX}${slug}`;
+}
+
+function memoryStore() {
+  if (!global.__heatmapMemoryStore) {
+    global.__heatmapMemoryStore = new Map();
+  }
+  return global.__heatmapMemoryStore;
+}
+
+function memoryKey(slug, field) {
+  return `${slug}::${field}`;
+}
+
+function sanitizeCells(cells) {
+  if (!Array.isArray(cells)) return [];
+  const sanitized = [];
+  cells.forEach((cell) => {
+    const cellIndex = normalizeCellIndex(cell?.cell ?? cell?.index ?? cell?.id);
+    const count = normalizeCount(cell?.count ?? cell?.value);
+    if (cellIndex === null || count === null) return;
+    const sectionId = normalizeSectionId(cell?.sectionId ?? cell?.section ?? cell?.bucket);
+    const eventType = normalizeEventType(cell?.eventType ?? cell?.type);
+    sanitized.push({ cellIndex, count, sectionId, eventType });
+  });
+  return sanitized;
+}
+
+async function hasRedis() {
+  const { hasUpstash } = await import('./redisClient');
+  return hasUpstash();
+}
+
+async function sendRedisIncrements(slug, bucket, increments) {
+  if (!increments.length) return false;
+  const { redisCommand } = await import('./redisClient');
+  const key = redisKeyForSlug(slug);
+  const tasks = increments.map((item) => {
+    const field = `${bucket}:${item.eventType}:${item.sectionId}:${item.cellIndex}`;
+    return redisCommand(['HINCRBY', key, field, item.count]).catch((error) => {
+      console.warn('[heatmap] redis increment failed', error);
+      return null;
+    });
+  });
+  const results = await Promise.all(tasks);
+  return results.some((value) => value !== null && value !== undefined);
+}
+
+function applyMemoryIncrements(slug, bucket, increments) {
+  if (!increments.length) return false;
+  const store = memoryStore();
+  let changed = false;
+  increments.forEach((item) => {
+    const field = `${bucket}:${item.eventType}:${item.sectionId}:${item.cellIndex}`;
+    const key = memoryKey(slug, field);
+    const prev = store.get(key) || 0;
+    store.set(key, prev + item.count);
+    changed = true;
+  });
+  return changed;
+}
+
+export async function recordHeatmapSamples({ slug, viewportBucket, cells, sessionId } = {}) {
+  const normalizedSlug = normalizeSlug(slug);
+  const bucket = normalizeBucket(viewportBucket) || 'default';
+  const normalizedCells = sanitizeCells(cells);
+
+  if (!normalizedSlug || !normalizedCells.length) {
+    return { stored: false, backend: null, count: 0 };
+  }
+
+  const totalCount = normalizedCells.reduce((sum, item) => sum + item.count, 0);
+
+  if (await hasRedis()) {
+    try {
+      const persisted = await sendRedisIncrements(normalizedSlug, bucket, normalizedCells);
+      if (persisted) {
+        return { stored: true, backend: 'redis', count: totalCount };
+      }
+    } catch (error) {
+      console.warn('[heatmap] redis write failed, falling back to memory', error);
+    }
+  }
+
+  const persisted = applyMemoryIncrements(normalizedSlug, bucket, normalizedCells);
+  return { stored: persisted, backend: 'memory', count: totalCount };
+}
+
+export async function getHeatmapSnapshot({ slug, viewportBucket } = {}) {
+  const normalizedSlug = normalizeSlug(slug);
+  if (!normalizedSlug) return { slug: '', bucket: '', cells: [] };
+  const bucket = normalizeBucket(viewportBucket);
+
+  if (await hasRedis()) {
+    try {
+      const { redisCommand } = await import('./redisClient');
+      const key = redisKeyForSlug(normalizedSlug);
+      const raw = await redisCommand(['HGETALL', key], { allowReadOnly: true });
+      const cells = [];
+      if (Array.isArray(raw)) {
+        for (let i = 0; i < raw.length; i += 2) {
+          const field = raw[i];
+          const countRaw = raw[i + 1];
+          if (typeof field !== 'string') continue;
+          const parts = field.split(':');
+          if (parts.length < 4) continue;
+          const [fieldBucket, eventType, sectionId, cellIndexRaw] = parts;
+          if (bucket && bucket !== fieldBucket) continue;
+          const count = Number(countRaw);
+          if (!Number.isFinite(count)) continue;
+          const cellIndex = Number(cellIndexRaw);
+          if (!Number.isFinite(cellIndex)) continue;
+          cells.push({
+            bucket: fieldBucket,
+            eventType,
+            sectionId,
+            cell: cellIndex,
+            count,
+          });
+        }
+      }
+      return { slug: normalizedSlug, bucket: bucket || null, cells };
+    } catch (error) {
+      console.warn('[heatmap] redis read failed, falling back to memory', error);
+    }
+  }
+
+  const store = memoryStore();
+  const cells = [];
+  store.forEach((count, key) => {
+    const [keySlug, field] = key.split('::');
+    if (keySlug !== normalizedSlug) return;
+    const parts = field.split(':');
+    if (parts.length < 4) return;
+    const [fieldBucket, eventType, sectionId, cellIndexRaw] = parts;
+    if (bucket && bucket !== fieldBucket) return;
+    const cellIndex = Number(cellIndexRaw);
+    if (!Number.isFinite(cellIndex)) return;
+    cells.push({
+      bucket: fieldBucket,
+      eventType,
+      sectionId,
+      cell: cellIndex,
+      count,
+    });
+  });
+  return { slug: normalizedSlug, bucket: bucket || null, cells };
+}


### PR DESCRIPTION
## 요약
- 콘텐츠 상세 페이지에서 신규 useHeatmapTracker 훅을 연결해 섹션별 포인터·스크롤 이벤트를 그리드로 샘플링하도록 구성했습니다.
- 샘플 버퍼를 /api/heatmap/record 엔드포인트로 전송하고, 세션 쿠키를 보장한 뒤 heatmapStore를 통해 Redis/메모리 백엔드에 누적합니다.
- heatmapStore는 향후 관리자 분석을 위해 누적 스냅샷 조회 함수도 제공하여 후속 UI에서 재사용할 수 있도록 했습니다.

## 테스트
- `npm run lint` *(기존 프로젝트 전반의 PropTypes 규칙 미준수로 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d1a4d98c8323906fd8e0ac626fae