### PR TITLE
feat: admin 히트맵 분석 탭 추가

### DIFF
--- a/components/admin/heatmap/HeatmapBreakdown.jsx
+++ b/components/admin/heatmap/HeatmapBreakdown.jsx
@@ -1,0 +1,121 @@
+function renderEmpty(message) {
+  return <p className="py-6 text-sm text-slate-400">{message}</p>;
+}
+
+function formatPercent(ratio, formatter) {
+  if (!Number.isFinite(ratio)) return '0%';
+  if (typeof formatter === 'function') return formatter(ratio);
+  return `${(ratio * 100).toFixed(1)}%`;
+}
+
+export default function HeatmapBreakdown({ bucket, formatNumber, formatPercent: formatPercentProp }) {
+  const sections = Array.isArray(bucket?.sections) ? bucket.sections : [];
+  const types = Array.isArray(bucket?.types) ? bucket.types : [];
+  const topCells = Array.isArray(bucket?.topCells) ? bucket.topCells : [];
+
+  return (
+    <div className="grid gap-4 xl:grid-cols-3">
+      <div className="rounded-3xl border border-slate-800/80 bg-slate-950/80 p-4">
+        <h3 className="text-lg font-semibold text-white">섹션별 분포</h3>
+        <p className="mt-1 text-xs text-slate-400">히트맵 데이터가 집중된 UI 섹션을 확인하세요.</p>
+        <div className="mt-4 overflow-hidden rounded-2xl border border-slate-800/60 bg-slate-950/40">
+          <table className="min-w-full divide-y divide-slate-800/80 text-sm">
+            <thead className="bg-slate-900/80 text-left text-xs uppercase tracking-widest text-slate-300">
+              <tr>
+                <th className="px-4 py-3">섹션</th>
+                <th className="px-4 py-3 text-right">샘플 수</th>
+                <th className="px-4 py-3 text-right">비율</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-800/60 text-sm text-slate-200">
+              {sections.length === 0 && (
+                <tr>
+                  <td colSpan={3} className="px-4">
+                    {renderEmpty('섹션별 데이터가 아직 없어요.')}
+                  </td>
+                </tr>
+              )}
+              {sections.map((section) => (
+                <tr key={section.section} className="hover:bg-slate-900/60">
+                  <td className="px-4 py-3 font-medium text-slate-100">{section.section}</td>
+                  <td className="px-4 py-3 text-right">{formatNumber(section.count || 0)}</td>
+                  <td className="px-4 py-3 text-right">{formatPercent(section.ratio || 0, formatPercentProp)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div className="rounded-3xl border border-slate-800/80 bg-slate-950/80 p-4">
+        <h3 className="text-lg font-semibold text-white">상위 셀</h3>
+        <p className="mt-1 text-xs text-slate-400">집중도가 높은 좌표를 기준으로 상호작용 패턴을 분석해요.</p>
+        <div className="mt-4 overflow-hidden rounded-2xl border border-slate-800/60 bg-slate-950/40">
+          <table className="min-w-full divide-y divide-slate-800/80 text-sm">
+            <thead className="bg-slate-900/80 text-left text-xs uppercase tracking-widest text-slate-300">
+              <tr>
+                <th className="px-4 py-3">위치</th>
+                <th className="px-4 py-3">섹션</th>
+                <th className="px-4 py-3">유형</th>
+                <th className="px-4 py-3 text-right">샘플 수</th>
+                <th className="px-4 py-3 text-right">비율</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-800/60 text-sm text-slate-200">
+              {topCells.length === 0 && (
+                <tr>
+                  <td colSpan={5} className="px-4">
+                    {renderEmpty('상위 셀 데이터가 아직 없어요.')}
+                  </td>
+                </tr>
+              )}
+              {topCells.map((cell) => (
+                <tr key={`${cell.cell}-${cell.section}-${cell.type}`} className="hover:bg-slate-900/60">
+                  <td className="px-4 py-3 text-sm font-medium text-slate-100">
+                    행 {cell.rowLabel}, 열 {cell.columnLabel}
+                  </td>
+                  <td className="px-4 py-3">{cell.section}</td>
+                  <td className="px-4 py-3">{cell.type}</td>
+                  <td className="px-4 py-3 text-right">{formatNumber(cell.count || 0)}</td>
+                  <td className="px-4 py-3 text-right">{formatPercent(cell.ratio || 0, formatPercentProp)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div className="rounded-3xl border border-slate-800/80 bg-slate-950/80 p-4">
+        <h3 className="text-lg font-semibold text-white">이벤트 유형</h3>
+        <p className="mt-1 text-xs text-slate-400">포인터 이동, 클릭 등 이벤트 타입별 기여도를 확인합니다.</p>
+        <div className="mt-4 overflow-hidden rounded-2xl border border-slate-800/60 bg-slate-950/40">
+          <table className="min-w-full divide-y divide-slate-800/80 text-sm">
+            <thead className="bg-slate-900/80 text-left text-xs uppercase tracking-widest text-slate-300">
+              <tr>
+                <th className="px-4 py-3">유형</th>
+                <th className="px-4 py-3 text-right">샘플 수</th>
+                <th className="px-4 py-3 text-right">비율</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-800/60 text-sm text-slate-200">
+              {types.length === 0 && (
+                <tr>
+                  <td colSpan={3} className="px-4">
+                    {renderEmpty('이벤트 유형 데이터가 아직 없어요.')}
+                  </td>
+                </tr>
+              )}
+              {types.map((type) => (
+                <tr key={type.type} className="hover:bg-slate-900/60">
+                  <td className="px-4 py-3 font-medium text-slate-100">{type.type}</td>
+                  <td className="px-4 py-3 text-right">{formatNumber(type.count || 0)}</td>
+                  <td className="px-4 py-3 text-right">{formatPercent(type.ratio || 0, formatPercentProp)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/admin/heatmap/HeatmapGrid.jsx
+++ b/components/admin/heatmap/HeatmapGrid.jsx
@@ -1,0 +1,92 @@
+function blendChannel(start, end, ratio) {
+  const value = Math.round(start + (end - start) * ratio);
+  return Math.min(255, Math.max(0, value));
+}
+
+function colorForIntensity(intensity) {
+  const ratio = Math.max(0, Math.min(1, intensity || 0));
+  const start = { r: 15, g: 23, b: 42 };
+  const mid = { r: 59, g: 130, b: 246 };
+  const end = { r: 236, g: 72, b: 153 };
+
+  if (ratio <= 0.5) {
+    const local = ratio / 0.5;
+    const r = blendChannel(start.r, mid.r, local);
+    const g = blendChannel(start.g, mid.g, local);
+    const b = blendChannel(start.b, mid.b, local);
+    return `rgb(${r}, ${g}, ${b})`;
+  }
+
+  const local = (ratio - 0.5) / 0.5;
+  const r = blendChannel(mid.r, end.r, local);
+  const g = blendChannel(mid.g, end.g, local);
+  const b = blendChannel(mid.b, end.b, local);
+  return `rgb(${r}, ${g}, ${b})`;
+}
+
+export default function HeatmapGrid({ grid, cells, maxCount, formatNumber }) {
+  const rows = Number.isFinite(grid?.rows) ? grid.rows : 0;
+  const cols = Number.isFinite(grid?.cols) ? grid.cols : 0;
+  if (rows <= 0 || cols <= 0) {
+    return (
+      <div className="rounded-3xl border border-slate-800/80 bg-slate-950/80 p-6 text-center text-sm text-slate-400">
+        아직 누적된 히트맵 샘플이 없어요.
+      </div>
+    );
+  }
+
+  const cellMap = new Map();
+  if (Array.isArray(cells)) {
+    cells.forEach((cell) => {
+      const row = Number(cell?.row);
+      const column = Number(cell?.column);
+      if (!Number.isFinite(row) || !Number.isFinite(column)) return;
+      const key = `${row}:${column}`;
+      cellMap.set(key, cell);
+    });
+  }
+
+  const items = [];
+  for (let row = 0; row < rows; row += 1) {
+    for (let column = 0; column < cols; column += 1) {
+      const key = `${row}:${column}`;
+      const cell = cellMap.get(key);
+      const count = Number(cell?.count) || 0;
+      const ratio = maxCount > 0 ? count / maxCount : 0;
+      const background = colorForIntensity(ratio);
+      const label = count > 0 ? formatNumber(count) : '';
+      const section = cell?.section || 'root';
+      const type = cell?.type || 'generic';
+      const title = `셀 #${cell?.cell ?? row * cols + column}\n섹션: ${section}\n유형: ${type}\n샘플: ${count}`;
+
+      items.push(
+        <div
+          key={key}
+          className={`relative aspect-square w-full rounded-md border border-slate-900/80 shadow-inner shadow-black/30 transition-transform duration-200 ${
+            ratio >= 0.85 ? 'ring-2 ring-rose-400' : ratio >= 0.65 ? 'ring-1 ring-sky-400/80' : ''
+          }`}
+          style={{ backgroundColor: background }}
+          title={title}
+        >
+          {count > 0 && (
+            <div className="absolute inset-1 flex flex-col items-center justify-center rounded-md bg-slate-950/30 text-[10px] font-semibold uppercase tracking-wide text-slate-100">
+              <span>{label}</span>
+              <span className="mt-0.5 text-[9px] text-slate-200/80">{section}</span>
+            </div>
+          )}
+        </div>
+      );
+    }
+  }
+
+  return (
+    <div className="rounded-3xl border border-slate-800/80 bg-slate-950/80 p-4">
+      <div
+        className="grid gap-[3px]"
+        style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }}
+      >
+        {items}
+      </div>
+    </div>
+  );
+}

--- a/components/admin/heatmap/HeatmapPanel.jsx
+++ b/components/admin/heatmap/HeatmapPanel.jsx
@@ -1,0 +1,283 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import HeatmapGrid from './HeatmapGrid';
+import HeatmapBreakdown from './HeatmapBreakdown';
+
+function formatDefaultPercent(value) {
+  if (!Number.isFinite(value)) return '0%';
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+export default function HeatmapPanel({
+  slug,
+  onSlugChange,
+  items,
+  data,
+  loading,
+  error,
+  onRefresh,
+  formatNumber,
+  formatPercent = formatDefaultPercent,
+}) {
+  const [activeBucket, setActiveBucket] = useState('');
+  const slugOptions = useMemo(() => {
+    if (!Array.isArray(items)) return [];
+    return items
+      .filter((item) => item?.slug)
+      .map((item) => ({
+        slug: item.slug,
+        label: item.display?.socialTitle || item.display?.cardTitle || item.slug,
+      }));
+  }, [items]);
+
+  const buckets = Array.isArray(data?.buckets) ? data.buckets : [];
+
+  useEffect(() => {
+    if (!buckets.length) {
+      setActiveBucket('');
+      return;
+    }
+    setActiveBucket((prev) => {
+      if (prev && buckets.some((bucket) => bucket.bucket === prev)) {
+        return prev;
+      }
+      return buckets[0].bucket;
+    });
+  }, [buckets]);
+
+  const activeBucketData = useMemo(() => {
+    if (!buckets.length) return null;
+    return buckets.find((bucket) => bucket.bucket === activeBucket) || buckets[0];
+  }, [activeBucket, buckets]);
+
+  const totalSamples = activeBucketData?.totalCount || 0;
+  const maxCellCount = activeBucketData?.maxCount || 0;
+  const topSection = activeBucketData?.sections?.[0];
+  const topCell = activeBucketData?.topCells?.[0];
+
+  const handleBucketChange = useCallback((event) => {
+    setActiveBucket(event.target.value);
+  }, []);
+
+  const handleSlugInput = useCallback(
+    (event) => {
+      onSlugChange(event.target.value);
+    },
+    [onSlugChange]
+  );
+
+  const handleExport = useCallback(() => {
+    if (!activeBucketData || typeof window === 'undefined') return;
+    const rows = [
+      ['bucket', 'row', 'column', 'cell', 'section', 'type', 'count', 'ratio'],
+    ];
+    activeBucketData.cells.forEach((cell) => {
+      rows.push([
+        activeBucketData.bucket,
+        cell.rowLabel,
+        cell.columnLabel,
+        cell.cell,
+        cell.section,
+        cell.type,
+        cell.count,
+        Number.isFinite(cell.ratio) ? cell.ratio : 0,
+      ]);
+    });
+    const csv = rows
+      .map((row) =>
+        row
+          .map((value) => {
+            if (value === null || value === undefined) return '';
+            const stringValue = typeof value === 'number' ? value.toString() : String(value);
+            if (/[",\n]/.test(stringValue)) {
+              return `"${stringValue.replace(/"/g, '""')}"`;
+            }
+            return stringValue;
+          })
+          .join(',')
+      )
+      .join('\n');
+    const blob = new Blob([`\uFEFF${csv}`], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `heatmap-${slug || 'content'}-${activeBucketData.bucket}.csv`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }, [activeBucketData, slug]);
+
+  const isEmpty = !loading && !error && (!activeBucketData || activeBucketData.totalCount === 0);
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-3xl border border-indigo-500/40 bg-slate-950/80 p-6 shadow-inner shadow-indigo-500/20">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <h2 className="text-2xl font-bold text-white">히트맵 분석</h2>
+            <p className="mt-1 text-sm text-slate-400">
+              콘텐츠 상세 페이지에서 수집한 좌표 기반 이벤트를 시각화하고, 섹션/이벤트 유형별 분포를 분석할 수 있어요.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={onRefresh}
+              disabled={loading}
+              className="rounded-full border border-slate-700 bg-slate-900 px-4 py-2 text-sm font-semibold text-slate-200 transition hover:border-indigo-400 hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {loading ? '불러오는 중…' : '새로고침'}
+            </button>
+            <button
+              type="button"
+              onClick={handleExport}
+              disabled={!activeBucketData || activeBucketData.totalCount === 0}
+              className="rounded-full border border-emerald-500/40 bg-emerald-500/10 px-4 py-2 text-sm font-semibold text-emerald-200 transition hover:border-emerald-300 hover:bg-emerald-500/20 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              CSV 내보내기
+            </button>
+          </div>
+        </div>
+
+        <div className="mt-6 grid gap-4 lg:grid-cols-[2fr_1fr]">
+          <div>
+            <label htmlFor="heatmap-slug-input" className="text-xs uppercase tracking-[0.3em] text-slate-400">
+              콘텐츠 슬러그
+            </label>
+            <input
+              id="heatmap-slug-input"
+              type="text"
+              list="heatmap-slug-options"
+              value={slug}
+              onChange={handleSlugInput}
+              placeholder="예: funny-cat-video"
+              className="mt-2 w-full rounded-2xl border border-slate-800 bg-slate-950/80 px-4 py-2 text-sm text-white placeholder-slate-600 focus:border-indigo-400 focus:outline-none"
+            />
+            <datalist id="heatmap-slug-options">
+              {slugOptions.map((option) => (
+                <option key={option.slug} value={option.slug}>
+                  {option.label}
+                </option>
+              ))}
+            </datalist>
+            <p className="mt-2 text-xs text-slate-500">
+              업로드 목록과 연동된 슬러그를 자동 완성으로 선택하거나 직접 입력할 수 있어요.
+            </p>
+          </div>
+
+          <div>
+            <label htmlFor="heatmap-bucket-select" className="text-xs uppercase tracking-[0.3em] text-slate-400">
+              뷰포트 버킷
+            </label>
+            <select
+              id="heatmap-bucket-select"
+              value={activeBucket}
+              onChange={handleBucketChange}
+              className="mt-2 w-full rounded-2xl border border-slate-800 bg-slate-950/80 px-4 py-2 text-sm text-white focus:border-indigo-400 focus:outline-none"
+              disabled={!buckets.length}
+            >
+              {!buckets.length && <option value="">데이터 없음</option>}
+              {buckets.map((bucket) => (
+                <option key={bucket.bucket} value={bucket.bucket}>
+                  {bucket.bucket}
+                </option>
+              ))}
+            </select>
+            <p className="mt-2 text-xs text-slate-500">
+              해상도·기기 조합별로 자동 생성되는 버킷 단위로 데이터를 전환할 수 있어요.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {error && (
+        <div className="rounded-3xl border border-rose-500/40 bg-rose-500/10 p-4 text-sm text-rose-200">
+          {error}
+        </div>
+      )}
+
+      {!error && slug && (
+        <div className="space-y-6">
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+            <div className="rounded-3xl border border-slate-800/80 bg-slate-950/80 p-4">
+              <p className="text-xs uppercase tracking-[0.3em] text-slate-400">총 샘플 수</p>
+              <p className="mt-2 text-3xl font-bold text-white">{formatNumber(totalSamples)}</p>
+              <p className="mt-1 text-xs text-slate-500">선택된 버킷에 누적된 히트맵 이벤트 합계</p>
+            </div>
+            <div className="rounded-3xl border border-slate-800/80 bg-slate-950/80 p-4">
+              <p className="text-xs uppercase tracking-[0.3em] text-slate-400">최대 셀 강도</p>
+              <p className="mt-2 text-3xl font-bold text-white">{formatNumber(maxCellCount)}</p>
+              <p className="mt-1 text-xs text-slate-500">가장 많이 기록된 셀의 샘플 수</p>
+            </div>
+            <div className="rounded-3xl border border-slate-800/80 bg-slate-950/80 p-4">
+              <p className="text-xs uppercase tracking-[0.3em] text-slate-400">주요 섹션</p>
+              <p className="mt-2 text-xl font-bold text-emerald-200">{topSection ? topSection.section : '데이터 없음'}</p>
+              <p className="mt-1 text-xs text-slate-500">
+                기여도 {topSection ? formatPercent(topSection.ratio || 0) : '0%'}
+              </p>
+            </div>
+            <div className="rounded-3xl border border-slate-800/80 bg-slate-950/80 p-4">
+              <p className="text-xs uppercase tracking-[0.3em] text-slate-400">핫스팟 셀</p>
+              <p className="mt-2 text-xl font-bold text-sky-200">
+                {topCell ? `행 ${topCell.rowLabel}, 열 ${topCell.columnLabel}` : '데이터 없음'}
+              </p>
+              <p className="mt-1 text-xs text-slate-500">
+                샘플 {topCell ? formatNumber(topCell.count || 0) : '0'} · 비율{' '}
+                {topCell ? formatPercent(topCell.ratio || 0) : '0%'}
+              </p>
+            </div>
+          </div>
+
+          {loading && (
+            <div className="rounded-3xl border border-slate-800/80 bg-slate-950/80 p-8 text-center text-sm text-slate-400">
+              히트맵 데이터를 불러오는 중이에요…
+            </div>
+          )}
+
+          {!loading && isEmpty && (
+            <div className="rounded-3xl border border-slate-800/80 bg-slate-950/80 p-8 text-center text-sm text-slate-400">
+              아직 선택한 조건에 대한 히트맵 샘플이 없습니다.
+            </div>
+          )}
+
+          {!loading && !isEmpty && activeBucketData && (
+            <div className="space-y-6">
+              <div>
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                  <h3 className="text-lg font-semibold text-white">히트맵 시각화</h3>
+                  <div className="flex items-center gap-3 text-xs text-slate-400">
+                    <span>낮음</span>
+                    <div className="h-2 w-40 rounded-full bg-gradient-to-r from-indigo-500/50 via-sky-400 to-rose-500"></div>
+                    <span>높음</span>
+                  </div>
+                </div>
+                <p className="text-xs text-slate-500">
+                  좌표는 12×8 그리드로 정규화되어 있으며, 셀 색상이 짙을수록 이벤트가 많이 기록된 지점을 의미합니다.
+                </p>
+              </div>
+
+              <HeatmapGrid
+                grid={activeBucketData.grid}
+                cells={activeBucketData.cells}
+                maxCount={activeBucketData.maxCount}
+                formatNumber={formatNumber}
+              />
+
+              <HeatmapBreakdown
+                bucket={activeBucketData}
+                formatNumber={formatNumber}
+                formatPercent={formatPercent}
+              />
+            </div>
+          )}
+        </div>
+      )}
+
+      {!slug && !error && (
+        <div className="rounded-3xl border border-slate-800/80 bg-slate-950/80 p-8 text-center text-sm text-slate-400">
+          분석할 콘텐츠 슬러그를 먼저 선택해 주세요.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/admin/layout/AdminNav.jsx
+++ b/components/admin/layout/AdminNav.jsx
@@ -1,7 +1,7 @@
 export default function AdminNav({ items, activeView, onChange }) {
   return (
     <nav className="rounded-full bg-slate-900/60 p-1 shadow-inner shadow-black/40">
-      <div className="grid grid-cols-1 gap-1 sm:grid-cols-3">
+      <div className="flex flex-wrap gap-1">
         {items.map((item) => {
           const active = activeView === item.key;
           const disabled = item.disabled;

--- a/components/x/slug/CategoryNavigation.jsx
+++ b/components/x/slug/CategoryNavigation.jsx
@@ -1,6 +1,12 @@
 import clsx from "clsx";
 
-export default function CategoryNavigation({ items = [], activeKey = "", onItemClick, ariaLabel }) {
+export default function CategoryNavigation({
+  items = [],
+  activeKey = "",
+  onItemClick,
+  ariaLabel,
+  ...rest
+}) {
   if (!Array.isArray(items) || items.length === 0) {
     return null;
   }
@@ -9,6 +15,7 @@ export default function CategoryNavigation({ items = [], activeKey = "", onItemC
     <nav
       className="relative mx-auto mb-6 max-w-4xl"
       aria-label={ariaLabel || "Category navigation"}
+      {...rest}
     >
       <div className="relative rounded-3xl bg-slate-900/70 backdrop-blur-md px-4 py-3 shadow-xl ring-1 ring-white/10">
         <span

--- a/components/x/slug/ContentDetailPage.jsx
+++ b/components/x/slug/ContentDetailPage.jsx
@@ -3,6 +3,7 @@ import { useTranslation } from "next-i18next";
 
 import { LikeButton, ShareButton, BookmarkButton } from "@/components/x/button";
 import { useLikes } from "@/hooks/useLikes";
+import { useHeatmapTracker } from "@/hooks/useHeatmapTracker";
 import { formatCount, formatRelativeTime, getOrientationClass } from "@/lib/formatters";
 import { loadFavorites } from "@/utils/storage";
 import VideoCard from "@/components/x/video/VideoCard";
@@ -37,6 +38,7 @@ export default function ContentDetailPage({
   const [serverCounts, setServerCounts] = useState({ views: null, likes: null });
   const [ctaHref, setCtaHref] = useState(SPONSOR_SMART_LINK_URL);
   const ctaRef = useRef(null);
+  const { containerRef: heatmapRef } = useHeatmapTracker({ slug: meme?.slug });
 
   if (!meme) return null;
 
@@ -191,7 +193,11 @@ export default function ContentDetailPage({
       )}
 
       <div className="min-h-screen bg-gradient-to-b from-slate-950 via-slate-900 to-slate-950">
-        <main className="mx-auto w-full max-w-3xl px-4 pb-20 pt-10 sm:px-6">
+        <main
+          ref={heatmapRef}
+          className="mx-auto w-full max-w-3xl px-4 pb-20 pt-10 sm:px-6"
+          data-heatmap-section="page"
+        >
           <div className="mt-6 mb-6 text-center">
             <LogoText size={"4xl"}/>
           </div>
@@ -201,6 +207,7 @@ export default function ContentDetailPage({
             activeKey={activeCategoryKey}
             onItemClick={openSmartLink}
             ariaLabel={t("nav.label", "navigation")}
+            data-heatmap-section="nav"
           />
 
           <article className="mt-6 space-y-7 rounded-3xl bg-slate-900/80 p-6 shadow-[0_30px_80px_-40px_rgba(15,23,42,0.9)] ring-1 ring-slate-800/70 sm:p-9">
@@ -222,6 +229,7 @@ export default function ContentDetailPage({
                 disablePlay={disableVideo}
                 onEngagement={onPreviewEngaged}
                 durationSeconds={meme.durationSeconds}
+                data-heatmap-section="video"
               />
               <div className="mt-8 flex w-full justify-center">
                 <a
@@ -230,6 +238,7 @@ export default function ContentDetailPage({
                   target="_blank"
                   rel="noopener"
                   onClick={handleCtaClick}
+                  data-heatmap-section="cta"
                   className="inline-flex items-center gap-3 rounded-full bg-gradient-to-br from-indigo-500 via-purple-500 to-pink-500 px-7 py-3 text-base font-semibold text-white shadow-[0_16px_40px_rgba(79,70,229,0.45)] transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-200 hover:brightness-110 active:scale-95 sm:px-9 sm:py-3.5 sm:text-lg"
                   aria-label="스폰서 링크로 이동"
                 >

--- a/components/x/video/VideoCard.jsx
+++ b/components/x/video/VideoCard.jsx
@@ -33,6 +33,7 @@ export default function VideoCard({
     sponsorUrl = VIDEO_PREVIEW_SPONSOR_URL,
     trackingRoute = "x",
     trackingPlacement = "overlay",
+    ...rest
 }) {
     const containerRef = useRef(null);
     const videoElementRef = useRef(null);
@@ -258,6 +259,7 @@ export default function VideoCard({
                 aspect
             )}
             onClickCapture={handleFallbackClick}
+            {...rest}
         >
             {shouldShowFallback ? (
                 <div className="flex h-full w-full items-center justify-center bg-[radial-gradient(circle_at_center,_#6366f1_0%,_#0f172a_70%)] text-sm font-semibold text-slate-100">

--- a/hooks/admin/useHeatmapAnalytics.js
+++ b/hooks/admin/useHeatmapAnalytics.js
@@ -1,0 +1,74 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+export default function useHeatmapAnalytics({ enabled, slug, token }) {
+  const [state, setState] = useState({
+    loading: false,
+    error: '',
+    data: null,
+  });
+  const [refreshIndex, setRefreshIndex] = useState(0);
+
+  const refresh = useCallback(() => {
+    setRefreshIndex((prev) => prev + 1);
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    if (!slug) {
+      setState((prev) => ({ ...prev, loading: false, error: '', data: null }));
+      return;
+    }
+
+    let cancelled = false;
+    setState((prev) => ({ ...prev, loading: true, error: '' }));
+
+    const params = new URLSearchParams();
+    params.set('slug', slug);
+    if (token) params.set('token', token);
+
+    fetch(`/api/admin/heatmap?${params.toString()}`)
+      .then(async (response) => {
+        const payload = await response.json().catch(() => ({}));
+        if (!response.ok) {
+          throw new Error(payload?.error || '히트맵 데이터를 불러오지 못했어요.');
+        }
+        if (cancelled) return;
+        setState({
+          loading: false,
+          error: '',
+          data: payload,
+        });
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        setState((prev) => ({
+          ...prev,
+          loading: false,
+          error: error?.message || '히트맵 데이터를 불러오지 못했어요.',
+        }));
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, slug, token, refreshIndex]);
+
+  const buckets = useMemo(() => {
+    if (!state.data || !Array.isArray(state.data.buckets)) return [];
+    return state.data.buckets;
+  }, [state.data]);
+
+  const availableBuckets = useMemo(() => buckets.map((bucket) => bucket.bucket), [buckets]);
+
+  return {
+    loading: state.loading,
+    error: state.error,
+    data: state.data,
+    buckets,
+    availableBuckets,
+    refresh,
+  };
+}

--- a/hooks/useHeatmapTracker.js
+++ b/hooks/useHeatmapTracker.js
@@ -1,0 +1,297 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+const DEFAULT_GRID = Object.freeze({ cols: 12, rows: 8 });
+const MAX_BUFFER_SAMPLES = 10;
+const FLUSH_INTERVAL_MS = 4000;
+const SCROLL_SAMPLE_INTERVAL_MS = 750;
+
+function clamp01(value) {
+  if (!Number.isFinite(value)) return 0;
+  if (value <= 0) return 0;
+  if (value >= 1) return 1;
+  return value;
+}
+
+function safeSectionId(target, container) {
+  if (!target || typeof target !== 'object') return 'root';
+  let node = target.nodeType === 1 ? target : target.parentElement;
+  while (node) {
+    if (node.dataset && typeof node.dataset.heatmapSection === 'string') {
+      const value = node.dataset.heatmapSection.trim();
+      if (value) return value.slice(0, 50);
+    }
+    if (node === container) break;
+    node = node.parentElement;
+  }
+  return 'root';
+}
+
+function resolveViewportBucket() {
+  if (typeof window === 'undefined') return 'ssr';
+  const width = Math.max(1, Math.floor(window.innerWidth || 0));
+  const height = Math.max(1, Math.floor(window.innerHeight || 0));
+  const density = Math.round((window.devicePixelRatio || 1) * 10) / 10;
+  const widthBucket = width <= 640 ? 'sm' : width <= 1024 ? 'md' : 'lg';
+  const heightBucket = height <= 700 ? 'short' : height <= 900 ? 'medium' : 'tall';
+  return `${widthBucket}-${heightBucket}-${width}x${height}-d${density}`;
+}
+
+function ensureSessionId() {
+  if (typeof window === 'undefined') return null;
+  const storageKey = 'laffy_heatmap_session';
+  try {
+    const storage = window.sessionStorage;
+    if (!storage) return null;
+    const existing = storage.getItem(storageKey);
+    if (existing && typeof existing === 'string') return existing;
+    const cryptoObj = window.crypto;
+    let generated = null;
+    if (cryptoObj && typeof cryptoObj.randomUUID === 'function') {
+      generated = cryptoObj.randomUUID().replace(/-/g, '');
+    } else {
+      generated = Math.random().toString(36).slice(2) + Date.now().toString(36);
+    }
+    if (generated) {
+      storage.setItem(storageKey, generated);
+    }
+    return generated;
+  } catch (error) {
+    return null;
+  }
+}
+
+function serializeSamples(buffer) {
+  const cells = [];
+  buffer.forEach((count, key) => {
+    if (!Number.isFinite(count) || count <= 0) return;
+    const [cellIndexStr, type, section] = key.split('|');
+    const cell = Number.parseInt(cellIndexStr, 10);
+    if (!Number.isFinite(cell)) return;
+    cells.push({ cell, type: type || 'generic', section: section || 'root', count: Math.round(count) });
+  });
+  return cells;
+}
+
+async function sendPayload(payload) {
+  const body = JSON.stringify(payload);
+  if (typeof navigator !== 'undefined' && typeof navigator.sendBeacon === 'function') {
+    try {
+      const blob = new Blob([body], { type: 'application/json' });
+      if (navigator.sendBeacon('/api/heatmap/record', blob)) return;
+    } catch (error) {
+      // swallow beacon errors and fallback to fetch
+    }
+  }
+
+  try {
+    await fetch('/api/heatmap/record', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body,
+      keepalive: true,
+    });
+  } catch (error) {
+    // ignore network errors
+  }
+}
+
+export function useHeatmapTracker(options = {}) {
+  const { slug, enabled = true, grid = DEFAULT_GRID } = options;
+  const [container, setContainer] = useState(null);
+  const containerRef = useCallback((node) => {
+    setContainer(node || null);
+  }, []);
+
+  const gridState = useMemo(() => {
+    const cols = Number.isFinite(grid?.cols) && grid.cols > 0 ? Math.floor(grid.cols) : DEFAULT_GRID.cols;
+    const rows = Number.isFinite(grid?.rows) && grid.rows > 0 ? Math.floor(grid.rows) : DEFAULT_GRID.rows;
+    return { cols, rows, total: cols * rows };
+  }, [grid]);
+
+  const bufferRef = useRef(new Map());
+  const sampleCountRef = useRef(0);
+  const flushTimerRef = useRef(null);
+  const rafRef = useRef(null);
+  const scrollTimerRef = useRef(null);
+  const sessionIdRef = useRef(null);
+
+  const clearTimers = useCallback(() => {
+    if (flushTimerRef.current) {
+      clearTimeout(flushTimerRef.current);
+      flushTimerRef.current = null;
+    }
+    if (scrollTimerRef.current) {
+      clearTimeout(scrollTimerRef.current);
+      scrollTimerRef.current = null;
+    }
+    if (rafRef.current && typeof cancelAnimationFrame === 'function') {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+  }, []);
+
+  const resetBuffer = useCallback(() => {
+    bufferRef.current = new Map();
+    sampleCountRef.current = 0;
+  }, []);
+
+  const flushBuffer = useCallback(
+    async (reason = 'interval') => {
+      if (!slug || !enabled) {
+        resetBuffer();
+        return;
+      }
+      const buffer = bufferRef.current;
+      if (!(buffer instanceof Map) || buffer.size === 0) {
+        resetBuffer();
+        return;
+      }
+      const cells = serializeSamples(buffer);
+      resetBuffer();
+      if (cells.length === 0) return;
+
+      const payload = {
+        slug,
+        viewportBucket: resolveViewportBucket(),
+        cells,
+        sessionId: sessionIdRef.current || null,
+        reason,
+        ts: Date.now(),
+      };
+      await sendPayload(payload);
+    },
+    [enabled, resetBuffer, slug]
+  );
+
+  const scheduleFlush = useCallback(
+    (reason) => {
+      if (sampleCountRef.current >= MAX_BUFFER_SAMPLES) {
+        flushBuffer(reason || 'sample_limit');
+        return;
+      }
+      if (flushTimerRef.current) return;
+      flushTimerRef.current = setTimeout(() => {
+        flushTimerRef.current = null;
+        flushBuffer('timer');
+      }, FLUSH_INTERVAL_MS);
+    },
+    [flushBuffer]
+  );
+
+  const pushSample = useCallback(
+    (sample) => {
+      if (!enabled || !slug) return;
+      if (!sample) return;
+      const cols = gridState.cols;
+      const rows = gridState.rows;
+      const x = clamp01(sample.xRatio ?? 0.5);
+      const y = clamp01(sample.yRatio ?? 0.5);
+      const column = Math.min(cols - 1, Math.floor(x * cols));
+      const row = Math.min(rows - 1, Math.floor(y * rows));
+      const cellIndex = row * cols + column;
+      const type = typeof sample.type === 'string' && sample.type ? sample.type.slice(0, 24) : 'generic';
+      const section = typeof sample.section === 'string' && sample.section ? sample.section.slice(0, 32) : 'root';
+      const key = `${cellIndex}|${type}|${section}`;
+      const current = bufferRef.current.get(key) || 0;
+      bufferRef.current.set(key, current + 1);
+      sampleCountRef.current += 1;
+      scheduleFlush('buffer');
+    },
+    [enabled, gridState.cols, gridState.rows, scheduleFlush, slug]
+  );
+
+  const processPointerEvent = useCallback(
+    (event, type) => {
+      if (!event || !enabled) return;
+      const viewportWidth = typeof window !== 'undefined' ? window.innerWidth || 1 : 1;
+      const viewportHeight = typeof window !== 'undefined' ? window.innerHeight || 1 : 1;
+      const xRatio = clamp01(event.clientX / Math.max(1, viewportWidth));
+      const yRatio = clamp01(event.clientY / Math.max(1, viewportHeight));
+      const section = safeSectionId(event.target, container);
+      pushSample({ type, xRatio, yRatio, section });
+    },
+    [container, enabled, pushSample]
+  );
+
+  const pointerHandler = useCallback(
+    (type) => (event) => {
+      if (!enabled) return;
+      if (rafRef.current && typeof cancelAnimationFrame === 'function') {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+      const handle = () => {
+        rafRef.current = null;
+        processPointerEvent(event, type);
+      };
+      if (typeof requestAnimationFrame === 'function') {
+        rafRef.current = requestAnimationFrame(handle);
+      } else {
+        setTimeout(handle, 16);
+      }
+    },
+    [enabled, processPointerEvent]
+  );
+
+  const handleScroll = useCallback(() => {
+    if (!enabled) return;
+    if (scrollTimerRef.current) return;
+    scrollTimerRef.current = setTimeout(() => {
+      scrollTimerRef.current = null;
+      const doc = typeof document !== 'undefined' ? document.documentElement : null;
+      if (!doc) return;
+      const scrollable = Math.max(1, doc.scrollHeight - (window.innerHeight || 0));
+      const yRatio = clamp01((window.scrollY || window.pageYOffset || 0) / scrollable);
+      pushSample({ type: 'scroll', xRatio: 0.5, yRatio, section: 'page' });
+    }, SCROLL_SAMPLE_INTERVAL_MS);
+  }, [enabled, pushSample]);
+
+  useEffect(() => {
+    if (!enabled || !slug) return undefined;
+    sessionIdRef.current = ensureSessionId();
+    return () => {
+      sessionIdRef.current = null;
+    };
+  }, [enabled, slug]);
+
+  useEffect(() => {
+    if (!enabled || !container) return undefined;
+
+    const moveListener = pointerHandler('pointermove');
+    const downListener = pointerHandler('pointerdown');
+    container.addEventListener('pointermove', moveListener, { passive: true });
+    container.addEventListener('pointerdown', downListener, { passive: true });
+    window.addEventListener('scroll', handleScroll, { passive: true });
+
+    const visibilityHandler = () => {
+      if (document.visibilityState === 'hidden') {
+        flushBuffer('hidden');
+      }
+    };
+    const pagehideHandler = () => flushBuffer('pagehide');
+
+    document.addEventListener('visibilitychange', visibilityHandler);
+    window.addEventListener('pagehide', pagehideHandler);
+    window.addEventListener('beforeunload', pagehideHandler);
+
+    return () => {
+      container.removeEventListener('pointermove', moveListener);
+      container.removeEventListener('pointerdown', downListener);
+      window.removeEventListener('scroll', handleScroll);
+      document.removeEventListener('visibilitychange', visibilityHandler);
+      window.removeEventListener('pagehide', pagehideHandler);
+      window.removeEventListener('beforeunload', pagehideHandler);
+      clearTimers();
+      flushBuffer('teardown');
+    };
+  }, [clearTimers, container, enabled, flushBuffer, handleScroll, pointerHandler, slug]);
+
+  useEffect(() => () => {
+    clearTimers();
+    flushBuffer('unmount');
+  }, [clearTimers, flushBuffer]);
+
+  return { containerRef };
+}
+
+export default useHeatmapTracker;

--- a/pages/api/admin/heatmap.js
+++ b/pages/api/admin/heatmap.js
@@ -1,0 +1,151 @@
+import { assertAdmin } from './_auth';
+import { getHeatmapSnapshot } from '../../../utils/heatmapStore';
+
+const DEFAULT_GRID_COLS = 12;
+
+function transformBucket(rawBucket) {
+  const bucketName = typeof rawBucket?.bucket === 'string' && rawBucket.bucket ? rawBucket.bucket : 'default';
+  const rawCells = Array.isArray(rawBucket?.cells) ? rawBucket.cells : [];
+
+  if (rawCells.length === 0) {
+    return {
+      bucket: bucketName,
+      totalCount: 0,
+      maxCount: 0,
+      grid: { cols: DEFAULT_GRID_COLS, rows: 0 },
+      matrix: [],
+      cells: [],
+      sections: [],
+      types: [],
+      topCells: [],
+    };
+  }
+
+  let maxCellIndex = 0;
+  for (const entry of rawCells) {
+    const idx = Number(entry?.cell);
+    if (Number.isFinite(idx) && idx > maxCellIndex) {
+      maxCellIndex = idx;
+    }
+  }
+
+  const rows = Math.max(1, Math.ceil((maxCellIndex + 1) / DEFAULT_GRID_COLS));
+  const matrix = Array.from({ length: rows }, () => Array.from({ length: DEFAULT_GRID_COLS }, () => 0));
+
+  let total = 0;
+  let maxCount = 0;
+  const details = [];
+  const sectionMap = new Map();
+  const typeMap = new Map();
+
+  for (const entry of rawCells) {
+    const idx = Number(entry?.cell);
+    const count = Number(entry?.count);
+    if (!Number.isFinite(idx) || idx < 0) continue;
+    if (!Number.isFinite(count) || count <= 0) continue;
+    const section = typeof entry?.section === 'string' && entry.section ? entry.section : 'root';
+    const type = typeof entry?.type === 'string' && entry.type ? entry.type : 'generic';
+    const row = Math.floor(idx / DEFAULT_GRID_COLS);
+    const column = idx % DEFAULT_GRID_COLS;
+    if (row >= rows || column >= DEFAULT_GRID_COLS) continue;
+
+    matrix[row][column] += count;
+    total += count;
+    if (count > maxCount) maxCount = count;
+
+    const detail = {
+      cell: idx,
+      row,
+      column,
+      rowLabel: row + 1,
+      columnLabel: column + 1,
+      section,
+      type,
+      count,
+    };
+
+    details.push(detail);
+    sectionMap.set(section, (sectionMap.get(section) || 0) + count);
+    typeMap.set(type, (typeMap.get(type) || 0) + count);
+  }
+
+  const safeTotal = total > 0 ? total : 0;
+  const decoratedDetails = details
+    .map((detail) => ({
+      ...detail,
+      ratio: safeTotal > 0 ? detail.count / safeTotal : 0,
+      intensity: maxCount > 0 ? detail.count / maxCount : 0,
+    }))
+    .sort((a, b) => a.cell - b.cell);
+
+  const sections = Array.from(sectionMap.entries())
+    .map(([section, count]) => ({
+      section,
+      count,
+      ratio: safeTotal > 0 ? count / safeTotal : 0,
+    }))
+    .sort((a, b) => b.count - a.count);
+
+  const types = Array.from(typeMap.entries())
+    .map(([type, count]) => ({
+      type,
+      count,
+      ratio: safeTotal > 0 ? count / safeTotal : 0,
+    }))
+    .sort((a, b) => b.count - a.count);
+
+  const topCells = decoratedDetails
+    .slice()
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 20);
+
+  return {
+    bucket: bucketName,
+    totalCount: safeTotal,
+    maxCount,
+    grid: { cols: DEFAULT_GRID_COLS, rows },
+    matrix,
+    cells: decoratedDetails,
+    sections,
+    types,
+    topCells,
+  };
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).end();
+  }
+
+  if (!assertAdmin(req, res)) {
+    return;
+  }
+
+  const rawSlug = req.query.slug;
+  const slug = typeof rawSlug === 'string' ? rawSlug.trim() : Array.isArray(rawSlug) ? rawSlug[0]?.trim() : '';
+  if (!slug) {
+    return res.status(400).json({ error: 'Missing slug' });
+  }
+
+  try {
+    const snapshot = await getHeatmapSnapshot(slug);
+    const buckets = Array.isArray(snapshot?.buckets)
+      ? snapshot.buckets.map((bucket) => transformBucket(bucket))
+      : [];
+
+    const totalSamples = buckets.reduce((acc, bucket) => acc + (bucket.totalCount || 0), 0);
+
+    return res.status(200).json({
+      ok: true,
+      slug: snapshot?.slug || slug,
+      generatedAt: new Date().toISOString(),
+      buckets,
+      bucketCount: buckets.length,
+      totalSamples,
+    });
+  } catch (error) {
+    console.error('[admin][heatmap] failed to load snapshot', error);
+    return res.status(500).json({ error: 'Failed to load heatmap snapshot' });
+  }
+}

--- a/pages/api/heatmap/record.js
+++ b/pages/api/heatmap/record.js
@@ -1,0 +1,51 @@
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).end();
+  }
+
+  try {
+    const body = req.body || {};
+    const slug = typeof body.slug === 'string' ? body.slug.trim() : '';
+    if (!slug) {
+      return res.status(400).json({ error: 'Missing slug' });
+    }
+
+    const { ensureViewerId } = await import('../../../utils/viewerSession');
+    const viewerId = ensureViewerId(req, res);
+
+    const cells = Array.isArray(body.cells) ? body.cells : [];
+    if (cells.length === 0) {
+      return res.status(200).json({ ok: true, recorded: 0, slug });
+    }
+
+    const { recordHeatmapSamples, normalizeHeatmapBucket } = await import('../../../utils/heatmapStore');
+    const bucket = normalizeHeatmapBucket(body.viewportBucket);
+
+    const normalizedCells = cells.map((cell) => ({
+      cell: cell?.cell,
+      count: cell?.count,
+      type: cell?.type,
+      section: cell?.section,
+    }));
+
+    const sessionId = typeof body.sessionId === 'string' ? body.sessionId.trim().slice(0, 80) : null;
+    const reason = typeof body.reason === 'string' ? body.reason.trim().slice(0, 40) : null;
+    const tsValue = Number(body.ts);
+    const ts = Number.isFinite(tsValue) ? tsValue : Date.now();
+
+    const result = await recordHeatmapSamples(slug, {
+      bucket,
+      cells: normalizedCells,
+      viewerId,
+      sessionId,
+      reason,
+      timestamp: ts,
+    });
+
+    return res.status(200).json({ ok: true, slug, recorded: result.recorded || 0 });
+  } catch (error) {
+    console.error('[heatmap] record failed', error);
+    return res.status(500).json({ error: 'Failed to record heatmap' });
+  }
+}

--- a/utils/heatmapStore.js
+++ b/utils/heatmapStore.js
@@ -1,0 +1,198 @@
+const FIELD_DELIMITER = '|';
+const DEFAULT_BUCKET = 'default';
+
+function sanitizeSegment(value, fallback, maxLength = 48) {
+  if (typeof value !== 'string') return fallback;
+  const trimmed = value.trim();
+  if (!trimmed) return fallback;
+  const safe = trimmed.replace(/[^a-z0-9_\-\.]/gi, '').slice(0, maxLength);
+  return safe || fallback;
+}
+
+function sanitizeBucket(value) {
+  return sanitizeSegment(value, DEFAULT_BUCKET, 40);
+}
+
+export function normalizeHeatmapBucket(value) {
+  return sanitizeBucket(value);
+}
+
+function heatmapKey(slug) {
+  return `heatmap:${slug}`;
+}
+
+function normalizeCells(cells) {
+  if (!Array.isArray(cells)) return [];
+  const result = [];
+  for (const entry of cells) {
+    const index = Number(entry?.cell);
+    if (!Number.isFinite(index) || index < 0) continue;
+    const count = Number(entry?.count ?? 1);
+    if (!Number.isFinite(count) || count <= 0) continue;
+    const type = sanitizeSegment(entry?.type, 'generic', 24);
+    const section = sanitizeSegment(entry?.section, 'root', 32);
+    result.push({
+      cell: Math.floor(index),
+      count: Math.max(1, Math.round(count)),
+      type,
+      section,
+    });
+  }
+  return result;
+}
+
+function formatField(bucket, section, type, cell) {
+  const safeBucket = sanitizeBucket(bucket);
+  const safeSection = sanitizeSegment(section, 'root', 32);
+  const safeType = sanitizeSegment(type, 'generic', 24);
+  return `${safeBucket}${FIELD_DELIMITER}${safeSection}${FIELD_DELIMITER}${safeType}${FIELD_DELIMITER}${cell}`;
+}
+
+function parseFieldKey(field) {
+  if (typeof field !== 'string') return null;
+  const [bucket, section, type, cellStr] = field.split(FIELD_DELIMITER);
+  const cell = Number.parseInt(cellStr, 10);
+  if (!Number.isFinite(cell) || cell < 0) return null;
+  return {
+    bucket: sanitizeBucket(bucket),
+    section: sanitizeSegment(section, 'root', 32),
+    type: sanitizeSegment(type, 'generic', 24),
+    cell,
+  };
+}
+
+function mergeBucketCell(map, bucket, entry) {
+  const bucketKey = sanitizeBucket(bucket);
+  const bucketMap = map.get(bucketKey) || new Map();
+  const cellKey = `${entry.section}${FIELD_DELIMITER}${entry.type}${FIELD_DELIMITER}${entry.cell}`;
+  const current = bucketMap.get(cellKey) || { ...entry, count: 0 };
+  current.count += entry.count;
+  bucketMap.set(cellKey, current);
+  map.set(bucketKey, bucketMap);
+}
+
+function ensureMemoryState() {
+  if (!global.__heatmapMemState) {
+    global.__heatmapMemState = new Map();
+  }
+  return global.__heatmapMemState;
+}
+
+async function recordWithRedis(slug, bucket, cells) {
+  const { redisCommand } = await import('./redisClient');
+  const key = heatmapKey(slug);
+  let recorded = 0;
+  for (const cell of cells) {
+    const field = formatField(bucket, cell.section, cell.type, cell.cell);
+    try {
+      await redisCommand(['HINCRBY', key, field, cell.count]);
+      recorded += cell.count;
+    } catch (error) {
+      throw error;
+    }
+  }
+  return recorded;
+}
+
+async function recordWithMemory(slug, bucket, cells) {
+  const state = ensureMemoryState();
+  const slugMap = state.get(slug) || new Map();
+  const bucketKey = sanitizeBucket(bucket);
+  const bucketMap = slugMap.get(bucketKey) || new Map();
+  let recorded = 0;
+  for (const cell of cells) {
+    const field = formatField(bucketKey, cell.section, cell.type, cell.cell);
+    const current = bucketMap.get(field) || 0;
+    bucketMap.set(field, current + cell.count);
+    recorded += cell.count;
+  }
+  slugMap.set(bucketKey, bucketMap);
+  state.set(slug, slugMap);
+  return recorded;
+}
+
+async function loadFromRedis(slug) {
+  const { redisCommand } = await import('./redisClient');
+  const key = heatmapKey(slug);
+  const result = await redisCommand(['HGETALL', key], { allowReadOnly: true });
+  return Array.isArray(result) ? result : [];
+}
+
+async function loadFromMemory(slug) {
+  const state = ensureMemoryState();
+  const slugMap = state.get(slug);
+  if (!slugMap) return [];
+  const payload = [];
+  for (const [bucketKey, bucketMap] of slugMap.entries()) {
+    for (const [field, count] of bucketMap.entries()) {
+      payload.push(field, count);
+    }
+  }
+  return payload;
+}
+
+function aggregateEntries(entries) {
+  const buckets = new Map();
+  for (let i = 0; i < entries.length; i += 2) {
+    const field = entries[i];
+    const value = Number(entries[i + 1]);
+    if (!Number.isFinite(value) || value <= 0) continue;
+    const parsed = parseFieldKey(field);
+    if (!parsed) continue;
+    mergeBucketCell(buckets, parsed.bucket, {
+      cell: parsed.cell,
+      section: parsed.section,
+      type: parsed.type,
+      count: Math.round(value),
+    });
+  }
+  return Array.from(buckets.entries()).map(([bucket, cellMap]) => ({
+    bucket,
+    cells: Array.from(cellMap.values()).sort((a, b) => a.cell - b.cell),
+  }));
+}
+
+export async function recordHeatmapSamples(slug, options = {}) {
+  const normalizedSlug = typeof slug === 'string' ? slug.trim() : '';
+  if (!normalizedSlug) return { recorded: 0 };
+  const bucket = sanitizeBucket(options.bucket);
+  const cells = normalizeCells(options.cells);
+  if (cells.length === 0) return { recorded: 0 };
+
+  const { hasUpstash } = await import('./redisClient');
+  if (hasUpstash()) {
+    try {
+      const recorded = await recordWithRedis(normalizedSlug, bucket, cells);
+      return { recorded };
+    } catch (error) {
+      console.warn('[heatmap] Redis record failed, falling back to memory', error);
+    }
+  }
+
+  const recorded = await recordWithMemory(normalizedSlug, bucket, cells);
+  return { recorded };
+}
+
+export async function getHeatmapSnapshot(slug) {
+  const normalizedSlug = typeof slug === 'string' ? slug.trim() : '';
+  if (!normalizedSlug) return { slug: '', buckets: [] };
+
+  const { hasUpstash } = await import('./redisClient');
+  if (hasUpstash()) {
+    try {
+      const entries = await loadFromRedis(normalizedSlug);
+      return { slug: normalizedSlug, buckets: aggregateEntries(entries) };
+    } catch (error) {
+      console.warn('[heatmap] Redis fetch failed, falling back to memory', error);
+    }
+  }
+
+  const entries = await loadFromMemory(normalizedSlug);
+  return { slug: normalizedSlug, buckets: aggregateEntries(entries) };
+}
+
+export function __dangerousResetHeatmapStore() {
+  if (global.__heatmapMemState) {
+    global.__heatmapMemState = new Map();
+  }
+}


### PR DESCRIPTION
## 요약
- 관리자 네비게이션에 히트맵 분석 탭을 추가하고 히트맵 데이터 전용 패널을 렌더링하도록 구성했습니다.
- 히트맵 스냅샷을 불러오는 `/api/admin/heatmap` 엔드포인트와 전용 훅을 구현해 버킷·셀 단위 데이터를 집계했습니다.
- 히트맵 그리드, 섹션/이벤트 유형 분포, CSV 내보내기 등 시각화와 가공 도구를 제공하는 컴포넌트를 추가했습니다.

## 테스트
- `npm run lint` *(React in scope 및 prop-types 규칙으로 기존과 동일하게 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d1a4d98c8323906fd8e0ac626fae