### PR TITLE
feat: 관리자 대시보드 명칭 및 분석 UI 개선

### DIFF
--- a/components/admin/adsterra/AdsterraChartPanel.jsx
+++ b/components/admin/adsterra/AdsterraChartPanel.jsx
@@ -1,9 +1,20 @@
 import { useMemo } from 'react';
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  Legend,
+  Line,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
 
 function buildSeries(rows) {
   const map = new Map();
   rows.forEach((row) => {
-    const dateLabel = row?.date || row?.day || row?.Day || row?.group;
+    const dateLabel = row?.kstDate || row?.date || row?.day || row?.Day || row?.group;
     if (!dateLabel) return;
     const impressions = Number(row?.impression ?? row?.impressions ?? 0) || 0;
     const clicks = Number(row?.clicks ?? row?.click ?? 0) || 0;
@@ -14,7 +25,24 @@ function buildSeries(rows) {
     current.revenue += revenue;
     map.set(dateLabel, current);
   });
-  return Array.from(map.entries()).sort((a, b) => new Date(a[0]) - new Date(b[0]));
+  return Array.from(map.entries())
+    .map(([date, value]) => ({ date, ...value }))
+    .sort((a, b) => new Date(a.date) - new Date(b.date));
+}
+
+function ChartTooltip({ active, payload, label, formatNumber }) {
+  if (!active || !payload?.length) return null;
+  const impressionEntry = payload.find((item) => item.dataKey === 'impressions');
+  const clickEntry = payload.find((item) => item.dataKey === 'clicks');
+  const revenueEntry = payload.find((item) => item.dataKey === 'revenue');
+  return (
+    <div className="rounded-lg border border-slate-800/70 bg-slate-950/90 px-3 py-2 text-xs text-slate-200 shadow-lg">
+      <p className="font-semibold text-white">{label}</p>
+      <p className="mt-1">노출: {formatNumber(impressionEntry?.value || 0)}</p>
+      <p>클릭: {formatNumber(clickEntry?.value || 0)}</p>
+      <p>수익 (USD): {(revenueEntry?.value || 0).toFixed(3)}</p>
+    </div>
+  );
 }
 
 export default function AdsterraChartPanel({ rows, formatNumber }) {
@@ -27,18 +55,7 @@ export default function AdsterraChartPanel({ rows, formatNumber }) {
     );
   }
 
-  const maxImpressions = Math.max(...series.map(([, value]) => value.impressions), 1);
-  const width = 600;
-  const height = 160;
-  const stepX = width / Math.max(series.length - 1, 1);
-
-  const linePath = series
-    .map(([, value], index) => {
-      const x = index * stepX;
-      const y = height - (value.impressions / maxImpressions) * height;
-      return `${index === 0 ? 'M' : 'L'}${x},${y}`;
-    })
-    .join(' ');
+  const maxImpressions = Math.max(...series.map((entry) => entry.impressions), 1);
 
   return (
     <div className="rounded-2xl border border-slate-800/70 bg-slate-900/80 p-6">
@@ -47,26 +64,70 @@ export default function AdsterraChartPanel({ rows, formatNumber }) {
           <p className="text-xs uppercase tracking-widest text-slate-500">노출 추세</p>
           <p className="text-lg font-semibold text-white">최근 {series.length}일</p>
         </div>
-        <div className="text-xs text-slate-400">
-          최고 노출 {formatNumber(maxImpressions)}
-        </div>
+        <div className="text-xs text-slate-400">최고 노출 {formatNumber(maxImpressions)}</div>
       </div>
-      <svg viewBox={`0 0 ${width} ${height}`} className="mt-4 h-40 w-full">
-        <defs>
-          <linearGradient id="adsterra-impressions" x1="0" x2="0" y1="0" y2="1">
-            <stop offset="0%" stopColor="#34d399" stopOpacity="0.8" />
-            <stop offset="100%" stopColor="#34d399" stopOpacity="0" />
-          </linearGradient>
-        </defs>
-        <path d={`${linePath} L${width},${height} L0,${height} Z`} fill="url(#adsterra-impressions)" />
-        <path d={linePath} stroke="#34d399" strokeWidth="3" fill="none" strokeLinecap="round" />
-      </svg>
+      <div className="mt-4 h-72 w-full">
+        <ResponsiveContainer>
+          <AreaChart data={series} margin={{ top: 16, right: 24, left: 0, bottom: 12 }}>
+            <defs>
+              <linearGradient id="adsterra-impressions" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="rgba(52, 211, 153, 0.6)" />
+                <stop offset="100%" stopColor="rgba(52, 211, 153, 0)" />
+              </linearGradient>
+            </defs>
+            <CartesianGrid stroke="rgba(148, 163, 184, 0.15)" strokeDasharray="4 4" vertical={false} />
+            <XAxis dataKey="date" stroke="rgba(148, 163, 184, 0.6)" tickLine={false} />
+            <YAxis
+              yAxisId="left"
+              stroke="rgba(148, 163, 184, 0.6)"
+              tickFormatter={(value) => formatNumber(Math.round(value))}
+              allowDecimals={false}
+            />
+            <YAxis
+              yAxisId="right"
+              orientation="right"
+              stroke="rgba(148, 163, 184, 0.4)"
+              tickFormatter={(value) => value.toFixed(2)}
+            />
+            <Tooltip content={(props) => <ChartTooltip {...props} formatNumber={formatNumber} />} />
+            <Legend wrapperStyle={{ color: 'rgba(226, 232, 240, 0.85)' }} />
+            <Area
+              type="monotone"
+              dataKey="impressions"
+              stroke="rgb(52, 211, 153)"
+              strokeWidth={3}
+              fill="url(#adsterra-impressions)"
+              dot={{ r: 3 }}
+              name="노출"
+              yAxisId="left"
+            />
+            <Line
+              type="monotone"
+              dataKey="clicks"
+              stroke="rgb(14, 165, 233)"
+              strokeWidth={3}
+              dot={{ r: 3 }}
+              name="클릭"
+              yAxisId="left"
+            />
+            <Line
+              type="monotone"
+              dataKey="revenue"
+              stroke="rgb(249, 115, 22)"
+              strokeWidth={2}
+              dot={{ r: 2 }}
+              name="수익 (USD)"
+              yAxisId="right"
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
       <div className="mt-3 grid grid-cols-2 gap-2 text-[11px] text-slate-400 sm:grid-cols-4">
-        {series.map(([date, value]) => (
-          <div key={date} className="rounded-lg bg-slate-900/60 px-3 py-2">
-            <p className="font-semibold text-slate-200">{date}</p>
-            <p>노출 {formatNumber(value.impressions)}</p>
-            <p>클릭 {formatNumber(value.clicks)}</p>
+        {series.map((entry) => (
+          <div key={entry.date} className="rounded-lg bg-slate-900/60 px-3 py-2">
+            <p className="font-semibold text-slate-200">{entry.date}</p>
+            <p>노출 {formatNumber(entry.impressions)}</p>
+            <p>클릭 {formatNumber(entry.clicks)}</p>
           </div>
         ))}
       </div>

--- a/components/admin/adsterra/AdsterraStatsTable.jsx
+++ b/components/admin/adsterra/AdsterraStatsTable.jsx
@@ -44,7 +44,8 @@ export default function AdsterraStatsTable({
                   row?.cpm ??
                     (impressions > 0 && revenue >= 0 ? (revenue / impressions) * 1000 : 0)
                 ) || 0;
-              const dateLabel = row?.date || row?.day || row?.Day || row?.group || `#${index + 1}`;
+              const dateLabel =
+                row?.kstDate || row?.date || row?.day || row?.Day || row?.group || `#${index + 1}`;
               const countryLabel = row?.country ?? row?.Country ?? row?.geo ?? row?.Geo ?? '—';
               const osLabel = row?.os ?? row?.OS ?? row?.platform ?? row?.Platform ?? '—';
               const deviceLabel = row?.device ?? row?.Device ?? row?.device_type ?? row?.deviceType ?? '—';

--- a/components/admin/analytics/AnalyticsOverview.jsx
+++ b/components/admin/analytics/AnalyticsOverview.jsx
@@ -1,9 +1,8 @@
 export default function AnalyticsOverview({
   itemCount,
   totals,
-  averageLikeRate,
+  averageViewsPerContent,
   formatNumber,
-  formatPercent,
 }) {
   return (
     <div className="grid gap-4 md:grid-cols-3">
@@ -18,9 +17,9 @@ export default function AnalyticsOverview({
         <p className="mt-1 text-xs text-slate-500">metrics 기준 누적</p>
       </div>
       <div className="rounded-2xl border border-white/5 bg-slate-900/80 p-4 shadow-lg shadow-black/20">
-        <p className="text-xs uppercase tracking-[0.25em] text-slate-400">평균 좋아요율</p>
-        <p className="mt-2 text-2xl font-bold text-white">{formatPercent(averageLikeRate)}</p>
-        <p className="mt-1 text-xs text-slate-500">조회가 있는 콘텐츠 평균</p>
+        <p className="text-xs uppercase tracking-[0.25em] text-slate-400">콘텐츠당 평균 조회수</p>
+        <p className="mt-2 text-2xl font-bold text-white">{formatNumber(Math.round(averageViewsPerContent))}</p>
+        <p className="mt-1 text-xs text-slate-500">총 조회수 ÷ 콘텐츠 수</p>
       </div>
     </div>
   );

--- a/components/admin/analytics/AnalyticsToolbar.jsx
+++ b/components/admin/analytics/AnalyticsToolbar.jsx
@@ -35,34 +35,37 @@ export default function AnalyticsToolbar({
 
   return (
     <div className="flex flex-col gap-4 rounded-2xl bg-slate-900/70 p-4 ring-1 ring-slate-800/60">
-      <div className="flex flex-wrap items-center gap-2 text-xs">
-        <span className="rounded-full bg-slate-950/60 px-3 py-1 text-slate-400">정렬 기준</span>
-        <button
-          type="button"
-          onClick={() => onSortChange('views')}
-          className={`rounded-full px-3 py-1 font-semibold transition ${
-            sortKey === 'views' ? 'bg-indigo-500 text-white' : 'bg-slate-800 text-slate-300'
-          }`}
-        >
-          조회수 {sortKey === 'views' ? (sortDirection === 'asc' ? '↑' : '↓') : ''}
-        </button>
-        <button
-          type="button"
-          onClick={() => onSortChange('likes')}
-          className={`rounded-full px-3 py-1 font-semibold transition ${
-            sortKey === 'likes' ? 'bg-indigo-500 text-white' : 'bg-slate-800 text-slate-300'
-          }`}
-        >
-          좋아요 {sortKey === 'likes' ? (sortDirection === 'asc' ? '↑' : '↓') : ''}
-        </button>
+      <div className="flex flex-col gap-2 text-xs sm:flex-row sm:items-center sm:gap-3">
+        <span className="inline-flex w-full items-center justify-center rounded-full bg-slate-950/60 px-3 py-1 text-slate-400 sm:w-auto">
+          정렬 기준
+        </span>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+          <button
+            type="button"
+            onClick={() => onSortChange('views')}
+            className={`w-full rounded-full px-3 py-2 font-semibold transition sm:w-auto ${
+              sortKey === 'views' ? 'bg-indigo-500 text-white' : 'bg-slate-800 text-slate-300'
+            }`}
+          >
+            조회수 {sortKey === 'views' ? (sortDirection === 'asc' ? '↑' : '↓') : ''}
+          </button>
+          <button
+            type="button"
+            onClick={() => onSortChange('likes')}
+            className={`w-full rounded-full px-3 py-2 font-semibold transition sm:w-auto ${
+              sortKey === 'likes' ? 'bg-indigo-500 text-white' : 'bg-slate-800 text-slate-300'
+            }`}
+          >
+            좋아요 {sortKey === 'likes' ? (sortDirection === 'asc' ? '↑' : '↓') : ''}
+          </button>
+        </div>
       </div>
-      <div className="flex flex-col gap-3 text-xs text-slate-300 md:flex-row md:items-center md:justify-between">
-
-        <div className="flex flex-wrap items-center gap-2">
+      <div className="flex flex-col gap-3 text-xs text-slate-300 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex flex-wrap gap-2">
           {Object.entries(visibleColumns).map(([key, value]) => (
             <label
               key={key}
-              className="flex items-center gap-1 rounded-full bg-slate-950/50 px-3 py-1 capitalize"
+              className="flex w-full items-center gap-1 rounded-full bg-slate-950/50 px-3 py-1 capitalize sm:w-auto"
             >
               <input
                 type="checkbox"
@@ -74,41 +77,40 @@ export default function AnalyticsToolbar({
             </label>
           ))}
         </div>
-        <div className="flex flex-wrap items-center gap-2 text-xs">
-          <span className="rounded-full bg-slate-950/50 px-3 py-1 text-slate-400">
+        <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
+          <span className="inline-flex items-center justify-center rounded-full bg-slate-950/50 px-3 py-1 text-slate-400">
             선택 {selectedCount}개
           </span>
           <button
             type="button"
             onClick={onOpenBulkEditor}
             disabled={!selectedCount}
-            className="rounded-full border border-slate-700/60 px-4 py-2 font-semibold text-slate-200 transition enabled:hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-50"
+            className="w-full rounded-full border border-slate-700/60 px-4 py-2 font-semibold text-slate-200 transition enabled:hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
           >
             선택 항목 편집
           </button>
           <button
             type="button"
             onClick={onOpenHistory}
-            className="rounded-full border border-slate-700/60 px-4 py-2 font-semibold text-slate-200 transition hover:bg-slate-800"
+            className="w-full rounded-full border border-slate-700/60 px-4 py-2 font-semibold text-slate-200 transition hover:bg-slate-800 sm:w-auto"
           >
             변경 이력
           </button>
           <button
             type="button"
             onClick={onOpenCsvUpload}
-            className="rounded-full border border-indigo-500/60 px-4 py-2 font-semibold text-indigo-200 transition hover:bg-indigo-500/20"
+            className="w-full rounded-full border border-indigo-500/60 px-4 py-2 font-semibold text-indigo-200 transition hover:bg-indigo-500/20 sm:w-auto"
           >
             CSV 업로드
           </button>
           <button
             type="button"
             onClick={onExportCsv}
-            className="rounded-full bg-gradient-to-r from-emerald-400 via-teal-400 to-cyan-400 px-4 py-2 font-semibold text-slate-950 shadow-lg shadow-emerald-500/30 transition hover:brightness-110"
+            className="w-full rounded-full bg-gradient-to-r from-emerald-400 via-teal-400 to-cyan-400 px-4 py-2 font-semibold text-slate-950 shadow-lg shadow-emerald-500/30 transition hover:brightness-110 sm:w-auto"
           >
             CSV 다운로드
           </button>
         </div>
-
       </div>
     </div>
   );

--- a/components/admin/analytics/AnalyticsTrendChart.jsx
+++ b/components/admin/analytics/AnalyticsTrendChart.jsx
@@ -1,25 +1,26 @@
 import { useMemo } from 'react';
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
 
-function buildPolylinePoints(history, key, width, height, padding) {
-  if (!history.length) return '';
-  const maxValue = Math.max(...history.map((entry) => Math.max(0, Number(entry[key]) || 0)));
-  if (maxValue === 0) {
-    const baselineY = height - padding;
-    return history
-      .map((entry, index) => {
-        const x = padding + (index / Math.max(1, history.length - 1)) * (width - padding * 2);
-        return `${x},${baselineY}`;
-      })
-      .join(' ');
-  }
-  return history
-    .map((entry, index) => {
-      const value = Math.max(0, Number(entry[key]) || 0);
-      const x = padding + (index / Math.max(1, history.length - 1)) * (width - padding * 2);
-      const y = padding + (1 - value / maxValue) * (height - padding * 2);
-      return `${x},${y}`;
-    })
-    .join(' ');
+function TrendTooltip({ active, payload, label, formatNumber }) {
+  if (!active || !payload?.length) return null;
+  const views = payload.find((item) => item.dataKey === 'views');
+  const likes = payload.find((item) => item.dataKey === 'likes');
+  return (
+    <div className="rounded-lg border border-slate-800/70 bg-slate-950/90 px-3 py-2 text-xs text-slate-200 shadow-lg">
+      <p className="font-semibold text-white">{label}</p>
+      <p className="mt-1">조회수: {formatNumber(views?.value || 0)}</p>
+      <p>좋아요: {formatNumber(likes?.value || 0)}</p>
+    </div>
+  );
 }
 
 export default function AnalyticsTrendChart({ history, formatNumber }) {
@@ -41,16 +42,7 @@ export default function AnalyticsTrendChart({ history, formatNumber }) {
     return null;
   }
 
-  const width = 720;
-  const height = 280;
-  const padding = 32;
-
-  const viewsPoints = buildPolylinePoints(sanitizedHistory, 'views', width, height, padding);
-  const likesPoints = buildPolylinePoints(sanitizedHistory, 'likes', width, height, padding);
-  const maxValue = Math.max(
-    ...sanitizedHistory.map((entry) => Math.max(entry.views, entry.likes)),
-    0
-  );
+  const maxValue = Math.max(...sanitizedHistory.map((entry) => Math.max(entry.views, entry.likes)), 0);
 
   return (
     <div className="rounded-2xl border border-slate-800/60 bg-slate-900/70 p-4 shadow-inner shadow-black/30">
@@ -65,71 +57,58 @@ export default function AnalyticsTrendChart({ history, formatNumber }) {
           </span>
         </div>
       </div>
-      <div className="relative">
-        <svg viewBox={`0 0 ${width} ${height}`} className="w-full">
-          <defs>
-            <linearGradient id="trendViews" x1="0%" y1="0%" x2="0%" y2="100%">
-              <stop offset="0%" stopColor="rgba(99, 102, 241, 0.35)" />
-              <stop offset="100%" stopColor="rgba(99, 102, 241, 0)" />
-            </linearGradient>
-            <linearGradient id="trendLikes" x1="0%" y1="0%" x2="0%" y2="100%">
-              <stop offset="0%" stopColor="rgba(244, 114, 182, 0.4)" />
-              <stop offset="100%" stopColor="rgba(244, 114, 182, 0)" />
-            </linearGradient>
-          </defs>
-          <rect
-            x={padding}
-            y={padding}
-            width={width - padding * 2}
-            height={height - padding * 2}
-            fill="transparent"
-            stroke="rgba(148, 163, 184, 0.2)"
-            strokeDasharray="4 4"
-          />
-          {viewsPoints && (
-            <>
-              <polyline
-                points={viewsPoints}
-                fill="none"
-                stroke="rgb(99, 102, 241)"
-                strokeWidth="2"
-                strokeLinejoin="round"
-                strokeLinecap="round"
-              />
-              <polygon
-                points={`${viewsPoints} ${padding + (width - padding * 2)},${height - padding} ${padding},${height - padding}`}
-                fill="url(#trendViews)"
-                opacity="0.4"
-              />
-            </>
-          )}
-          {likesPoints && (
-            <>
-              <polyline
-                points={likesPoints}
-                fill="none"
-                stroke="rgb(244, 114, 182)"
-                strokeWidth="2"
-                strokeLinejoin="round"
-                strokeLinecap="round"
-              />
-              <polygon
-                points={`${likesPoints} ${padding + (width - padding * 2)},${height - padding} ${padding},${height - padding}`}
-                fill="url(#trendLikes)"
-                opacity="0.35"
-              />
-            </>
-          )}
-        </svg>
-        <div className="mt-4 grid grid-cols-2 gap-2 text-[11px] text-slate-400 sm:grid-cols-4">
-          {sanitizedHistory.map((entry) => (
-            <div key={entry.date} className="flex flex-col rounded-lg bg-slate-950/40 px-2 py-1">
-              <span className="text-slate-300">{entry.date}</span>
-              <span className="text-[10px] text-slate-500">조회수 {formatNumber(entry.views)}</span>
-              <span className="text-[10px] text-slate-500">좋아요 {formatNumber(entry.likes)}</span>
-            </div>
-          ))}
-        </div>
+      <div className="relative h-72 w-full">
+        <ResponsiveContainer>
+          <AreaChart data={sanitizedHistory} margin={{ top: 16, right: 24, left: 0, bottom: 8 }}>
+            <defs>
+              <linearGradient id="analyticsViews" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="rgba(99, 102, 241, 0.55)" />
+                <stop offset="100%" stopColor="rgba(99, 102, 241, 0)" />
+              </linearGradient>
+              <linearGradient id="analyticsLikes" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="rgba(244, 114, 182, 0.55)" />
+                <stop offset="100%" stopColor="rgba(244, 114, 182, 0)" />
+              </linearGradient>
+            </defs>
+            <CartesianGrid stroke="rgba(148, 163, 184, 0.18)" strokeDasharray="4 4" vertical={false} />
+            <XAxis dataKey="date" stroke="rgba(148, 163, 184, 0.6)" tickLine={false} />
+            <YAxis
+              stroke="rgba(148, 163, 184, 0.6)"
+              tickLine={false}
+              tickFormatter={(value) => formatNumber(Math.round(value))}
+              allowDecimals={false}
+            />
+            <Tooltip content={(props) => <TrendTooltip {...props} formatNumber={formatNumber} />} />
+            <Legend wrapperStyle={{ color: 'rgba(226, 232, 240, 0.9)' }} />
+            <Area
+              type="monotone"
+              dataKey="views"
+              stroke="rgb(99, 102, 241)"
+              strokeWidth={3}
+              fill="url(#analyticsViews)"
+              dot={{ r: 3 }}
+              name="조회수"
+            />
+            <Area
+              type="monotone"
+              dataKey="likes"
+              stroke="rgb(244, 114, 182)"
+              strokeWidth={3}
+              fill="url(#analyticsLikes)"
+              dot={{ r: 3 }}
+              name="좋아요"
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+      <div className="mt-4 grid grid-cols-2 gap-2 text-[11px] text-slate-400 sm:grid-cols-4">
+        {sanitizedHistory.map((entry) => (
+          <div key={entry.date} className="flex flex-col rounded-lg bg-slate-950/40 px-2 py-1">
+            <span className="text-slate-300">{entry.date}</span>
+            <span className="text-[10px] text-slate-500">조회수 {formatNumber(entry.views)}</span>
+            <span className="text-[10px] text-slate-500">좋아요 {formatNumber(entry.likes)}</span>
+          </div>
+        ))}
       </div>
       <div className="mt-4 text-right text-[11px] uppercase tracking-[0.3em] text-slate-500">
         최대값 {formatNumber(maxValue)}

--- a/components/admin/events/EventSummaryCards.jsx
+++ b/components/admin/events/EventSummaryCards.jsx
@@ -1,24 +1,49 @@
-export default function EventSummaryCards({ totals, formatNumber }) {
-  const totalCount = Number(totals?.count) || 0;
-  const uniqueSessions = Number(totals?.uniqueSessions) || 0;
+function aggregateByEvent(items) {
+  const map = new Map();
+  if (!Array.isArray(items)) return map;
+  items.forEach((item) => {
+    const name = typeof item?.eventName === 'string' ? item.eventName : '';
+    if (!name) return;
+    const prev = map.get(name) || { count: 0, uniqueSessions: 0 };
+    const count = Number(item?.count) || 0;
+    const uniqueSessions = Number(item?.uniqueSessions) || 0;
+    map.set(name, {
+      count: prev.count + count,
+      uniqueSessions: prev.uniqueSessions + uniqueSessions,
+    });
+  });
+  return map;
+}
+
+function formatPercentDefault(value) {
+  return `${(Math.max(0, Math.min(1, value || 0)) * 100).toFixed(1)}%`;
+}
+
+export default function EventSummaryCards({ totals, items = [], formatNumber, formatPercent = formatPercentDefault }) {
+  const stats = aggregateByEvent(items);
+  const visits = stats.get('x_visit') || { count: Number(totals?.count) || 0, uniqueSessions: Number(totals?.uniqueSessions) || 0 };
+  const anyClick = stats.get('x_any_click') || { count: 0 };
+
+  const visitorCount = Number(visits.uniqueSessions) || 0;
+  const pageViews = Number(visits.count) || 0;
+  const bounceRate = pageViews > 0 ? Math.max(0, Math.min(1, 1 - anyClick.count / pageViews)) : 0;
+
   return (
     <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
       <div className="rounded-2xl border border-slate-800/70 bg-slate-900/80 p-4 shadow-inner shadow-black/40">
-        <p className="text-xs uppercase tracking-[0.3em] text-slate-400">총 이벤트 수</p>
-        <p className="mt-2 text-3xl font-bold text-white">{formatNumber(totalCount)}</p>
-        <p className="mt-1 text-xs text-slate-500">선택한 기간 동안 수집된 이벤트 합계</p>
+        <p className="text-xs uppercase tracking-[0.3em] text-slate-400">방문자</p>
+        <p className="mt-2 text-3xl font-bold text-white">{formatNumber(visitorCount)}</p>
+        <p className="mt-1 text-xs text-slate-500">고유 세션 수 = uniqueSessions(x_visit)</p>
       </div>
       <div className="rounded-2xl border border-slate-800/70 bg-slate-900/80 p-4 shadow-inner shadow-black/40">
-        <p className="text-xs uppercase tracking-[0.3em] text-slate-400">고유 세션</p>
-        <p className="mt-2 text-3xl font-bold text-white">{formatNumber(uniqueSessions)}</p>
-        <p className="mt-1 text-xs text-slate-500">동일 기간 내 이벤트를 발생시킨 고유 세션 수</p>
+        <p className="text-xs uppercase tracking-[0.3em] text-slate-400">페이지 뷰</p>
+        <p className="mt-2 text-3xl font-bold text-white">{formatNumber(pageViews)}</p>
+        <p className="mt-1 text-xs text-slate-500">페이지 뷰 = Σ count(x_visit)</p>
       </div>
       <div className="rounded-2xl border border-emerald-500/40 bg-gradient-to-br from-emerald-500/10 via-teal-500/5 to-transparent p-4 shadow-lg shadow-emerald-500/20">
-        <p className="text-xs uppercase tracking-[0.3em] text-emerald-200">평균 이벤트 수/세션</p>
-        <p className="mt-2 text-3xl font-bold text-emerald-100">
-          {uniqueSessions > 0 ? (totalCount / uniqueSessions).toFixed(2) : '0.00'}
-        </p>
-        <p className="mt-1 text-xs text-emerald-200/80">고유 세션 대비 이벤트 발생량</p>
+        <p className="text-xs uppercase tracking-[0.3em] text-emerald-200">이탈률</p>
+        <p className="mt-2 text-3xl font-bold text-emerald-100">{formatPercent(bounceRate)}</p>
+        <p className="mt-1 text-xs text-emerald-200/80">이탈률 = 1 - (count(x_any_click) ÷ count(x_visit))</p>
       </div>
     </div>
   );

--- a/components/admin/events/EventTrendChart.jsx
+++ b/components/admin/events/EventTrendChart.jsx
@@ -1,25 +1,15 @@
 import { useMemo } from 'react';
+import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 
-function buildPoints(series, width, height, padding) {
-  if (!Array.isArray(series) || !series.length) return '';
-  const max = Math.max(...series.map((entry) => Number(entry.count) || 0), 0);
-  if (max <= 0) {
-    return series
-      .map((_, index) => {
-        const x = padding + (index / Math.max(series.length - 1, 1)) * (width - padding * 2);
-        const y = height - padding;
-        return `${x},${y}`;
-      })
-      .join(' ');
-  }
-  return series
-    .map((entry, index) => {
-      const value = Math.max(0, Number(entry.count) || 0);
-      const x = padding + (index / Math.max(series.length - 1, 1)) * (width - padding * 2);
-      const y = padding + (1 - value / max) * (height - padding * 2);
-      return `${x},${y}`;
-    })
-    .join(' ');
+function TrendTooltip({ active, payload, label, formatNumber }) {
+  if (!active || !payload?.length) return null;
+  const value = payload[0]?.value || 0;
+  return (
+    <div className="rounded-lg border border-slate-800/70 bg-slate-950/90 px-3 py-2 text-xs text-slate-200 shadow-lg">
+      <p className="font-semibold text-white">{label}</p>
+      <p className="mt-1">이벤트 수: {formatNumber(value)}</p>
+    </div>
+  );
 }
 
 export default function EventTrendChart({ series, formatNumber }) {
@@ -37,10 +27,6 @@ export default function EventTrendChart({ series, formatNumber }) {
     return null;
   }
 
-  const width = 720;
-  const height = 240;
-  const padding = 32;
-  const points = buildPoints(sanitized, width, height, padding);
   const maxValue = Math.max(...sanitized.map((entry) => entry.count), 0);
 
   return (
@@ -49,40 +35,36 @@ export default function EventTrendChart({ series, formatNumber }) {
         <span>기간별 이벤트 추이</span>
         <span className="text-[11px] text-slate-300">최대 {formatNumber(maxValue)}건</span>
       </div>
-      <svg viewBox={`0 0 ${width} ${height}`} className="w-full">
-        <defs>
-          <linearGradient id="eventTrend" x1="0" x2="0" y1="0" y2="1">
-            <stop offset="0%" stopColor="rgba(129, 140, 248, 0.6)" />
-            <stop offset="100%" stopColor="rgba(129, 140, 248, 0)" />
-          </linearGradient>
-        </defs>
-        <rect
-          x={padding}
-          y={padding}
-          width={width - padding * 2}
-          height={height - padding * 2}
-          fill="transparent"
-          stroke="rgba(148, 163, 184, 0.25)"
-          strokeDasharray="4 4"
-        />
-        {points && (
-          <>
-            <polyline
-              points={points}
-              fill="none"
+      <div className="relative h-64 w-full">
+        <ResponsiveContainer>
+          <AreaChart data={sanitized} margin={{ top: 16, right: 24, left: 0, bottom: 8 }}>
+            <defs>
+              <linearGradient id="eventTrend" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="rgba(129, 140, 248, 0.65)" />
+                <stop offset="100%" stopColor="rgba(129, 140, 248, 0)" />
+              </linearGradient>
+            </defs>
+            <CartesianGrid stroke="rgba(148, 163, 184, 0.2)" strokeDasharray="4 4" vertical={false} />
+            <XAxis dataKey="date" stroke="rgba(148, 163, 184, 0.6)" tickLine={false} />
+            <YAxis
+              stroke="rgba(148, 163, 184, 0.6)"
+              tickLine={false}
+              allowDecimals={false}
+              tickFormatter={(value) => formatNumber(Math.round(value))}
+            />
+            <Tooltip content={(props) => <TrendTooltip {...props} formatNumber={formatNumber} />} />
+            <Area
+              type="monotone"
+              dataKey="count"
               stroke="rgb(129, 140, 248)"
-              strokeWidth="2.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-            <polygon
-              points={`${points} ${padding + (width - padding * 2)},${height - padding} ${padding},${height - padding}`}
+              strokeWidth={3}
               fill="url(#eventTrend)"
-              opacity="0.4"
+              dot={{ r: 3 }}
+              name="이벤트 수"
             />
-          </>
-        )}
-      </svg>
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
       <div className="mt-4 grid grid-cols-2 gap-2 text-[11px] text-slate-400 sm:grid-cols-4">
         {sanitized.map((entry) => (
           <div key={entry.date} className="rounded-lg bg-slate-950/40 px-3 py-2">

--- a/components/admin/heatmap/HeatmapGrid.jsx
+++ b/components/admin/heatmap/HeatmapGrid.jsx
@@ -81,11 +81,13 @@ export default function HeatmapGrid({ grid, cells, maxCount, formatNumber }) {
 
   return (
     <div className="rounded-3xl border border-slate-800/80 bg-slate-950/80 p-4">
-      <div
-        className="grid gap-[3px]"
-        style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }}
-      >
-        {items}
+      <div className="max-h-[32rem] overflow-auto">
+        <div
+          className="grid gap-[3px]"
+          style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }}
+        >
+          {items}
+        </div>
       </div>
     </div>
   );

--- a/components/admin/heatmap/HeatmapPanel.jsx
+++ b/components/admin/heatmap/HeatmapPanel.jsx
@@ -114,7 +114,7 @@ export default function HeatmapPanel({
       <div className="rounded-3xl border border-indigo-500/40 bg-slate-950/80 p-6 shadow-inner shadow-indigo-500/20">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
           <div>
-            <h2 className="text-2xl font-bold text-white">히트맵 분석</h2>
+            <h2 className="text-2xl font-bold text-white">분석</h2>
             <p className="mt-1 text-sm text-slate-400">
               콘텐츠 상세 페이지에서 수집한 좌표 기반 이벤트를 시각화하고, 섹션/이벤트 유형별 분포를 분석할 수 있어요.
             </p>

--- a/components/admin/uploads/UploadedItemCard.jsx
+++ b/components/admin/uploads/UploadedItemCard.jsx
@@ -38,11 +38,6 @@ export default function UploadedItemCard({
         ) : (
           <div className="grid h-full w-full place-items-center text-xs text-slate-400">No preview</div>
         )}
-        {item.type && (
-          <span className="absolute left-3 top-3 rounded-full bg-black/60 px-2 py-0.5 text-[11px] font-semibold uppercase text-white">
-            {item.type}
-          </span>
-        )}
         {item._error && (
           <span className="absolute right-3 top-3 rounded-full bg-rose-600/80 px-2 py-0.5 text-[11px] font-semibold text-white shadow-lg">
             메타 오류

--- a/components/admin/uploads/UploadsSection.jsx
+++ b/components/admin/uploads/UploadsSection.jsx
@@ -280,7 +280,7 @@ export default function UploadsSection({
       <div className="space-y-4">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-center gap-3">
-            <h2 className="text-sm font-semibold uppercase tracking-widest text-slate-400">Uploaded ({items.length})</h2>
+            <h2 className="text-sm font-semibold uppercase tracking-widest text-slate-400">업로드 ({items.length})</h2>
             <label className="flex items-center gap-2 rounded-full bg-slate-900/60 px-3 py-1 text-xs text-slate-300">
               <input
                 ref={selectAllRef}

--- a/hooks/admin/useAnalyticsMetrics.js
+++ b/hooks/admin/useAnalyticsMetrics.js
@@ -338,11 +338,13 @@ export default function useAnalyticsMetrics({
     [rowsWithDisplayMetrics]
   );
 
-  const averageLikeRate = useMemo(() => {
-    const withViews = rowsWithDisplayMetrics.filter((row) => row.displayMetrics && row.displayMetrics.views > 0);
-    if (!withViews.length) return 0;
-    const totalRate = withViews.reduce((acc, row) => acc + row.displayMetrics.likes / row.displayMetrics.views, 0);
-    return totalRate / withViews.length;
+  const averageViewsPerContent = useMemo(() => {
+    if (!rowsWithDisplayMetrics.length) return 0;
+    const totalViews = rowsWithDisplayMetrics.reduce(
+      (sum, row) => sum + (row.displayMetrics?.views || 0),
+      0
+    );
+    return totalViews / rowsWithDisplayMetrics.length;
   }, [rowsWithDisplayMetrics]);
 
   const aggregatedRangeTotals = useMemo(() => {
@@ -614,7 +616,7 @@ export default function useAnalyticsMetrics({
     isRangeActive: rangeActive,
     trendHistory,
     exportRows,
-    averageLikeRate,
+    averageViewsPerContent,
     filteredItems,
     filters,
     setFilters,

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-i18next": "^14.1.1",
+        "recharts": "^3.2.1",
         "video.js": "^8.23.4"
       },
       "devDependencies": {
@@ -571,6 +572,44 @@
         "node": ">=14"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.9.0.tgz",
+      "integrity": "sha512-fSfQlSRu9Z5yBkvsNhYF2rPS8cGXn/TZVrlwN1948QyZ8xMZ0JvP50S2acZNaf+o63u6aEeMjipFyksjIcWrog==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -586,6 +625,69 @@
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -622,6 +724,12 @@
       "dependencies": {
         "csstype": "^3.0.2"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@upstash/redis": {
       "version": "1.35.4",
@@ -1424,6 +1532,127 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -1495,6 +1724,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -1784,6 +2019,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.39.10",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.10.tgz",
+      "integrity": "sha512-E0iGnTtbDhkeczB0T+mxmoVlT4YNweEKBLq7oaU4p11mecdsZpNWOglI4895Vh4usbQ+LsJiuLuI2L0Vdmfm2w==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -2060,6 +2305,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -2590,6 +2841,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.3.tgz",
+      "integrity": "sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -2630,6 +2891,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -4123,6 +4393,29 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -4144,6 +4437,48 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.2.1.tgz",
+      "integrity": "sha512-0JKwHRiFZdmLq/6nmilxEZl3pqb4T+aKkOkOi/ZISRZwfBhVMgInxzlYU9D4KnCH3KINScLy68m/OvMXoYGZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -4189,6 +4524,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -4927,6 +5268,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5122,12 +5469,43 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
     },
     "node_modules/video.js": {
       "version": "8.23.4",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-i18next": "^14.1.1",
+    "recharts": "^3.2.1",
     "video.js": "^8.23.4"
   },
   "devDependencies": {


### PR DESCRIPTION
## 요약
- 관리자 네비게이션과 업로드 섹션 명칭을 요구사항에 맞게 정리하고 선택한 탭을 새로고침 이후에도 유지되도록 했습니다.
- 콘텐츠, 이벤트, 수익 그래프를 Recharts 기반으로 교체하고 평균 조회수/이탈률 등 지표 산식을 최신 요구에 맞게 수정했습니다.
- Adsterra 통계를 한국 시간대로 변환하고 통합 인사이트 영역을 이벤트-광고 교차 분석 중심으로 재구성했습니다.

## 테스트
- npm run lint *(기존 react/react-in-jsx-scope 규칙으로 인해 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68d6e395f30c8323abd20df5ed176fd7