### PR TITLE
관리자 분석 데이터 동기화 및 내비게이션 구조 개선

### DIFF
--- a/components/admin/layout/AdminNav.jsx
+++ b/components/admin/layout/AdminNav.jsx
@@ -1,7 +1,7 @@
 export default function AdminNav({ items, activeView, onChange }) {
   return (
-    <nav className="rounded-full bg-slate-900/60 p-1 shadow-inner shadow-black/40">
-      <div className="flex flex-wrap gap-1">
+    <nav className="flex justify-center rounded-full bg-slate-900/60 p-1 shadow-inner shadow-black/40">
+      <div className="flex flex-wrap items-center justify-center gap-1">
         {items.map((item) => {
           const active = activeView === item.key;
           const disabled = item.disabled;

--- a/hooks/admin/useAdminContentIndex.js
+++ b/hooks/admin/useAdminContentIndex.js
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+function buildRequestUrl(token) {
+  const params = new URLSearchParams();
+  if (token) params.set('token', token);
+  const query = params.toString();
+  return `/api/admin/content/all${query ? `?${query}` : ''}`;
+}
+
+function normalizeItems(rawItems) {
+  if (!Array.isArray(rawItems)) return [];
+  return rawItems
+    .filter((item) => item && typeof item.slug === 'string' && item.slug.trim())
+    .map((item) => {
+      const slug = item.slug.trim();
+      const type = typeof item.type === 'string' ? item.type : '';
+      const routePath = item.routePath || (type === 'image' ? `/x/${slug}` : `/m/${slug}`);
+      return {
+        ...item,
+        slug,
+        type,
+        routePath,
+        title: item.title || item.display?.socialTitle || item.display?.cardTitle || slug,
+        description: item.description || item.summary || '',
+        orientation: item.orientation || 'landscape',
+        likes: Number.isFinite(Number(item.likes)) ? Number(item.likes) : 0,
+        views: Number.isFinite(Number(item.views)) ? Number(item.views) : 0,
+      };
+    });
+}
+
+export default function useAdminContentIndex({ enabled, token }) {
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const url = useMemo(() => buildRequestUrl(token), [token]);
+
+  const refresh = useCallback(async () => {
+    if (!enabled) {
+      setItems([]);
+      setLoading(false);
+      setError('');
+      return;
+    }
+
+    setLoading(true);
+    setError('');
+
+    try {
+      const response = await fetch(url, { cache: 'no-store' });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(payload?.error || '전체 콘텐츠를 불러오지 못했어요.');
+      }
+      setItems(normalizeItems(payload.items));
+    } catch (err) {
+      console.error('[admin] failed to load content index', err);
+      setItems([]);
+      setError(err?.message || '전체 콘텐츠를 불러오지 못했어요.');
+    } finally {
+      setLoading(false);
+    }
+  }, [enabled, url]);
+
+  useEffect(() => {
+    if (!enabled) {
+      setItems([]);
+      setError('');
+      setLoading(false);
+      return;
+    }
+    refresh();
+  }, [enabled, refresh]);
+
+  const safeSetItems = useCallback((updater) => {
+    setItems((prev) => {
+      if (typeof updater === 'function') {
+        return normalizeItems(updater(prev));
+      }
+      return normalizeItems(updater);
+    });
+  }, []);
+
+  return {
+    items,
+    setItems: safeSetItems,
+    loading,
+    error,
+    refresh,
+  };
+}

--- a/pages/api/admin/content/all.js
+++ b/pages/api/admin/content/all.js
@@ -1,0 +1,39 @@
+import { assertAdmin } from '../_auth';
+import { getAllContent } from '@/utils/contentSource';
+
+function normalizeItems(items) {
+  if (!Array.isArray(items)) return [];
+  return items
+    .filter((item) => item && typeof item.slug === 'string' && item.slug.trim())
+    .map((item) => {
+      const slug = item.slug.trim();
+      const type = typeof item.type === 'string' ? item.type : '';
+      const routePath = type === 'image' ? `/x/${slug}` : `/m/${slug}`;
+      return {
+        ...item,
+        slug,
+        type,
+        routePath,
+      };
+    });
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  if (!assertAdmin(req, res)) {
+    return;
+  }
+
+  try {
+    const { items } = await getAllContent();
+    const normalized = normalizeItems(items);
+    return res.status(200).json({ items: normalized, count: normalized.length });
+  } catch (error) {
+    console.error('[admin][content][all] failed to load content index', error);
+    return res.status(500).json({ error: 'Failed to load full content index' });
+  }
+}


### PR DESCRIPTION
## 요약
- 전체 콘텐츠 메타를 수집하는 API와 훅을 추가해 관리자 분석·히트맵 기능이 모든 콘텐츠를 기준으로 동작하도록 개선했습니다.
- 관리자 내비게이션을 중앙 정렬하고 이벤트·광고·통합 인사이트 탭을 분리해 각 섹션의 역할을 명확히 했습니다.
- 히트맵 API와 패널을 보강해 x/[slug] 경로 전반의 데이터를 통합 분석하고 관련 UI 안내를 정비했습니다.

## 테스트
- `npm run lint` (기존 React import/prop-types 규칙으로 인해 실패)


------
https://chatgpt.com/codex/tasks/task_e_68d6db05fcf08323842f6bc1bd1f516c