### PR TITLE
관리자 분석/수익 화면 UI와 인사이트 개편

### DIFF
--- a/components/admin/adsterra/AdsterraControls.jsx
+++ b/components/admin/adsterra/AdsterraControls.jsx
@@ -77,7 +77,7 @@ export default function AdsterraControls({
 
       <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
         <div className="md:col-span-2 xl:col-span-1">
-          <label className="mb-1 block text-xs uppercase tracking-widest text-slate-400">광고 포맷 (플레이스먼트)</label>
+          <label className="mb-1 block text-xs uppercase tracking-widest text-slate-400">수익 포맷 (플레이스먼트)</label>
           <select
             value={placementId}
             onChange={(event) => onPlacementChange(event.target.value)}

--- a/components/admin/adsterra/AdsterraStatsTable.jsx
+++ b/components/admin/adsterra/AdsterraStatsTable.jsx
@@ -18,7 +18,7 @@ export default function AdsterraStatsTable({
             <tr>
               <th className="px-4 py-3 font-semibold">날짜</th>
               <th className="px-4 py-3 font-semibold">국가</th>
-              <th className="px-4 py-3 font-semibold">광고 포맷</th>
+              <th className="px-4 py-3 font-semibold">수익 포맷</th>
               <th className="px-4 py-3 font-semibold">OS</th>
               <th className="px-4 py-3 font-semibold">디바이스</th>
               <th className="px-4 py-3 font-semibold">디바이스 포맷</th>
@@ -44,7 +44,8 @@ export default function AdsterraStatsTable({
                   row?.cpm ??
                     (impressions > 0 && revenue >= 0 ? (revenue / impressions) * 1000 : 0)
                 ) || 0;
-              const dateLabel = row?.date || row?.day || row?.Day || row?.group || `#${index + 1}`;
+              const dateLabel = row?.localDate || row?.date || row?.day || row?.Day || row?.group || `#${index + 1}`;
+              const dateDetail = row?.localDateLabel || dateLabel;
               const countryLabel = row?.country ?? row?.Country ?? row?.geo ?? row?.Geo ?? '—';
               const osLabel = row?.os ?? row?.OS ?? row?.platform ?? row?.Platform ?? '—';
               const deviceLabel = row?.device ?? row?.Device ?? row?.device_type ?? row?.deviceType ?? '—';
@@ -66,10 +67,12 @@ export default function AdsterraStatsTable({
                 (allSelected
                   ? '전체 보기'
                   : placementLabelMap.get(String(selectedPlacementId)) || '—');
-              const rowKey = `${dateLabel}-${index}-${placementId ?? ''}-${countryLabel}-${osLabel}-${deviceLabel}-${deviceFormatLabel}`;
+              const rowKey = `${row?.localDateIso || dateLabel}-${index}-${placementId ?? ''}-${countryLabel}-${osLabel}-${deviceLabel}-${deviceFormatLabel}`;
               return (
                 <tr key={rowKey} className="hover:bg-slate-800/40">
-                  <td className="px-4 py-3 font-semibold text-slate-100">{dateLabel}</td>
+                  <td className="px-4 py-3 font-semibold text-slate-100" title={dateDetail}>
+                    {dateLabel}
+                  </td>
                   <td className="px-4 py-3 text-slate-100">{countryLabel}</td>
                   <td className="px-4 py-3 text-slate-100">{placementDisplay}</td>
                   <td className="px-4 py-3 text-slate-100">{osLabel}</td>

--- a/components/admin/analytics/AnalyticsOverview.jsx
+++ b/components/admin/analytics/AnalyticsOverview.jsx
@@ -1,10 +1,4 @@
-export default function AnalyticsOverview({
-  itemCount,
-  totals,
-  averageLikeRate,
-  formatNumber,
-  formatPercent,
-}) {
+export default function AnalyticsOverview({ itemCount, totals, averageViews, formatNumber }) {
   return (
     <div className="grid gap-4 md:grid-cols-3">
       <div className="rounded-2xl border border-white/5 bg-slate-900/80 p-4 shadow-lg shadow-black/20">
@@ -18,9 +12,9 @@ export default function AnalyticsOverview({
         <p className="mt-1 text-xs text-slate-500">metrics 기준 누적</p>
       </div>
       <div className="rounded-2xl border border-white/5 bg-slate-900/80 p-4 shadow-lg shadow-black/20">
-        <p className="text-xs uppercase tracking-[0.25em] text-slate-400">평균 좋아요율</p>
-        <p className="mt-2 text-2xl font-bold text-white">{formatPercent(averageLikeRate)}</p>
-        <p className="mt-1 text-xs text-slate-500">조회가 있는 콘텐츠 평균</p>
+        <p className="text-xs uppercase tracking-[0.25em] text-slate-400">평균 조회수율</p>
+        <p className="mt-2 text-2xl font-bold text-white">{formatNumber(Math.round(averageViews))}</p>
+        <p className="mt-1 text-xs text-slate-500">콘텐츠당 평균 조회수</p>
       </div>
     </div>
   );

--- a/components/admin/analytics/AnalyticsToolbar.jsx
+++ b/components/admin/analytics/AnalyticsToolbar.jsx
@@ -35,49 +35,32 @@ export default function AnalyticsToolbar({
 
   return (
     <div className="flex flex-col gap-4 rounded-2xl bg-slate-900/70 p-4 ring-1 ring-slate-800/60">
-      <div className="flex flex-wrap items-center gap-2 text-xs">
-        <span className="rounded-full bg-slate-950/60 px-3 py-1 text-slate-400">정렬 기준</span>
-        <button
-          type="button"
-          onClick={() => onSortChange('views')}
-          className={`rounded-full px-3 py-1 font-semibold transition ${
-            sortKey === 'views' ? 'bg-indigo-500 text-white' : 'bg-slate-800 text-slate-300'
-          }`}
-        >
-          조회수 {sortKey === 'views' ? (sortDirection === 'asc' ? '↑' : '↓') : ''}
-        </button>
-        <button
-          type="button"
-          onClick={() => onSortChange('likes')}
-          className={`rounded-full px-3 py-1 font-semibold transition ${
-            sortKey === 'likes' ? 'bg-indigo-500 text-white' : 'bg-slate-800 text-slate-300'
-          }`}
-        >
-          좋아요 {sortKey === 'likes' ? (sortDirection === 'asc' ? '↑' : '↓') : ''}
-        </button>
-      </div>
-      <div className="flex flex-col gap-3 text-xs text-slate-300 md:flex-row md:items-center md:justify-between">
-
-        <div className="flex flex-wrap items-center gap-2">
-          {Object.entries(visibleColumns).map(([key, value]) => (
-            <label
-              key={key}
-              className="flex items-center gap-1 rounded-full bg-slate-950/50 px-3 py-1 capitalize"
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex items-center gap-2 overflow-x-auto text-xs [scrollbar-width:thin] [-ms-overflow-style:none] lg:overflow-visible">
+          <span className="whitespace-nowrap rounded-full bg-slate-950/60 px-3 py-1 text-slate-400">정렬 기준</span>
+          <div className="flex min-w-0 flex-nowrap gap-2">
+            <button
+              type="button"
+              onClick={() => onSortChange('views')}
+              className={`whitespace-nowrap rounded-full px-3 py-1 font-semibold transition ${
+                sortKey === 'views' ? 'bg-indigo-500 text-white' : 'bg-slate-800 text-slate-300'
+              }`}
             >
-              <input
-                type="checkbox"
-                checked={value}
-                onChange={() => onToggleColumn(key)}
-                className="accent-indigo-400"
-              />
-              {key}
-            </label>
-          ))}
+              조회수 {sortKey === 'views' ? (sortDirection === 'asc' ? '↑' : '↓') : ''}
+            </button>
+            <button
+              type="button"
+              onClick={() => onSortChange('likes')}
+              className={`whitespace-nowrap rounded-full px-3 py-1 font-semibold transition ${
+                sortKey === 'likes' ? 'bg-indigo-500 text-white' : 'bg-slate-800 text-slate-300'
+              }`}
+            >
+              좋아요 {sortKey === 'likes' ? (sortDirection === 'asc' ? '↑' : '↓') : ''}
+            </button>
+          </div>
         </div>
-        <div className="flex flex-wrap items-center gap-2 text-xs">
-          <span className="rounded-full bg-slate-950/50 px-3 py-1 text-slate-400">
-            선택 {selectedCount}개
-          </span>
+        <div className="flex flex-wrap items-center gap-2 text-xs text-slate-300 lg:justify-end">
+          <span className="rounded-full bg-slate-950/60 px-3 py-1 text-slate-400">선택 {selectedCount}개</span>
           <button
             type="button"
             onClick={onOpenBulkEditor}
@@ -107,6 +90,25 @@ export default function AnalyticsToolbar({
           >
             CSV 다운로드
           </button>
+        </div>
+      </div>
+      <div className="flex flex-col gap-3 text-xs text-slate-300 md:flex-row md:items-center md:justify-between">
+
+        <div className="flex flex-wrap items-center gap-2">
+          {Object.entries(visibleColumns).map(([key, value]) => (
+            <label
+              key={key}
+              className="flex items-center gap-1 rounded-full bg-slate-950/50 px-3 py-1 capitalize"
+            >
+              <input
+                type="checkbox"
+                checked={value}
+                onChange={() => onToggleColumn(key)}
+                className="accent-indigo-400"
+              />
+              {key}
+            </label>
+          ))}
         </div>
 
       </div>

--- a/components/admin/analytics/AnalyticsTrendChart.jsx
+++ b/components/admin/analytics/AnalyticsTrendChart.jsx
@@ -1,138 +1,58 @@
+import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from 'recharts';
 import { useMemo } from 'react';
 
-function buildPolylinePoints(history, key, width, height, padding) {
-  if (!history.length) return '';
-  const maxValue = Math.max(...history.map((entry) => Math.max(0, Number(entry[key]) || 0)));
-  if (maxValue === 0) {
-    const baselineY = height - padding;
-    return history
-      .map((entry, index) => {
-        const x = padding + (index / Math.max(1, history.length - 1)) * (width - padding * 2);
-        return `${x},${baselineY}`;
-      })
-      .join(' ');
-  }
+function normalizeHistory(history) {
+  if (!Array.isArray(history)) return [];
   return history
-    .map((entry, index) => {
-      const value = Math.max(0, Number(entry[key]) || 0);
-      const x = padding + (index / Math.max(1, history.length - 1)) * (width - padding * 2);
-      const y = padding + (1 - value / maxValue) * (height - padding * 2);
-      return `${x},${y}`;
-    })
-    .join(' ');
+    .map((entry) => ({
+      date: entry?.date || '',
+      views: Number(entry?.views) || 0,
+      likes: Number(entry?.likes) || 0,
+    }))
+    .filter((entry) => Boolean(entry.date));
+}
+
+function AnalyticsTooltip({ active, payload, label, formatNumber }) {
+  if (!active || !payload || !payload.length) return null;
+  const views = payload.find((item) => item.dataKey === 'views');
+  const likes = payload.find((item) => item.dataKey === 'likes');
+  return (
+    <div className="rounded-xl border border-slate-800/60 bg-slate-950/90 px-3 py-2 text-xs text-slate-200 shadow-lg shadow-black/30">
+      <p className="font-semibold text-white">{label}</p>
+      <p className="mt-1">조회수 {formatNumber(views?.value || 0)}</p>
+      <p>좋아요 {formatNumber(likes?.value || 0)}</p>
+    </div>
+  );
 }
 
 export default function AnalyticsTrendChart({ history, formatNumber }) {
-  const sanitizedHistory = useMemo(
-    () =>
-      Array.isArray(history)
-        ? history
-            .map((entry) => ({
-              date: entry?.date || '',
-              views: Number(entry?.views) || 0,
-              likes: Number(entry?.likes) || 0,
-            }))
-            .filter((entry) => entry.date)
-        : [],
-    [history]
-  );
-
-  if (!sanitizedHistory.length) {
+  const data = useMemo(() => normalizeHistory(history), [history]);
+  if (!data.length) {
     return null;
   }
 
-  const width = 720;
-  const height = 280;
-  const padding = 32;
-
-  const viewsPoints = buildPolylinePoints(sanitizedHistory, 'views', width, height, padding);
-  const likesPoints = buildPolylinePoints(sanitizedHistory, 'likes', width, height, padding);
-  const maxValue = Math.max(
-    ...sanitizedHistory.map((entry) => Math.max(entry.views, entry.likes)),
-    0
-  );
+  const maxViews = Math.max(...data.map((entry) => entry.views), 0);
+  const maxLikes = Math.max(...data.map((entry) => entry.likes), 0);
+  const yMax = Math.max(maxViews, maxLikes, 1);
 
   return (
     <div className="rounded-2xl border border-slate-800/60 bg-slate-900/70 p-4 shadow-inner shadow-black/30">
       <div className="mb-4 flex items-center justify-between text-xs uppercase tracking-[0.3em] text-slate-400">
         <span>기간별 추이</span>
-        <div className="flex items-center gap-3 text-[11px] tracking-normal text-slate-300">
-          <span className="flex items-center gap-1">
-            <span className="inline-block h-2 w-2 rounded-full bg-indigo-400" /> 조회수
-          </span>
-          <span className="flex items-center gap-1">
-            <span className="inline-block h-2 w-2 rounded-full bg-rose-400" /> 좋아요
-          </span>
-        </div>
+        <span className="tracking-normal text-slate-300">최대 {formatNumber(yMax)}</span>
       </div>
-      <div className="relative">
-        <svg viewBox={`0 0 ${width} ${height}`} className="w-full">
-          <defs>
-            <linearGradient id="trendViews" x1="0%" y1="0%" x2="0%" y2="100%">
-              <stop offset="0%" stopColor="rgba(99, 102, 241, 0.35)" />
-              <stop offset="100%" stopColor="rgba(99, 102, 241, 0)" />
-            </linearGradient>
-            <linearGradient id="trendLikes" x1="0%" y1="0%" x2="0%" y2="100%">
-              <stop offset="0%" stopColor="rgba(244, 114, 182, 0.4)" />
-              <stop offset="100%" stopColor="rgba(244, 114, 182, 0)" />
-            </linearGradient>
-          </defs>
-          <rect
-            x={padding}
-            y={padding}
-            width={width - padding * 2}
-            height={height - padding * 2}
-            fill="transparent"
-            stroke="rgba(148, 163, 184, 0.2)"
-            strokeDasharray="4 4"
-          />
-          {viewsPoints && (
-            <>
-              <polyline
-                points={viewsPoints}
-                fill="none"
-                stroke="rgb(99, 102, 241)"
-                strokeWidth="2"
-                strokeLinejoin="round"
-                strokeLinecap="round"
-              />
-              <polygon
-                points={`${viewsPoints} ${padding + (width - padding * 2)},${height - padding} ${padding},${height - padding}`}
-                fill="url(#trendViews)"
-                opacity="0.4"
-              />
-            </>
-          )}
-          {likesPoints && (
-            <>
-              <polyline
-                points={likesPoints}
-                fill="none"
-                stroke="rgb(244, 114, 182)"
-                strokeWidth="2"
-                strokeLinejoin="round"
-                strokeLinecap="round"
-              />
-              <polygon
-                points={`${likesPoints} ${padding + (width - padding * 2)},${height - padding} ${padding},${height - padding}`}
-                fill="url(#trendLikes)"
-                opacity="0.35"
-              />
-            </>
-          )}
-        </svg>
-        <div className="mt-4 grid grid-cols-2 gap-2 text-[11px] text-slate-400 sm:grid-cols-4">
-          {sanitizedHistory.map((entry) => (
-            <div key={entry.date} className="flex flex-col rounded-lg bg-slate-950/40 px-2 py-1">
-              <span className="text-slate-300">{entry.date}</span>
-              <span className="text-[10px] text-slate-500">조회수 {formatNumber(entry.views)}</span>
-              <span className="text-[10px] text-slate-500">좋아요 {formatNumber(entry.likes)}</span>
-            </div>
-          ))}
-        </div>
-      </div>
-      <div className="mt-4 text-right text-[11px] uppercase tracking-[0.3em] text-slate-500">
-        최대값 {formatNumber(maxValue)}
+      <div className="h-72 w-full">
+        <ResponsiveContainer>
+          <LineChart data={data} margin={{ top: 10, right: 20, bottom: 0, left: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="rgba(148, 163, 184, 0.2)" />
+            <XAxis dataKey="date" stroke="rgba(148, 163, 184, 0.5)" tick={{ fontSize: 11 }} interval="preserveStartEnd" />
+            <YAxis stroke="rgba(148, 163, 184, 0.5)" tickFormatter={(value) => formatNumber(value)} tick={{ fontSize: 11 }} />
+            <Tooltip content={<AnalyticsTooltip formatNumber={formatNumber} />} />
+            <Legend wrapperStyle={{ fontSize: 12 }} />
+            <Line type="monotone" dataKey="views" stroke="#60a5fa" strokeWidth={2.5} dot={false} name="조회수" />
+            <Line type="monotone" dataKey="likes" stroke="#f472b6" strokeWidth={2} dot={false} name="좋아요" />
+          </LineChart>
+        </ResponsiveContainer>
       </div>
     </div>
   );

--- a/components/admin/events/EventSummaryCards.jsx
+++ b/components/admin/events/EventSummaryCards.jsx
@@ -1,24 +1,40 @@
-export default function EventSummaryCards({ totals, formatNumber }) {
+export default function EventSummaryCards({ totals, formatNumber, formatPercent }) {
   const totalCount = Number(totals?.count) || 0;
-  const uniqueSessions = Number(totals?.uniqueSessions) || 0;
+  const visitors = Number(totals?.visitors ?? totals?.uniqueSessions) || 0;
+  const pageViews = Number(totals?.pageViews ?? totalCount) || 0;
+  const bounceRateRaw = Number(totals?.bounceRate) || 0;
+  const bounceRate = bounceRateRaw > 0 ? Math.min(1, bounceRateRaw) : 0;
+  const pageViewEvents = Array.isArray(totals?.pageViewEventNames) ? totals.pageViewEventNames : [];
+  const visitorEvents = Array.isArray(totals?.visitorEventNames) ? totals.visitorEventNames : [];
+  const bounceEvents = Array.isArray(totals?.bounceEventNames) ? totals.bounceEventNames : [];
+
+  const formatEventList = (events, fallback) => {
+    if (!events.length) return fallback;
+    return events.slice(0, 3).join(', ');
+  };
+
   return (
     <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
       <div className="rounded-2xl border border-slate-800/70 bg-slate-900/80 p-4 shadow-inner shadow-black/40">
-        <p className="text-xs uppercase tracking-[0.3em] text-slate-400">총 이벤트 수</p>
-        <p className="mt-2 text-3xl font-bold text-white">{formatNumber(totalCount)}</p>
-        <p className="mt-1 text-xs text-slate-500">선택한 기간 동안 수집된 이벤트 합계</p>
+        <p className="text-xs uppercase tracking-[0.3em] text-slate-400">방문자</p>
+        <p className="mt-2 text-3xl font-bold text-white">{formatNumber(visitors)}</p>
+        <p className="mt-1 text-xs text-slate-500">
+          {formatEventList(visitorEvents, '전체 이벤트')} 고유 세션 수 기반
+        </p>
       </div>
       <div className="rounded-2xl border border-slate-800/70 bg-slate-900/80 p-4 shadow-inner shadow-black/40">
-        <p className="text-xs uppercase tracking-[0.3em] text-slate-400">고유 세션</p>
-        <p className="mt-2 text-3xl font-bold text-white">{formatNumber(uniqueSessions)}</p>
-        <p className="mt-1 text-xs text-slate-500">동일 기간 내 이벤트를 발생시킨 고유 세션 수</p>
+        <p className="text-xs uppercase tracking-[0.3em] text-slate-400">페이지 뷰</p>
+        <p className="mt-2 text-3xl font-bold text-white">{formatNumber(pageViews)}</p>
+        <p className="mt-1 text-xs text-slate-500">
+          {formatEventList(pageViewEvents, '전체 이벤트')} 이벤트 누적 합계
+        </p>
       </div>
       <div className="rounded-2xl border border-emerald-500/40 bg-gradient-to-br from-emerald-500/10 via-teal-500/5 to-transparent p-4 shadow-lg shadow-emerald-500/20">
-        <p className="text-xs uppercase tracking-[0.3em] text-emerald-200">평균 이벤트 수/세션</p>
-        <p className="mt-2 text-3xl font-bold text-emerald-100">
-          {uniqueSessions > 0 ? (totalCount / uniqueSessions).toFixed(2) : '0.00'}
+        <p className="text-xs uppercase tracking-[0.3em] text-emerald-200">이탈률</p>
+        <p className="mt-2 text-3xl font-bold text-emerald-100">{formatPercent(bounceRate)}</p>
+        <p className="mt-1 text-xs text-emerald-200/80">
+          {formatEventList(bounceEvents, '이탈 이벤트')} ÷ {formatEventList(visitorEvents, '방문 이벤트')}
         </p>
-        <p className="mt-1 text-xs text-emerald-200/80">고유 세션 대비 이벤트 발생량</p>
       </div>
     </div>
   );

--- a/components/admin/events/EventTrendChart.jsx
+++ b/components/admin/events/EventTrendChart.jsx
@@ -1,47 +1,34 @@
+import { ResponsiveContainer, AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts';
 import { useMemo } from 'react';
 
-function buildPoints(series, width, height, padding) {
-  if (!Array.isArray(series) || !series.length) return '';
-  const max = Math.max(...series.map((entry) => Number(entry.count) || 0), 0);
-  if (max <= 0) {
-    return series
-      .map((_, index) => {
-        const x = padding + (index / Math.max(series.length - 1, 1)) * (width - padding * 2);
-        const y = height - padding;
-        return `${x},${y}`;
-      })
-      .join(' ');
-  }
+function normalizeSeries(series) {
+  if (!Array.isArray(series)) return [];
   return series
-    .map((entry, index) => {
-      const value = Math.max(0, Number(entry.count) || 0);
-      const x = padding + (index / Math.max(series.length - 1, 1)) * (width - padding * 2);
-      const y = padding + (1 - value / max) * (height - padding * 2);
-      return `${x},${y}`;
-    })
-    .join(' ');
+    .map((entry) => ({
+      date: entry?.date || '',
+      count: Number(entry?.count) || 0,
+    }))
+    .filter((entry) => Boolean(entry.date));
+}
+
+function EventTooltip({ active, payload, label, formatNumber }) {
+  if (!active || !payload || !payload.length) return null;
+  const first = payload[0];
+  return (
+    <div className="rounded-xl border border-slate-800/60 bg-slate-950/90 px-3 py-2 text-xs text-slate-200 shadow-lg shadow-black/30">
+      <p className="font-semibold text-white">{label}</p>
+      <p className="mt-1">이벤트 {formatNumber(first?.value || 0)}회</p>
+    </div>
+  );
 }
 
 export default function EventTrendChart({ series, formatNumber }) {
-  const sanitized = useMemo(() => {
-    if (!Array.isArray(series)) return [];
-    return series
-      .map((entry) => ({
-        date: entry?.date || '',
-        count: Number(entry?.count) || 0,
-      }))
-      .filter((entry) => Boolean(entry.date));
-  }, [series]);
-
-  if (!sanitized.length) {
+  const data = useMemo(() => normalizeSeries(series), [series]);
+  if (!data.length) {
     return null;
   }
 
-  const width = 720;
-  const height = 240;
-  const padding = 32;
-  const points = buildPoints(sanitized, width, height, padding);
-  const maxValue = Math.max(...sanitized.map((entry) => entry.count), 0);
+  const maxValue = Math.max(...data.map((entry) => entry.count), 0);
 
   return (
     <div className="rounded-2xl border border-slate-800/70 bg-slate-900/80 p-4 shadow-inner shadow-black/40">
@@ -49,47 +36,22 @@ export default function EventTrendChart({ series, formatNumber }) {
         <span>기간별 이벤트 추이</span>
         <span className="text-[11px] text-slate-300">최대 {formatNumber(maxValue)}건</span>
       </div>
-      <svg viewBox={`0 0 ${width} ${height}`} className="w-full">
-        <defs>
-          <linearGradient id="eventTrend" x1="0" x2="0" y1="0" y2="1">
-            <stop offset="0%" stopColor="rgba(129, 140, 248, 0.6)" />
-            <stop offset="100%" stopColor="rgba(129, 140, 248, 0)" />
-          </linearGradient>
-        </defs>
-        <rect
-          x={padding}
-          y={padding}
-          width={width - padding * 2}
-          height={height - padding * 2}
-          fill="transparent"
-          stroke="rgba(148, 163, 184, 0.25)"
-          strokeDasharray="4 4"
-        />
-        {points && (
-          <>
-            <polyline
-              points={points}
-              fill="none"
-              stroke="rgb(129, 140, 248)"
-              strokeWidth="2.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-            <polygon
-              points={`${points} ${padding + (width - padding * 2)},${height - padding} ${padding},${height - padding}`}
-              fill="url(#eventTrend)"
-              opacity="0.4"
-            />
-          </>
-        )}
-      </svg>
-      <div className="mt-4 grid grid-cols-2 gap-2 text-[11px] text-slate-400 sm:grid-cols-4">
-        {sanitized.map((entry) => (
-          <div key={entry.date} className="rounded-lg bg-slate-950/40 px-3 py-2">
-            <p className="font-semibold text-slate-200">{entry.date}</p>
-            <p className="text-[10px] text-slate-400">{formatNumber(entry.count)}회</p>
-          </div>
-        ))}
+      <div className="h-64 w-full">
+        <ResponsiveContainer>
+          <AreaChart data={data} margin={{ top: 10, right: 20, bottom: 0, left: 0 }}>
+            <defs>
+              <linearGradient id="eventTrendFill" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="rgba(129, 140, 248, 0.6)" />
+                <stop offset="100%" stopColor="rgba(129, 140, 248, 0)" />
+              </linearGradient>
+            </defs>
+            <CartesianGrid strokeDasharray="3 3" stroke="rgba(148, 163, 184, 0.2)" />
+            <XAxis dataKey="date" stroke="rgba(148, 163, 184, 0.5)" tick={{ fontSize: 11 }} interval="preserveStartEnd" />
+            <YAxis stroke="rgba(148, 163, 184, 0.5)" tickFormatter={(value) => formatNumber(value)} tick={{ fontSize: 11 }} />
+            <Tooltip content={<EventTooltip formatNumber={formatNumber} />} />
+            <Area type="monotone" dataKey="count" stroke="#818cf8" fill="url(#eventTrendFill)" strokeWidth={2.5} name="이벤트" />
+          </AreaChart>
+        </ResponsiveContainer>
       </div>
     </div>
   );

--- a/components/admin/heatmap/HeatmapPanel.jsx
+++ b/components/admin/heatmap/HeatmapPanel.jsx
@@ -114,7 +114,7 @@ export default function HeatmapPanel({
       <div className="rounded-3xl border border-indigo-500/40 bg-slate-950/80 p-6 shadow-inner shadow-indigo-500/20">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
           <div>
-            <h2 className="text-2xl font-bold text-white">히트맵 분석</h2>
+            <h2 className="text-2xl font-bold text-white">분석</h2>
             <p className="mt-1 text-sm text-slate-400">
               콘텐츠 상세 페이지에서 수집한 좌표 기반 이벤트를 시각화하고, 섹션/이벤트 유형별 분포를 분석할 수 있어요.
             </p>

--- a/components/admin/insights/EventAdCorrelation.jsx
+++ b/components/admin/insights/EventAdCorrelation.jsx
@@ -82,7 +82,7 @@ export default function EventAdCorrelation({ eventSeries, adSeries, formatNumber
   if (!combined.length) {
     return (
       <div className="rounded-2xl border border-slate-800/60 bg-slate-900/70 p-6 text-sm text-slate-400">
-        기간 내 광고 데이터와 이벤트 데이터를 모두 불러오면 상관관계를 분석할 수 있어요.
+        기간 내 수익 데이터와 이벤트 데이터를 모두 불러오면 상관관계를 분석할 수 있어요.
       </div>
     );
   }
@@ -91,8 +91,8 @@ export default function EventAdCorrelation({ eventSeries, adSeries, formatNumber
     <div className="space-y-4 rounded-2xl border border-slate-800/60 bg-slate-900/70 p-6 shadow-inner shadow-black/30">
       <div className="flex flex-col gap-2 text-sm text-slate-200 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <p className="text-xs uppercase tracking-[0.3em] text-slate-400">이벤트-광고 상관분석</p>
-          <p className="text-lg font-semibold text-white">일자별 이벤트 수와 광고 지표 비교</p>
+          <p className="text-xs uppercase tracking-[0.3em] text-slate-400">이벤트-수익 상관분석</p>
+          <p className="text-lg font-semibold text-white">일자별 이벤트 수와 수익 지표 비교</p>
         </div>
         <div className="flex gap-3 text-xs text-slate-300">
           <span className="rounded-full bg-slate-950/60 px-3 py-1">수익 상관계수 {formatDecimal(revenueCorrelation, 3)}</span>
@@ -105,9 +105,9 @@ export default function EventAdCorrelation({ eventSeries, adSeries, formatNumber
             <tr>
               <th className="px-3 py-2 text-left">날짜</th>
               <th className="px-3 py-2 text-right">이벤트 수</th>
-              <th className="px-3 py-2 text-right">광고 노출</th>
-              <th className="px-3 py-2 text-right">광고 클릭</th>
-              <th className="px-3 py-2 text-right">광고 수익</th>
+              <th className="px-3 py-2 text-right">노출(수익)</th>
+              <th className="px-3 py-2 text-right">클릭(수익)</th>
+              <th className="px-3 py-2 text-right">수익 (USD)</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-800/40 text-slate-200">

--- a/components/admin/insights/IntegratedInsightHighlights.jsx
+++ b/components/admin/insights/IntegratedInsightHighlights.jsx
@@ -1,0 +1,91 @@
+import clsx from 'clsx';
+
+function formatEventList(events = [], fallback) {
+  if (!Array.isArray(events) || events.length === 0) {
+    return fallback;
+  }
+  if (events.length === 1) return events[0];
+  const displayed = events.slice(0, 2);
+  const remaining = events.length - displayed.length;
+  return remaining > 0 ? `${displayed.join(', ')} 외 ${remaining}건` : displayed.join(', ');
+}
+
+const CARD_CONFIG = [
+  {
+    key: 'revenuePerVisitor',
+    title: '방문자당 수익',
+    accent: 'from-emerald-500/20 via-teal-400/15 to-transparent',
+    border: 'border-emerald-400/40',
+  },
+  {
+    key: 'eventsPerClick',
+    title: '클릭 대비 이벤트',
+    accent: 'from-sky-500/20 via-indigo-400/15 to-transparent',
+    border: 'border-sky-400/40',
+  },
+  {
+    key: 'pageviewToImpression',
+    title: '페이지 뷰·노출 비율',
+    accent: 'from-fuchsia-500/20 via-rose-400/15 to-transparent',
+    border: 'border-fuchsia-400/40',
+  },
+];
+
+export default function IntegratedInsightHighlights({
+  eventTotals,
+  adTotals,
+  formatNumber,
+  formatDecimal,
+  formatPercent,
+}) {
+  const visitors = Number(eventTotals?.visitors ?? eventTotals?.uniqueSessions ?? 0) || 0;
+  const pageViews = Number(eventTotals?.pageViews ?? eventTotals?.count ?? 0) || 0;
+  const totalEvents = Number(eventTotals?.count ?? 0) || 0;
+  const revenue = Number(adTotals?.revenue ?? 0) || 0;
+  const clicks = Number(adTotals?.clicks ?? 0) || 0;
+  const impressions = Number(adTotals?.impressions ?? 0) || 0;
+
+  const visitorEvents = eventTotals?.visitorEventNames || [];
+  const pageViewEvents = eventTotals?.pageViewEventNames || [];
+
+  const derived = {
+    revenuePerVisitor: visitors > 0 ? revenue / visitors : 0,
+    eventsPerClick: clicks > 0 ? totalEvents / clicks : 0,
+    pageviewToImpression: impressions > 0 ? pageViews / impressions : 0,
+  };
+
+  const descriptions = {
+    revenuePerVisitor: `${formatEventList(visitorEvents, '방문 이벤트')} 대비 수익 (${formatNumber(visitors)}명 기준)`,
+    eventsPerClick: `${formatNumber(totalEvents)}건 ÷ 수익 클릭 ${formatNumber(clicks)}회`,
+    pageviewToImpression: `${formatEventList(pageViewEvents, '페이지 뷰 이벤트')} ÷ 노출 ${formatNumber(impressions)}`,
+  };
+
+  const valueRenderers = {
+    revenuePerVisitor: (value) => `$${formatDecimal(value, 3)}`,
+    eventsPerClick: (value) => formatDecimal(value, 2),
+    pageviewToImpression: (value) => formatPercent(value),
+  };
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-3">
+      {CARD_CONFIG.map((card) => {
+        const value = derived[card.key] || 0;
+        const render = valueRenderers[card.key];
+        return (
+          <div
+            key={card.key}
+            className={clsx(
+              'rounded-2xl border bg-slate-950/70 p-5 shadow-lg shadow-black/20',
+              card.border,
+              `bg-gradient-to-br ${card.accent}`
+            )}
+          >
+            <p className="text-xs uppercase tracking-[0.3em] text-slate-300">{card.title}</p>
+            <p className="mt-3 text-3xl font-extrabold text-white">{render(value)}</p>
+            <p className="mt-2 text-xs text-slate-400">{descriptions[card.key]}</p>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/admin/layout/AdminNav.jsx
+++ b/components/admin/layout/AdminNav.jsx
@@ -14,6 +14,7 @@ export default function AdminNav({ items, activeView, onChange }) {
               }}
               disabled={disabled}
               aria-pressed={active}
+              aria-label={item.ariaLabel || item.label}
               className={`rounded-full px-4 py-2 text-sm font-semibold transition-all duration-200 ease-out focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-400 ${
                 active
                   ? 'bg-gradient-to-r from-indigo-400 via-sky-400 to-emerald-400 text-slate-950 shadow-lg shadow-emerald-500/30'

--- a/components/admin/uploads/UploadedItemCard.jsx
+++ b/components/admin/uploads/UploadedItemCard.jsx
@@ -38,11 +38,6 @@ export default function UploadedItemCard({
         ) : (
           <div className="grid h-full w-full place-items-center text-xs text-slate-400">No preview</div>
         )}
-        {item.type && (
-          <span className="absolute left-3 top-3 rounded-full bg-black/60 px-2 py-0.5 text-[11px] font-semibold uppercase text-white">
-            {item.type}
-          </span>
-        )}
         {item._error && (
           <span className="absolute right-3 top-3 rounded-full bg-rose-600/80 px-2 py-0.5 text-[11px] font-semibold text-white shadow-lg">
             메타 오류

--- a/hooks/admin/useAnalyticsMetrics.js
+++ b/hooks/admin/useAnalyticsMetrics.js
@@ -338,11 +338,13 @@ export default function useAnalyticsMetrics({
     [rowsWithDisplayMetrics]
   );
 
-  const averageLikeRate = useMemo(() => {
-    const withViews = rowsWithDisplayMetrics.filter((row) => row.displayMetrics && row.displayMetrics.views > 0);
-    if (!withViews.length) return 0;
-    const totalRate = withViews.reduce((acc, row) => acc + row.displayMetrics.likes / row.displayMetrics.views, 0);
-    return totalRate / withViews.length;
+  const averageViewsPerContent = useMemo(() => {
+    const withMetrics = rowsWithDisplayMetrics.filter((row) => row.displayMetrics);
+    if (!withMetrics.length) {
+      return 0;
+    }
+    const totalViews = withMetrics.reduce((acc, row) => acc + (row.displayMetrics.views || 0), 0);
+    return totalViews / withMetrics.length;
   }, [rowsWithDisplayMetrics]);
 
   const aggregatedRangeTotals = useMemo(() => {
@@ -614,7 +616,7 @@ export default function useAnalyticsMetrics({
     isRangeActive: rangeActive,
     trendHistory,
     exportRows,
-    averageLikeRate,
+    averageViewsPerContent,
     filteredItems,
     filters,
     setFilters,

--- a/hooks/admin/useEventAnalytics.js
+++ b/hooks/admin/useEventAnalytics.js
@@ -2,7 +2,17 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 
 const EMPTY_SUMMARY = Object.freeze({
   items: [],
-  totals: { count: 0, uniqueSessions: 0 },
+  totals: {
+    count: 0,
+    uniqueSessions: 0,
+    visitors: 0,
+    pageViews: 0,
+    bounceEvents: 0,
+    bounceRate: 0,
+    pageViewEventNames: [],
+    visitorEventNames: [],
+    bounceEventNames: [],
+  },
   timeseries: [],
   catalog: { events: [], slugsByEvent: {} },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-i18next": "^14.1.1",
+        "recharts": "^2.13.3",
         "video.js": "^8.23.4"
       },
       "devDependencies": {
@@ -586,6 +587,69 @@
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1421,8 +1485,128 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -1496,6 +1680,12 @@
         }
       }
     },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1564,6 +1754,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dom-walk": {
@@ -2061,12 +2261,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.3.2.tgz",
+      "integrity": "sha512-6rxyATwPCkaFIL3JLqw8qXqMpIZ942pTX/tbQFkRsDGblS8tNGtlUauA/+mt6RUfqn/4MoEr+WDkYoIQbibWuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -2630,6 +2845,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -3255,6 +3479,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -3581,7 +3811,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4031,7 +4260,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -4123,6 +4351,37 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -4145,6 +4404,44 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -4927,6 +5224,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5128,6 +5431,28 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
     },
     "node_modules/video.js": {
       "version": "8.23.4",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-i18next": "^14.1.1",
+    "recharts": "^2.13.3",
     "video.js": "^8.23.4"
   },
   "devDependencies": {


### PR DESCRIPTION
## 요약
- 관리자 네비게이션과 섹션 문구를 요구사항에 맞춰 갱신하고 업로드 카드의 IMAGE 배지를 제거했습니다.
- 분석, 이벤트, 수익, 인사이트 영역을 리팩터링하여 Recharts 기반 그래프로 교체하고 평균 조회수, 방문자/페이지뷰/이탈률 등 새로운 지표를 제공합니다.
- Adsterra 통계를 한국 표준시로 정규화하고 통합 인사이트 섹션을 이벤트-수익 상관 분석 중심으로 재구성했습니다.
- 히트맵, 뷰 정렬 UI 등의 모바일 대응과 새로고침 시 탭 유지 등 사용성 개선을 적용했습니다.

## 테스트
- `npm run lint` *(기존 React import/prop-types 규칙 위반으로 실패)*


------
https://chatgpt.com/codex/tasks/task_e_68d6e395f30c8323abd20df5ed176fd7