### PR TITLE
관리자 분석 네비게이션 및 데이터 개선

### DIFF
--- a/components/admin/layout/AdminNav.jsx
+++ b/components/admin/layout/AdminNav.jsx
@@ -1,7 +1,7 @@
 export default function AdminNav({ items, activeView, onChange }) {
   return (
     <nav className="rounded-full bg-slate-900/60 p-1 shadow-inner shadow-black/40">
-      <div className="flex flex-wrap gap-1">
+      <div className="flex flex-wrap items-center justify-center gap-1">
         {items.map((item) => {
           const active = activeView === item.key;
           const disabled = item.disabled;

--- a/hooks/admin/useAdminCatalog.js
+++ b/hooks/admin/useAdminCatalog.js
@@ -1,0 +1,95 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+const PAGE_LIMIT = 60;
+const MAX_PAGES = 100;
+
+function buildBaseQuery(raw) {
+  if (!raw) return '';
+  return String(raw).replace(/^\?/, '');
+}
+
+export default function useAdminCatalog({ enabled, queryString }) {
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const baseQuery = useMemo(() => buildBaseQuery(queryString), [queryString]);
+
+  const refresh = useCallback(async () => {
+    if (!enabled) {
+      setItems([]);
+      setError('');
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError('');
+
+    try {
+      const aggregated = [];
+      const seenKeys = new Set();
+      let cursor = null;
+      let hasMore = true;
+      let iterations = 0;
+
+      while (hasMore && iterations < MAX_PAGES) {
+        const prevCursor = cursor;
+        const params = new URLSearchParams(baseQuery);
+        params.set('limit', String(PAGE_LIMIT));
+        if (cursor) {
+          params.set('cursor', cursor);
+        }
+
+        const response = await fetch(`/api/admin/list?${params.toString()}`);
+        if (!response.ok) {
+          throw new Error('catalog_fetch_failed');
+        }
+
+        const payload = await response.json().catch(() => ({}));
+        const pageItems = Array.isArray(payload?.items) ? payload.items : [];
+        pageItems.forEach((item) => {
+          const key = item?.pathname || item?.slug || item?.url;
+          if (!key || seenKeys.has(key)) return;
+          seenKeys.add(key);
+          aggregated.push(item);
+        });
+
+        const nextCursorValue = typeof payload?.nextCursor === 'string' ? payload.nextCursor : null;
+        if (payload?.hasMore && nextCursorValue && nextCursorValue !== prevCursor) {
+          cursor = nextCursorValue;
+          hasMore = true;
+        } else {
+          cursor = null;
+          hasMore = false;
+        }
+        iterations += 1;
+
+        if (!hasMore) break;
+      }
+
+      setItems(aggregated);
+    } catch (err) {
+      console.error('Failed to load admin catalog', err);
+      setError('전체 콘텐츠 목록을 불러오지 못했어요.');
+    } finally {
+      setLoading(false);
+    }
+  }, [baseQuery, enabled]);
+
+  useEffect(() => {
+    if (!enabled) {
+      setItems([]);
+      setError('');
+      return;
+    }
+    refresh();
+  }, [enabled, refresh]);
+
+  return {
+    items,
+    loading,
+    error,
+    refresh,
+  };
+}


### PR DESCRIPTION
## 요약
- 관리자 내비게이션 항목을 재구성하고 중앙 정렬하여 업로드, 분석, 이벤트, 광고, 통합 인사이트, 히트맵 탭을 분리했습니다.
- 전체 콘텐츠를 불러오는 useAdminCatalog 훅을 추가해 분석/히트맵에서 전체 데이터를 사용할 수 있도록 했습니다.
- 분석·이벤트·광고·통합 인사이트 섹션을 분리하고 분석 탭에 전체 콘텐츠 집계를 표시하며 히트맵 자동완성에도 전체 목록을 연동했습니다.

## 테스트
- `npm run lint` (기존 React import 설정 요구로 실패)

------
https://chatgpt.com/codex/tasks/task_e_68d6db05fcf08323842f6bc1bd1f516c