### PR TITLE
feat: bootstrap heatmap tracking pipeline

### DIFF
--- a/components/admin/heatmap/HeatmapBreakdown.jsx
+++ b/components/admin/heatmap/HeatmapBreakdown.jsx
@@ -1,0 +1,100 @@
+function RatioCell({ count, total }) {
+  const ratio = total > 0 ? (count / total) * 100 : 0;
+  return (
+    <span className="text-xs text-slate-400">
+      {ratio.toFixed(ratio >= 10 ? 1 : 2)}%
+    </span>
+  );
+}
+
+function BreakdownTable({ title, rows, total, getLabel }) {
+  return (
+    <div className="flex flex-col gap-3 rounded-xl border border-slate-800/70 bg-slate-950/70 p-4">
+      <div>
+        <h3 className="text-base font-semibold text-white">{title}</h3>
+        <p className="text-xs text-slate-400">{rows.length ? '상위 8개 항목을 표시합니다.' : '데이터가 아직 없습니다.'}</p>
+      </div>
+      <table className="w-full text-left text-sm text-slate-200">
+        <tbody>
+          {rows.slice(0, 8).map((row) => (
+            <tr key={getLabel(row)} className="border-t border-slate-800/60 first:border-t-0">
+              <td className="py-2 pr-2 font-medium text-white/90">{getLabel(row)}</td>
+              <td className="py-2 pr-2 text-right text-slate-200">
+                {row.count.toLocaleString('ko-KR')}
+              </td>
+              <td className="py-2 text-right">
+                <RatioCell count={row.count} total={total} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function CellTable({ cells, total }) {
+  return (
+    <div className="flex flex-col gap-3 rounded-xl border border-slate-800/70 bg-slate-950/70 p-4">
+      <div>
+        <h3 className="text-base font-semibold text-white">상위 셀</h3>
+        <p className="text-xs text-slate-400">
+          히트맵 상에서 가장 이벤트가 많이 발생한 6개 셀입니다.
+        </p>
+      </div>
+      <table className="w-full text-left text-sm text-slate-200">
+        <thead>
+          <tr className="text-xs uppercase tracking-[0.2em] text-slate-400">
+            <th className="py-2 pr-2">셀</th>
+            <th className="py-2 pr-2 text-right">카운트</th>
+            <th className="py-2 text-right">비중</th>
+          </tr>
+        </thead>
+        <tbody>
+          {cells.length === 0 ? (
+            <tr>
+              <td colSpan={3} className="py-4 text-center text-sm text-slate-400">
+                데이터가 아직 없습니다.
+              </td>
+            </tr>
+          ) : (
+            cells.map((cell) => {
+              const label = `${cell.row + 1}행 ${cell.col + 1}열`;
+              return (
+                <tr key={`${cell.row}-${cell.col}`} className="border-t border-slate-800/60 first:border-t-0">
+                  <td className="py-2 pr-2 text-white/90">{label}</td>
+                  <td className="py-2 pr-2 text-right text-slate-200">
+                    {cell.count.toLocaleString('ko-KR')}
+                  </td>
+                  <td className="py-2 text-right">
+                    <RatioCell count={cell.count} total={total} />
+                  </td>
+                </tr>
+              );
+            })
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default function HeatmapBreakdown({ stats }) {
+  return (
+    <div className="grid gap-4 lg:grid-cols-3">
+      <BreakdownTable
+        title="섹션별 분포"
+        rows={stats.sections}
+        total={stats.totalCount}
+        getLabel={(row) => row.section}
+      />
+      <BreakdownTable
+        title="이벤트 타입"
+        rows={stats.types}
+        total={stats.totalCount}
+        getLabel={(row) => row.type}
+      />
+      <CellTable cells={stats.topCells} total={stats.totalCount} />
+    </div>
+  );
+}

--- a/components/admin/heatmap/HeatmapGridView.jsx
+++ b/components/admin/heatmap/HeatmapGridView.jsx
@@ -1,0 +1,82 @@
+function formatTitle({ row, col, count, section, type }) {
+  const sectionLabel = section ? section : '섹션 미지정';
+  const typeLabel = type ? type : 'generic';
+  return `${row + 1}행 ${col + 1}열 | ${sectionLabel} · ${typeLabel} | ${count.toLocaleString('ko-KR')}회`;
+}
+
+export default function HeatmapGridView({ grid, maxCount, loading, error, cellSummaries }) {
+  const templateColumns = `repeat(${grid.cols}, minmax(0, 1fr))`;
+  const templateRows = `repeat(${grid.rows}, minmax(0, 1fr))`;
+  const summaryMap = new Map();
+  (cellSummaries || []).forEach((summary) => {
+    const key = `${summary.row}-${summary.col}`;
+    summaryMap.set(key, summary);
+  });
+
+  return (
+    <div className="rounded-xl border border-slate-800/80 bg-slate-950/70 p-4 shadow-xl shadow-slate-950/30">
+      <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h3 className="text-lg font-semibold text-white">히트맵 시각화</h3>
+          <p className="text-xs text-slate-400">
+            셀은 12×{grid.rows} 그리드로 표시되며, 진한 영역일수록 이벤트가 집중된 지점을 의미합니다.
+          </p>
+        </div>
+        <div className="flex items-center gap-2 text-xs text-slate-400">
+          <span className="flex h-3 w-3 rounded-full bg-slate-700" aria-hidden />
+          <span>낮은 강도</span>
+          <span className="flex h-3 w-12 rounded-full bg-gradient-to-r from-orange-500 via-rose-500 to-red-600" aria-hidden />
+          <span>높은 강도</span>
+        </div>
+      </div>
+
+      {error ? (
+        <div className="rounded-lg border border-red-500/40 bg-red-950/40 p-4 text-sm text-red-200">{error}</div>
+      ) : (
+        <div
+          className="grid gap-[3px] rounded-lg border border-slate-800/60 bg-slate-950/70 p-3"
+          style={{ gridTemplateColumns: templateColumns, gridTemplateRows: templateRows }}
+        >
+          {grid.counts.map((rowCounts, rowIndex) =>
+            rowCounts.map((cellCount, colIndex) => {
+              const intensity = maxCount > 0 ? cellCount / maxCount : 0;
+              const alpha = intensity > 0 ? Math.min(0.85, 0.18 + intensity * 0.72) : 0.08;
+              const background = intensity
+                ? `linear-gradient(135deg, rgba(249,115,22,${alpha}) 0%, rgba(239,68,68,${alpha}) 100%)`
+                : 'rgba(15,23,42,0.75)';
+              const textVisible = intensity > 0.45;
+              const summary = summaryMap.get(`${rowIndex}-${colIndex}`);
+              const title = formatTitle({
+                row: rowIndex,
+                col: colIndex,
+                count: cellCount,
+                section: summary?.topSection?.id || '',
+                type: summary?.topType?.id || '',
+              });
+              return (
+                <div
+                  key={`${rowIndex}-${colIndex}`}
+                  className="flex items-center justify-center rounded-md border border-slate-900/40 text-[0.65rem] font-medium text-slate-200 transition hover:scale-[1.02] hover:border-indigo-400/60"
+                  style={{ background }}
+                  title={title}
+                >
+                  {loading ? (
+                    <span className="animate-pulse text-slate-500">…</span>
+                  ) : textVisible ? (
+                    <span>{cellCount.toLocaleString('ko-KR')}</span>
+                  ) : summary?.topSection ? (
+                    <span className="max-w-full truncate px-1 text-center text-[0.55rem] text-slate-200/70">
+                      {summary.topSection.id}
+                    </span>
+                  ) : (
+                    <span className="text-slate-400/40">{cellCount > 0 ? '•' : ''}</span>
+                  )}
+                </div>
+              );
+            })
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/admin/heatmap/HeatmapPanel.jsx
+++ b/components/admin/heatmap/HeatmapPanel.jsx
@@ -1,0 +1,45 @@
+import { useMemo } from 'react';
+import HeatmapToolbar from './HeatmapToolbar';
+import HeatmapSummary from './HeatmapSummary';
+import HeatmapGridView from './HeatmapGridView';
+import HeatmapBreakdown from './HeatmapBreakdown';
+
+export default function HeatmapPanel({ items, heatmap, formatNumber, formatDecimal }) {
+  const slugOptions = useMemo(() => {
+    if (!Array.isArray(items)) return [];
+    return items
+      .filter((item) => item?.slug)
+      .map((item) => ({
+        value: item.slug,
+        label: `${item.display?.cardTitle || item.title || item.slug} (${item.slug})`,
+      }));
+  }, [items]);
+
+  return (
+    <div className="space-y-6">
+      <HeatmapToolbar
+        slugOptions={slugOptions}
+        selectedSlug={heatmap.selectedSlug || ''}
+        onSlugChange={heatmap.setSelectedSlug}
+        bucketOptions={heatmap.bucketOptions}
+        selectedBucket={heatmap.selectedBucket || ''}
+        onBucketChange={heatmap.setSelectedBucket}
+        onRefresh={heatmap.refresh}
+        onExport={heatmap.exportCsv}
+        loading={heatmap.loading}
+      />
+
+      <HeatmapSummary stats={heatmap.stats} formatNumber={formatNumber} formatDecimal={formatDecimal} />
+
+      <HeatmapGridView
+        grid={heatmap.stats.grid}
+        maxCount={heatmap.stats.maxCount}
+        loading={heatmap.loading}
+        error={heatmap.error}
+        cellSummaries={heatmap.stats.cellSummaries}
+      />
+
+      <HeatmapBreakdown stats={heatmap.stats} />
+    </div>
+  );
+}

--- a/components/admin/heatmap/HeatmapSummary.jsx
+++ b/components/admin/heatmap/HeatmapSummary.jsx
@@ -1,0 +1,34 @@
+export default function HeatmapSummary({ stats, formatNumber, formatDecimal }) {
+  const cards = [
+    {
+      label: '총 샘플 수',
+      value: formatNumber(stats.totalCount || 0),
+      description: '히트맵에 누적된 이벤트 샘플의 총량',
+    },
+    {
+      label: '활성 섹션',
+      value: formatNumber(stats.sections.length || 0),
+      description: '데이터가 수집된 히트맵 섹션 개수',
+    },
+    {
+      label: '셀 평균 강도',
+      value: formatDecimal(stats.averagePerCell || 0, 3),
+      description: '셀당 평균 샘플 수 (그리드 전체 대비)',
+    },
+  ];
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-3">
+      {cards.map((card) => (
+        <div
+          key={card.label}
+          className="rounded-xl border border-slate-800/60 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 p-4 shadow-inner shadow-slate-950/50"
+        >
+          <p className="text-xs uppercase tracking-[0.25em] text-slate-500">{card.label}</p>
+          <p className="mt-2 text-2xl font-semibold text-white">{card.value}</p>
+          <p className="mt-1 text-xs text-slate-400">{card.description}</p>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/admin/heatmap/HeatmapToolbar.jsx
+++ b/components/admin/heatmap/HeatmapToolbar.jsx
@@ -1,0 +1,68 @@
+export default function HeatmapToolbar({
+  slugOptions,
+  selectedSlug,
+  onSlugChange,
+  bucketOptions,
+  selectedBucket,
+  onBucketChange,
+  onRefresh,
+  onExport,
+  loading,
+}) {
+  return (
+    <div className="flex flex-col gap-3 rounded-xl bg-slate-900/80 p-4 shadow-inner shadow-slate-900/40 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <label className="flex flex-col text-xs text-slate-400 sm:flex-row sm:items-center sm:gap-2">
+          <span className="uppercase tracking-[0.2em]">콘텐츠</span>
+          <select
+            value={selectedSlug}
+            onChange={(event) => onSlugChange?.(event.target.value)}
+            className="mt-1 rounded-lg border border-slate-700 bg-slate-950/60 px-3 py-2 text-sm text-slate-200 outline-none transition hover:border-slate-500 focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/50 sm:mt-0"
+          >
+            {slugOptions.length === 0 && <option value="">선택 가능한 슬러그가 없어요</option>}
+            {slugOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex flex-col text-xs text-slate-400 sm:flex-row sm:items-center sm:gap-2">
+          <span className="uppercase tracking-[0.2em]">뷰포트 버킷</span>
+          <select
+            value={selectedBucket}
+            onChange={(event) => onBucketChange?.(event.target.value)}
+            className="mt-1 rounded-lg border border-slate-700 bg-slate-950/60 px-3 py-2 text-sm text-slate-200 outline-none transition hover:border-slate-500 focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/50 sm:mt-0"
+          >
+            {bucketOptions.length === 0 && <option value="">데이터 없음</option>}
+            {bucketOptions.map((option) => (
+              <option key={option.key} value={option.key}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={onRefresh}
+          disabled={loading}
+          className="inline-flex items-center gap-2 rounded-lg border border-slate-700 bg-slate-950/60 px-4 py-2 text-sm font-medium text-slate-200 transition hover:border-indigo-400 hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {loading ? '불러오는 중…' : '새로고침'}
+        </button>
+        <button
+          type="button"
+          onClick={onExport}
+          disabled={loading || !selectedBucket}
+          className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-indigo-900/40 transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          CSV 내보내기
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/x/slug/CategoryNavigation.jsx
+++ b/components/x/slug/CategoryNavigation.jsx
@@ -1,6 +1,12 @@
 import clsx from "clsx";
 
-export default function CategoryNavigation({ items = [], activeKey = "", onItemClick, ariaLabel }) {
+export default function CategoryNavigation({
+  items = [],
+  activeKey = "",
+  onItemClick,
+  ariaLabel,
+  ...rest
+}) {
   if (!Array.isArray(items) || items.length === 0) {
     return null;
   }
@@ -9,6 +15,7 @@ export default function CategoryNavigation({ items = [], activeKey = "", onItemC
     <nav
       className="relative mx-auto mb-6 max-w-4xl"
       aria-label={ariaLabel || "Category navigation"}
+      {...rest}
     >
       <div className="relative rounded-3xl bg-slate-900/70 backdrop-blur-md px-4 py-3 shadow-xl ring-1 ring-white/10">
         <span

--- a/components/x/slug/ContentDetailPage.jsx
+++ b/components/x/slug/ContentDetailPage.jsx
@@ -3,6 +3,7 @@ import { useTranslation } from "next-i18next";
 
 import { LikeButton, ShareButton, BookmarkButton } from "@/components/x/button";
 import { useLikes } from "@/hooks/useLikes";
+import { useHeatmapTracker } from "@/hooks/useHeatmapTracker";
 import { formatCount, formatRelativeTime, getOrientationClass } from "@/lib/formatters";
 import { loadFavorites } from "@/utils/storage";
 import VideoCard from "@/components/x/video/VideoCard";
@@ -37,6 +38,7 @@ export default function ContentDetailPage({
   const [serverCounts, setServerCounts] = useState({ views: null, likes: null });
   const [ctaHref, setCtaHref] = useState(SPONSOR_SMART_LINK_URL);
   const ctaRef = useRef(null);
+  const { containerRef: heatmapRef } = useHeatmapTracker({ slug: meme?.slug });
 
   if (!meme) return null;
 
@@ -191,7 +193,11 @@ export default function ContentDetailPage({
       )}
 
       <div className="min-h-screen bg-gradient-to-b from-slate-950 via-slate-900 to-slate-950">
-        <main className="mx-auto w-full max-w-3xl px-4 pb-20 pt-10 sm:px-6">
+        <main
+          ref={heatmapRef}
+          className="mx-auto w-full max-w-3xl px-4 pb-20 pt-10 sm:px-6"
+          data-heatmap-section="page"
+        >
           <div className="mt-6 mb-6 text-center">
             <LogoText size={"4xl"}/>
           </div>
@@ -201,6 +207,7 @@ export default function ContentDetailPage({
             activeKey={activeCategoryKey}
             onItemClick={openSmartLink}
             ariaLabel={t("nav.label", "navigation")}
+            data-heatmap-section="nav"
           />
 
           <article className="mt-6 space-y-7 rounded-3xl bg-slate-900/80 p-6 shadow-[0_30px_80px_-40px_rgba(15,23,42,0.9)] ring-1 ring-slate-800/70 sm:p-9">
@@ -222,6 +229,7 @@ export default function ContentDetailPage({
                 disablePlay={disableVideo}
                 onEngagement={onPreviewEngaged}
                 durationSeconds={meme.durationSeconds}
+                data-heatmap-section="video"
               />
               <div className="mt-8 flex w-full justify-center">
                 <a
@@ -230,6 +238,7 @@ export default function ContentDetailPage({
                   target="_blank"
                   rel="noopener"
                   onClick={handleCtaClick}
+                  data-heatmap-section="cta"
                   className="inline-flex items-center gap-3 rounded-full bg-gradient-to-br from-indigo-500 via-purple-500 to-pink-500 px-7 py-3 text-base font-semibold text-white shadow-[0_16px_40px_rgba(79,70,229,0.45)] transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-200 hover:brightness-110 active:scale-95 sm:px-9 sm:py-3.5 sm:text-lg"
                   aria-label="스폰서 링크로 이동"
                 >

--- a/components/x/video/VideoCard.jsx
+++ b/components/x/video/VideoCard.jsx
@@ -33,6 +33,7 @@ export default function VideoCard({
     sponsorUrl = VIDEO_PREVIEW_SPONSOR_URL,
     trackingRoute = "x",
     trackingPlacement = "overlay",
+    ...rest
 }) {
     const containerRef = useRef(null);
     const videoElementRef = useRef(null);
@@ -258,6 +259,7 @@ export default function VideoCard({
                 aspect
             )}
             onClickCapture={handleFallbackClick}
+            {...rest}
         >
             {shouldShowFallback ? (
                 <div className="flex h-full w-full items-center justify-center bg-[radial-gradient(circle_at_center,_#6366f1_0%,_#0f172a_70%)] text-sm font-semibold text-slate-100">

--- a/hooks/admin/useHeatmapAnalytics.js
+++ b/hooks/admin/useHeatmapAnalytics.js
@@ -1,0 +1,297 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+const DEFAULT_GRID = Object.freeze({ cols: 12, rows: 8 });
+
+function ensureArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function formatBucketLabel(value) {
+  if (!value) return '알 수 없음';
+  if (value === 'default') return 'default (기본)';
+  return value;
+}
+
+function findInitialSlug(items) {
+  if (!Array.isArray(items)) return '';
+  const target = items.find((item) => item?.slug);
+  return target?.slug || '';
+}
+
+function deriveGridStats(bucket) {
+  const cells = ensureArray(bucket?.cells);
+  if (cells.length === 0) {
+    return {
+      grid: {
+        cols: DEFAULT_GRID.cols,
+        rows: DEFAULT_GRID.rows,
+        counts: Array.from({ length: DEFAULT_GRID.rows }, () =>
+          Array(DEFAULT_GRID.cols).fill(0)
+        ),
+      },
+      totalCount: 0,
+      maxCount: 0,
+      averagePerCell: 0,
+      sections: [],
+      types: [],
+      topCells: [],
+      cellSummaries: [],
+    };
+  }
+
+  const normalizedCells = cells
+    .map((cell) => ({
+      cell: Number(cell?.cell),
+      count: Math.max(0, Number(cell?.count) || 0),
+      section: typeof cell?.section === 'string' ? cell.section : 'root',
+      type: typeof cell?.type === 'string' ? cell.type : 'generic',
+    }))
+    .filter((cell) => Number.isFinite(cell.cell) && cell.cell >= 0 && cell.count > 0);
+
+  if (!normalizedCells.length) {
+    return {
+      grid: {
+        cols: DEFAULT_GRID.cols,
+        rows: DEFAULT_GRID.rows,
+        counts: Array.from({ length: DEFAULT_GRID.rows }, () =>
+          Array(DEFAULT_GRID.cols).fill(0)
+        ),
+      },
+      totalCount: 0,
+      maxCount: 0,
+      averagePerCell: 0,
+      sections: [],
+      types: [],
+      topCells: [],
+      cellSummaries: [],
+    };
+  }
+
+  const maxIndex = normalizedCells.reduce((max, cell) => Math.max(max, cell.cell), 0);
+  const rowCount = Math.max(DEFAULT_GRID.rows, Math.floor(maxIndex / DEFAULT_GRID.cols) + 1);
+  const gridCounts = Array.from({ length: rowCount }, () => Array(DEFAULT_GRID.cols).fill(0));
+  const sectionMap = new Map();
+  const typeMap = new Map();
+  const details = [];
+  const cellSummaryMap = new Map();
+
+  let totalCount = 0;
+  let maxCount = 0;
+
+  normalizedCells.forEach((cell) => {
+    const row = Math.floor(cell.cell / DEFAULT_GRID.cols);
+    const col = cell.cell % DEFAULT_GRID.cols;
+    if (row < 0 || row >= gridCounts.length || col < 0 || col >= DEFAULT_GRID.cols) {
+      return;
+    }
+    gridCounts[row][col] += cell.count;
+    totalCount += cell.count;
+    if (gridCounts[row][col] > maxCount) {
+      maxCount = gridCounts[row][col];
+    }
+    const sectionKey = cell.section || 'root';
+    const typeKey = cell.type || 'generic';
+    sectionMap.set(sectionKey, (sectionMap.get(sectionKey) || 0) + cell.count);
+    typeMap.set(typeKey, (typeMap.get(typeKey) || 0) + cell.count);
+    details.push({
+      index: cell.cell,
+      row,
+      col,
+      count: cell.count,
+      section: sectionKey,
+      type: typeKey,
+    });
+
+    const summaryKey = `${row}-${col}`;
+    const summary = cellSummaryMap.get(summaryKey) || {
+      row,
+      col,
+      count: 0,
+      sections: new Map(),
+      types: new Map(),
+    };
+    summary.count += cell.count;
+    summary.sections.set(sectionKey, (summary.sections.get(sectionKey) || 0) + cell.count);
+    summary.types.set(typeKey, (summary.types.get(typeKey) || 0) + cell.count);
+    cellSummaryMap.set(summaryKey, summary);
+  });
+
+  const averagePerCell =
+    gridCounts.length > 0 ? totalCount / (gridCounts.length * DEFAULT_GRID.cols) : 0;
+
+  const sections = Array.from(sectionMap.entries())
+    .map(([section, count]) => ({ section, count }))
+    .sort((a, b) => b.count - a.count);
+
+  const cellSummaries = Array.from(cellSummaryMap.values()).map((entry) => {
+    const sections = Array.from(entry.sections.entries()).sort((a, b) => b[1] - a[1]);
+    const typesList = Array.from(entry.types.entries()).sort((a, b) => b[1] - a[1]);
+    return {
+      row: entry.row,
+      col: entry.col,
+      count: entry.count,
+      topSection: sections.length ? { id: sections[0][0], count: sections[0][1] } : null,
+      topType: typesList.length ? { id: typesList[0][0], count: typesList[0][1] } : null,
+    };
+  });
+
+  const types = Array.from(typeMap.entries())
+    .map(([type, count]) => ({ type, count }))
+    .sort((a, b) => b.count - a.count);
+
+  const topCells = cellSummaries
+    .slice()
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 6);
+
+  return {
+    grid: {
+      cols: DEFAULT_GRID.cols,
+      rows: gridCounts.length,
+      counts: gridCounts,
+    },
+    totalCount,
+    maxCount,
+    averagePerCell,
+    sections,
+    types,
+    topCells,
+    cellSummaries,
+    rawCells: details,
+  };
+}
+
+export default function useHeatmapAnalytics({ enabled, token, items }) {
+  const [selectedSlug, setSelectedSlug] = useState(() => findInitialSlug(items));
+  const [selectedBucket, setSelectedBucket] = useState('');
+  const [snapshot, setSnapshot] = useState({ slug: '', buckets: [] });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [version, setVersion] = useState(0);
+
+  useEffect(() => {
+    setSelectedSlug((prev) => {
+      if (prev && items?.some?.((item) => item?.slug === prev)) {
+        return prev;
+      }
+      return findInitialSlug(items);
+    });
+  }, [items]);
+
+  const refresh = useCallback(() => {
+    setVersion((prev) => prev + 1);
+  }, []);
+
+  useEffect(() => {
+    if (!enabled || !selectedSlug) {
+      return undefined;
+    }
+
+    const controller = new AbortController();
+
+    const run = async () => {
+      setLoading(true);
+      setError('');
+      try {
+        const params = new URLSearchParams();
+        params.set('slug', selectedSlug);
+        if (token) params.set('token', token);
+        const res = await fetch(`/api/admin/heatmap/snapshot?${params.toString()}`, {
+          signal: controller.signal,
+        });
+        const json = await res.json().catch(() => ({}));
+        if (!res.ok) {
+          throw new Error(json?.error || '히트맵 데이터를 불러오지 못했어요.');
+        }
+        const buckets = ensureArray(json?.buckets);
+        setSnapshot({ slug: json?.slug || selectedSlug, buckets });
+
+        setSelectedBucket((prev) => {
+          if (prev && buckets.some((bucket) => bucket?.bucket === prev)) {
+            return prev;
+          }
+          const defaultBucket = buckets.find((bucket) => bucket?.bucket === 'default');
+          return defaultBucket?.bucket || (buckets[0]?.bucket || '');
+        });
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        setError(err?.message || '히트맵 데이터를 불러오지 못했어요.');
+        setSnapshot({ slug: selectedSlug, buckets: [] });
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    run();
+    return () => controller.abort();
+  }, [enabled, selectedSlug, token, version]);
+
+  const bucketOptions = useMemo(() => {
+    return snapshot.buckets.map((bucket) => ({
+      key: bucket?.bucket || 'unknown',
+      label: formatBucketLabel(bucket?.bucket || 'unknown'),
+    }));
+  }, [snapshot.buckets]);
+
+  const activeBucket = useMemo(() => {
+    if (!selectedBucket) return snapshot.buckets[0] || null;
+    return snapshot.buckets.find((bucket) => bucket?.bucket === selectedBucket) || null;
+  }, [selectedBucket, snapshot.buckets]);
+
+  const stats = useMemo(() => deriveGridStats(activeBucket), [activeBucket]);
+
+  const exportCsv = useCallback(() => {
+    if (!activeBucket) return;
+    const rows = [['cell', 'row', 'col', 'count', 'section', 'type']];
+    ensureArray(activeBucket?.cells)
+      .map((cell) => ({
+        index: Number(cell?.cell),
+        row: Math.floor(Number(cell?.cell) / stats.grid.cols),
+        col: Number(cell?.cell) % stats.grid.cols,
+        count: Number(cell?.count) || 0,
+        section: typeof cell?.section === 'string' ? cell.section : 'root',
+        type: typeof cell?.type === 'string' ? cell.type : 'generic',
+      }))
+      .filter((cell) => Number.isFinite(cell.index) && cell.index >= 0 && Number.isFinite(cell.count))
+      .sort((a, b) => b.count - a.count)
+      .forEach((cell) => {
+        rows.push([
+          String(cell.index),
+          String(cell.row),
+          String(cell.col),
+          String(cell.count),
+          String(cell.section || 'root'),
+          String(cell.type || 'generic'),
+        ]);
+      });
+    const csv = rows.map((row) => row.map((field) => `"${String(field).replace(/"/g, '""')}"`).join(',')).join('\n');
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    const bucketLabel = activeBucket?.bucket || 'bucket';
+    link.href = url;
+    link.setAttribute('download', `heatmap-${snapshot.slug || selectedSlug}-${bucketLabel}.csv`);
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }, [activeBucket, selectedSlug, snapshot.slug, stats]);
+
+  return {
+    selectedSlug,
+    setSelectedSlug,
+    selectedBucket,
+    setSelectedBucket,
+    snapshot,
+    bucketOptions,
+    stats,
+    loading,
+    error,
+    refresh,
+    exportCsv,
+  };
+}
+
+export { DEFAULT_GRID as HEATMAP_DEFAULT_GRID };

--- a/hooks/useHeatmapTracker.js
+++ b/hooks/useHeatmapTracker.js
@@ -1,0 +1,297 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+const DEFAULT_GRID = Object.freeze({ cols: 12, rows: 8 });
+const MAX_BUFFER_SAMPLES = 10;
+const FLUSH_INTERVAL_MS = 4000;
+const SCROLL_SAMPLE_INTERVAL_MS = 750;
+
+function clamp01(value) {
+  if (!Number.isFinite(value)) return 0;
+  if (value <= 0) return 0;
+  if (value >= 1) return 1;
+  return value;
+}
+
+function safeSectionId(target, container) {
+  if (!target || typeof target !== 'object') return 'root';
+  let node = target.nodeType === 1 ? target : target.parentElement;
+  while (node) {
+    if (node.dataset && typeof node.dataset.heatmapSection === 'string') {
+      const value = node.dataset.heatmapSection.trim();
+      if (value) return value.slice(0, 50);
+    }
+    if (node === container) break;
+    node = node.parentElement;
+  }
+  return 'root';
+}
+
+function resolveViewportBucket() {
+  if (typeof window === 'undefined') return 'ssr';
+  const width = Math.max(1, Math.floor(window.innerWidth || 0));
+  const height = Math.max(1, Math.floor(window.innerHeight || 0));
+  const density = Math.round((window.devicePixelRatio || 1) * 10) / 10;
+  const widthBucket = width <= 640 ? 'sm' : width <= 1024 ? 'md' : 'lg';
+  const heightBucket = height <= 700 ? 'short' : height <= 900 ? 'medium' : 'tall';
+  return `${widthBucket}-${heightBucket}-${width}x${height}-d${density}`;
+}
+
+function ensureSessionId() {
+  if (typeof window === 'undefined') return null;
+  const storageKey = 'laffy_heatmap_session';
+  try {
+    const storage = window.sessionStorage;
+    if (!storage) return null;
+    const existing = storage.getItem(storageKey);
+    if (existing && typeof existing === 'string') return existing;
+    const cryptoObj = window.crypto;
+    let generated = null;
+    if (cryptoObj && typeof cryptoObj.randomUUID === 'function') {
+      generated = cryptoObj.randomUUID().replace(/-/g, '');
+    } else {
+      generated = Math.random().toString(36).slice(2) + Date.now().toString(36);
+    }
+    if (generated) {
+      storage.setItem(storageKey, generated);
+    }
+    return generated;
+  } catch (error) {
+    return null;
+  }
+}
+
+function serializeSamples(buffer) {
+  const cells = [];
+  buffer.forEach((count, key) => {
+    if (!Number.isFinite(count) || count <= 0) return;
+    const [cellIndexStr, type, section] = key.split('|');
+    const cell = Number.parseInt(cellIndexStr, 10);
+    if (!Number.isFinite(cell)) return;
+    cells.push({ cell, type: type || 'generic', section: section || 'root', count: Math.round(count) });
+  });
+  return cells;
+}
+
+async function sendPayload(payload) {
+  const body = JSON.stringify(payload);
+  if (typeof navigator !== 'undefined' && typeof navigator.sendBeacon === 'function') {
+    try {
+      const blob = new Blob([body], { type: 'application/json' });
+      if (navigator.sendBeacon('/api/heatmap/record', blob)) return;
+    } catch (error) {
+      // swallow beacon errors and fallback to fetch
+    }
+  }
+
+  try {
+    await fetch('/api/heatmap/record', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body,
+      keepalive: true,
+    });
+  } catch (error) {
+    // ignore network errors
+  }
+}
+
+export function useHeatmapTracker(options = {}) {
+  const { slug, enabled = true, grid = DEFAULT_GRID } = options;
+  const [container, setContainer] = useState(null);
+  const containerRef = useCallback((node) => {
+    setContainer(node || null);
+  }, []);
+
+  const gridState = useMemo(() => {
+    const cols = Number.isFinite(grid?.cols) && grid.cols > 0 ? Math.floor(grid.cols) : DEFAULT_GRID.cols;
+    const rows = Number.isFinite(grid?.rows) && grid.rows > 0 ? Math.floor(grid.rows) : DEFAULT_GRID.rows;
+    return { cols, rows, total: cols * rows };
+  }, [grid]);
+
+  const bufferRef = useRef(new Map());
+  const sampleCountRef = useRef(0);
+  const flushTimerRef = useRef(null);
+  const rafRef = useRef(null);
+  const scrollTimerRef = useRef(null);
+  const sessionIdRef = useRef(null);
+
+  const clearTimers = useCallback(() => {
+    if (flushTimerRef.current) {
+      clearTimeout(flushTimerRef.current);
+      flushTimerRef.current = null;
+    }
+    if (scrollTimerRef.current) {
+      clearTimeout(scrollTimerRef.current);
+      scrollTimerRef.current = null;
+    }
+    if (rafRef.current && typeof cancelAnimationFrame === 'function') {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+  }, []);
+
+  const resetBuffer = useCallback(() => {
+    bufferRef.current = new Map();
+    sampleCountRef.current = 0;
+  }, []);
+
+  const flushBuffer = useCallback(
+    async (reason = 'interval') => {
+      if (!slug || !enabled) {
+        resetBuffer();
+        return;
+      }
+      const buffer = bufferRef.current;
+      if (!(buffer instanceof Map) || buffer.size === 0) {
+        resetBuffer();
+        return;
+      }
+      const cells = serializeSamples(buffer);
+      resetBuffer();
+      if (cells.length === 0) return;
+
+      const payload = {
+        slug,
+        viewportBucket: resolveViewportBucket(),
+        cells,
+        sessionId: sessionIdRef.current || null,
+        reason,
+        ts: Date.now(),
+      };
+      await sendPayload(payload);
+    },
+    [enabled, resetBuffer, slug]
+  );
+
+  const scheduleFlush = useCallback(
+    (reason) => {
+      if (sampleCountRef.current >= MAX_BUFFER_SAMPLES) {
+        flushBuffer(reason || 'sample_limit');
+        return;
+      }
+      if (flushTimerRef.current) return;
+      flushTimerRef.current = setTimeout(() => {
+        flushTimerRef.current = null;
+        flushBuffer('timer');
+      }, FLUSH_INTERVAL_MS);
+    },
+    [flushBuffer]
+  );
+
+  const pushSample = useCallback(
+    (sample) => {
+      if (!enabled || !slug) return;
+      if (!sample) return;
+      const cols = gridState.cols;
+      const rows = gridState.rows;
+      const x = clamp01(sample.xRatio ?? 0.5);
+      const y = clamp01(sample.yRatio ?? 0.5);
+      const column = Math.min(cols - 1, Math.floor(x * cols));
+      const row = Math.min(rows - 1, Math.floor(y * rows));
+      const cellIndex = row * cols + column;
+      const type = typeof sample.type === 'string' && sample.type ? sample.type.slice(0, 24) : 'generic';
+      const section = typeof sample.section === 'string' && sample.section ? sample.section.slice(0, 32) : 'root';
+      const key = `${cellIndex}|${type}|${section}`;
+      const current = bufferRef.current.get(key) || 0;
+      bufferRef.current.set(key, current + 1);
+      sampleCountRef.current += 1;
+      scheduleFlush('buffer');
+    },
+    [enabled, gridState.cols, gridState.rows, scheduleFlush, slug]
+  );
+
+  const processPointerEvent = useCallback(
+    (event, type) => {
+      if (!event || !enabled) return;
+      const viewportWidth = typeof window !== 'undefined' ? window.innerWidth || 1 : 1;
+      const viewportHeight = typeof window !== 'undefined' ? window.innerHeight || 1 : 1;
+      const xRatio = clamp01(event.clientX / Math.max(1, viewportWidth));
+      const yRatio = clamp01(event.clientY / Math.max(1, viewportHeight));
+      const section = safeSectionId(event.target, container);
+      pushSample({ type, xRatio, yRatio, section });
+    },
+    [container, enabled, pushSample]
+  );
+
+  const pointerHandler = useCallback(
+    (type) => (event) => {
+      if (!enabled) return;
+      if (rafRef.current && typeof cancelAnimationFrame === 'function') {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+      const handle = () => {
+        rafRef.current = null;
+        processPointerEvent(event, type);
+      };
+      if (typeof requestAnimationFrame === 'function') {
+        rafRef.current = requestAnimationFrame(handle);
+      } else {
+        setTimeout(handle, 16);
+      }
+    },
+    [enabled, processPointerEvent]
+  );
+
+  const handleScroll = useCallback(() => {
+    if (!enabled) return;
+    if (scrollTimerRef.current) return;
+    scrollTimerRef.current = setTimeout(() => {
+      scrollTimerRef.current = null;
+      const doc = typeof document !== 'undefined' ? document.documentElement : null;
+      if (!doc) return;
+      const scrollable = Math.max(1, doc.scrollHeight - (window.innerHeight || 0));
+      const yRatio = clamp01((window.scrollY || window.pageYOffset || 0) / scrollable);
+      pushSample({ type: 'scroll', xRatio: 0.5, yRatio, section: 'page' });
+    }, SCROLL_SAMPLE_INTERVAL_MS);
+  }, [enabled, pushSample]);
+
+  useEffect(() => {
+    if (!enabled || !slug) return undefined;
+    sessionIdRef.current = ensureSessionId();
+    return () => {
+      sessionIdRef.current = null;
+    };
+  }, [enabled, slug]);
+
+  useEffect(() => {
+    if (!enabled || !container) return undefined;
+
+    const moveListener = pointerHandler('pointermove');
+    const downListener = pointerHandler('pointerdown');
+    container.addEventListener('pointermove', moveListener, { passive: true });
+    container.addEventListener('pointerdown', downListener, { passive: true });
+    window.addEventListener('scroll', handleScroll, { passive: true });
+
+    const visibilityHandler = () => {
+      if (document.visibilityState === 'hidden') {
+        flushBuffer('hidden');
+      }
+    };
+    const pagehideHandler = () => flushBuffer('pagehide');
+
+    document.addEventListener('visibilitychange', visibilityHandler);
+    window.addEventListener('pagehide', pagehideHandler);
+    window.addEventListener('beforeunload', pagehideHandler);
+
+    return () => {
+      container.removeEventListener('pointermove', moveListener);
+      container.removeEventListener('pointerdown', downListener);
+      window.removeEventListener('scroll', handleScroll);
+      document.removeEventListener('visibilitychange', visibilityHandler);
+      window.removeEventListener('pagehide', pagehideHandler);
+      window.removeEventListener('beforeunload', pagehideHandler);
+      clearTimers();
+      flushBuffer('teardown');
+    };
+  }, [clearTimers, container, enabled, flushBuffer, handleScroll, pointerHandler, slug]);
+
+  useEffect(() => () => {
+    clearTimers();
+    flushBuffer('unmount');
+  }, [clearTimers, flushBuffer]);
+
+  return { containerRef };
+}
+
+export default useHeatmapTracker;

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -32,11 +32,14 @@ import useAdsterraStats, { ADSTERRA_ALL_PLACEMENTS_VALUE } from '../hooks/admin/
 import useEventAnalytics from '../hooks/admin/useEventAnalytics';
 import useAdminModals from '../hooks/admin/useAdminModals';
 import { downloadAnalyticsCsv } from '../components/admin/analytics/export/AnalyticsCsvExporter';
+import HeatmapPanel from '../components/admin/heatmap/HeatmapPanel';
+import useHeatmapAnalytics from '../hooks/admin/useHeatmapAnalytics';
 
 const NAV_ITEMS = [
   { key: 'uploads', label: '업로드 · 목록', requiresToken: false },
   { key: 'analytics', label: '분석', requiresToken: true },
   { key: 'insights', label: '광고 통합 인사이트', requiresToken: true },
+  { key: 'heatmap', label: '히트맵 분석', requiresToken: true },
 ];
 
 function getDefaultAdsterraDateRange() {
@@ -138,6 +141,12 @@ export default function AdminPage() {
     startDate: analyticsStartDate,
     endDate: analyticsEndDate,
     filters: { ...eventFilters, limit: 200 },
+  });
+
+  const heatmap = useHeatmapAnalytics({
+    enabled: hasToken && view === 'heatmap',
+    token,
+    items,
   });
 
   const fetchHistory = useCallback(
@@ -263,7 +272,7 @@ export default function AdminPage() {
   } = useAdminModals({ hasToken, queryString: qs, setItems, refresh });
 
   useEffect(() => {
-    if (!hasToken && (view === 'analytics' || view === 'insights')) {
+    if (!hasToken && (view === 'analytics' || view === 'insights' || view === 'heatmap')) {
       setView('uploads');
     }
   }, [hasToken, view]);
@@ -862,6 +871,15 @@ export default function AdminPage() {
               selectedPlacementId={adsterra.placementId}
             />
           </div>
+        )}
+
+        {view === 'heatmap' && (
+          <HeatmapPanel
+            items={items}
+            heatmap={heatmap}
+            formatNumber={formatNumber}
+            formatDecimal={formatDecimal}
+          />
         )}
       </div>
 

--- a/pages/api/admin/heatmap/snapshot.js
+++ b/pages/api/admin/heatmap/snapshot.js
@@ -1,0 +1,35 @@
+import { assertAdmin } from '../../_auth';
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  if (!assertAdmin(req, res)) return;
+
+  const slug = typeof req.query.slug === 'string' ? req.query.slug.trim() : '';
+  if (!slug) {
+    return res.status(400).json({ error: 'slug 파라미터를 입력해 주세요.' });
+  }
+
+  try {
+    const { getHeatmapSnapshot, normalizeHeatmapBucket } = await import('../../../../utils/heatmapStore');
+    const snapshot = await getHeatmapSnapshot(slug);
+    const requestedBucket = typeof req.query.bucket === 'string' ? req.query.bucket : '';
+    const normalizedBucket = requestedBucket ? normalizeHeatmapBucket(requestedBucket) : '';
+
+    let buckets = Array.isArray(snapshot?.buckets) ? snapshot.buckets : [];
+    if (normalizedBucket) {
+      buckets = buckets.filter((bucket) => bucket?.bucket === normalizedBucket);
+    }
+
+    return res.status(200).json({
+      slug: snapshot?.slug || slug,
+      buckets,
+    });
+  } catch (error) {
+    console.error('[admin/heatmap] snapshot failed', error);
+    return res.status(500).json({ error: '히트맵 데이터를 불러오지 못했어요.' });
+  }
+}

--- a/pages/api/heatmap/record.js
+++ b/pages/api/heatmap/record.js
@@ -1,0 +1,51 @@
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).end();
+  }
+
+  try {
+    const body = req.body || {};
+    const slug = typeof body.slug === 'string' ? body.slug.trim() : '';
+    if (!slug) {
+      return res.status(400).json({ error: 'Missing slug' });
+    }
+
+    const { ensureViewerId } = await import('../../../utils/viewerSession');
+    const viewerId = ensureViewerId(req, res);
+
+    const cells = Array.isArray(body.cells) ? body.cells : [];
+    if (cells.length === 0) {
+      return res.status(200).json({ ok: true, recorded: 0, slug });
+    }
+
+    const { recordHeatmapSamples, normalizeHeatmapBucket } = await import('../../../utils/heatmapStore');
+    const bucket = normalizeHeatmapBucket(body.viewportBucket);
+
+    const normalizedCells = cells.map((cell) => ({
+      cell: cell?.cell,
+      count: cell?.count,
+      type: cell?.type,
+      section: cell?.section,
+    }));
+
+    const sessionId = typeof body.sessionId === 'string' ? body.sessionId.trim().slice(0, 80) : null;
+    const reason = typeof body.reason === 'string' ? body.reason.trim().slice(0, 40) : null;
+    const tsValue = Number(body.ts);
+    const ts = Number.isFinite(tsValue) ? tsValue : Date.now();
+
+    const result = await recordHeatmapSamples(slug, {
+      bucket,
+      cells: normalizedCells,
+      viewerId,
+      sessionId,
+      reason,
+      timestamp: ts,
+    });
+
+    return res.status(200).json({ ok: true, slug, recorded: result.recorded || 0 });
+  } catch (error) {
+    console.error('[heatmap] record failed', error);
+    return res.status(500).json({ error: 'Failed to record heatmap' });
+  }
+}

--- a/utils/heatmapStore.js
+++ b/utils/heatmapStore.js
@@ -1,0 +1,198 @@
+const FIELD_DELIMITER = '|';
+const DEFAULT_BUCKET = 'default';
+
+function sanitizeSegment(value, fallback, maxLength = 48) {
+  if (typeof value !== 'string') return fallback;
+  const trimmed = value.trim();
+  if (!trimmed) return fallback;
+  const safe = trimmed.replace(/[^a-z0-9_\-\.]/gi, '').slice(0, maxLength);
+  return safe || fallback;
+}
+
+function sanitizeBucket(value) {
+  return sanitizeSegment(value, DEFAULT_BUCKET, 40);
+}
+
+export function normalizeHeatmapBucket(value) {
+  return sanitizeBucket(value);
+}
+
+function heatmapKey(slug) {
+  return `heatmap:${slug}`;
+}
+
+function normalizeCells(cells) {
+  if (!Array.isArray(cells)) return [];
+  const result = [];
+  for (const entry of cells) {
+    const index = Number(entry?.cell);
+    if (!Number.isFinite(index) || index < 0) continue;
+    const count = Number(entry?.count ?? 1);
+    if (!Number.isFinite(count) || count <= 0) continue;
+    const type = sanitizeSegment(entry?.type, 'generic', 24);
+    const section = sanitizeSegment(entry?.section, 'root', 32);
+    result.push({
+      cell: Math.floor(index),
+      count: Math.max(1, Math.round(count)),
+      type,
+      section,
+    });
+  }
+  return result;
+}
+
+function formatField(bucket, section, type, cell) {
+  const safeBucket = sanitizeBucket(bucket);
+  const safeSection = sanitizeSegment(section, 'root', 32);
+  const safeType = sanitizeSegment(type, 'generic', 24);
+  return `${safeBucket}${FIELD_DELIMITER}${safeSection}${FIELD_DELIMITER}${safeType}${FIELD_DELIMITER}${cell}`;
+}
+
+function parseFieldKey(field) {
+  if (typeof field !== 'string') return null;
+  const [bucket, section, type, cellStr] = field.split(FIELD_DELIMITER);
+  const cell = Number.parseInt(cellStr, 10);
+  if (!Number.isFinite(cell) || cell < 0) return null;
+  return {
+    bucket: sanitizeBucket(bucket),
+    section: sanitizeSegment(section, 'root', 32),
+    type: sanitizeSegment(type, 'generic', 24),
+    cell,
+  };
+}
+
+function mergeBucketCell(map, bucket, entry) {
+  const bucketKey = sanitizeBucket(bucket);
+  const bucketMap = map.get(bucketKey) || new Map();
+  const cellKey = `${entry.section}${FIELD_DELIMITER}${entry.type}${FIELD_DELIMITER}${entry.cell}`;
+  const current = bucketMap.get(cellKey) || { ...entry, count: 0 };
+  current.count += entry.count;
+  bucketMap.set(cellKey, current);
+  map.set(bucketKey, bucketMap);
+}
+
+function ensureMemoryState() {
+  if (!global.__heatmapMemState) {
+    global.__heatmapMemState = new Map();
+  }
+  return global.__heatmapMemState;
+}
+
+async function recordWithRedis(slug, bucket, cells) {
+  const { redisCommand } = await import('./redisClient');
+  const key = heatmapKey(slug);
+  let recorded = 0;
+  for (const cell of cells) {
+    const field = formatField(bucket, cell.section, cell.type, cell.cell);
+    try {
+      await redisCommand(['HINCRBY', key, field, cell.count]);
+      recorded += cell.count;
+    } catch (error) {
+      throw error;
+    }
+  }
+  return recorded;
+}
+
+async function recordWithMemory(slug, bucket, cells) {
+  const state = ensureMemoryState();
+  const slugMap = state.get(slug) || new Map();
+  const bucketKey = sanitizeBucket(bucket);
+  const bucketMap = slugMap.get(bucketKey) || new Map();
+  let recorded = 0;
+  for (const cell of cells) {
+    const field = formatField(bucketKey, cell.section, cell.type, cell.cell);
+    const current = bucketMap.get(field) || 0;
+    bucketMap.set(field, current + cell.count);
+    recorded += cell.count;
+  }
+  slugMap.set(bucketKey, bucketMap);
+  state.set(slug, slugMap);
+  return recorded;
+}
+
+async function loadFromRedis(slug) {
+  const { redisCommand } = await import('./redisClient');
+  const key = heatmapKey(slug);
+  const result = await redisCommand(['HGETALL', key], { allowReadOnly: true });
+  return Array.isArray(result) ? result : [];
+}
+
+async function loadFromMemory(slug) {
+  const state = ensureMemoryState();
+  const slugMap = state.get(slug);
+  if (!slugMap) return [];
+  const payload = [];
+  for (const [bucketKey, bucketMap] of slugMap.entries()) {
+    for (const [field, count] of bucketMap.entries()) {
+      payload.push(field, count);
+    }
+  }
+  return payload;
+}
+
+function aggregateEntries(entries) {
+  const buckets = new Map();
+  for (let i = 0; i < entries.length; i += 2) {
+    const field = entries[i];
+    const value = Number(entries[i + 1]);
+    if (!Number.isFinite(value) || value <= 0) continue;
+    const parsed = parseFieldKey(field);
+    if (!parsed) continue;
+    mergeBucketCell(buckets, parsed.bucket, {
+      cell: parsed.cell,
+      section: parsed.section,
+      type: parsed.type,
+      count: Math.round(value),
+    });
+  }
+  return Array.from(buckets.entries()).map(([bucket, cellMap]) => ({
+    bucket,
+    cells: Array.from(cellMap.values()).sort((a, b) => a.cell - b.cell),
+  }));
+}
+
+export async function recordHeatmapSamples(slug, options = {}) {
+  const normalizedSlug = typeof slug === 'string' ? slug.trim() : '';
+  if (!normalizedSlug) return { recorded: 0 };
+  const bucket = sanitizeBucket(options.bucket);
+  const cells = normalizeCells(options.cells);
+  if (cells.length === 0) return { recorded: 0 };
+
+  const { hasUpstash } = await import('./redisClient');
+  if (hasUpstash()) {
+    try {
+      const recorded = await recordWithRedis(normalizedSlug, bucket, cells);
+      return { recorded };
+    } catch (error) {
+      console.warn('[heatmap] Redis record failed, falling back to memory', error);
+    }
+  }
+
+  const recorded = await recordWithMemory(normalizedSlug, bucket, cells);
+  return { recorded };
+}
+
+export async function getHeatmapSnapshot(slug) {
+  const normalizedSlug = typeof slug === 'string' ? slug.trim() : '';
+  if (!normalizedSlug) return { slug: '', buckets: [] };
+
+  const { hasUpstash } = await import('./redisClient');
+  if (hasUpstash()) {
+    try {
+      const entries = await loadFromRedis(normalizedSlug);
+      return { slug: normalizedSlug, buckets: aggregateEntries(entries) };
+    } catch (error) {
+      console.warn('[heatmap] Redis fetch failed, falling back to memory', error);
+    }
+  }
+
+  const entries = await loadFromMemory(normalizedSlug);
+  return { slug: normalizedSlug, buckets: aggregateEntries(entries) };
+}
+
+export function __dangerousResetHeatmapStore() {
+  if (global.__heatmapMemState) {
+    global.__heatmapMemState = new Map();
+  }
+}


### PR DESCRIPTION
## 요약
- 콘텐츠 상세 페이지에 히트맵 수집 훅(useHeatmapTracker)을 연결하고 주요 영역에 데이터 속성을 지정했습니다.
- 히트맵 샘플을 버퍼링하여 `/api/heatmap/record`로 전송하는 클라이언트 훅과 서버 API, 저장소(heatmapStore)를 추가했습니다.
- VideoCard 및 카테고리 네비게이션 컴포넌트가 히트맵 섹션 메타데이터를 전달할 수 있도록 보완했습니다.

## 테스트
- `npm run lint` *(기존 린트 규칙 미설정으로 React in scope 등 다수 오류 발생)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d1a4d98c8323906fd8e0ac626fae