### PR TITLE
관리자 지표 API 요청 캐싱 및 속도 제한

### DIFF
--- a/pages/api/admin/events/summary.js
+++ b/pages/api/admin/events/summary.js
@@ -1,4 +1,6 @@
 import { assertAdmin } from '../_auth';
+import { applyRateLimit, setRateLimitHeaders } from '../../../../utils/apiRateLimit';
+import { resolveWithCache } from '../../../../utils/serverCache';
 
 export default async function handler(req, res) {
   if (req.method !== 'GET') {
@@ -15,13 +17,22 @@ export default async function handler(req, res) {
     const slug = typeof req.query.slug === 'string' ? req.query.slug.trim() : '';
     const limitRaw = typeof req.query.limit === 'string' ? req.query.limit : undefined;
 
-    const { getEventSummary } = await import('../../../../utils/eventsStore');
-    const summary = await getEventSummary({
-      startDate,
-      endDate,
-      eventName,
-      slug,
-      limit: limitRaw,
+    const rate = applyRateLimit(req, 'admin:events:summary', { limit: 45, windowMs: 60_000 });
+    setRateLimitHeaders(res, rate);
+    if (!rate.ok) {
+      return res.status(429).json({ error: '이벤트 요약 요청이 너무 잦아요. 잠시 후 다시 시도해 주세요.' });
+    }
+
+    const cacheKey = JSON.stringify({ startDate, endDate, eventName, slug, limitRaw });
+    const summary = await resolveWithCache('admin:events:summary', cacheKey, 45_000, async () => {
+      const { getEventSummary } = await import('../../../../utils/eventsStore');
+      return getEventSummary({
+        startDate,
+        endDate,
+        eventName,
+        slug,
+        limit: limitRaw,
+      });
     });
 
     return res.status(200).json({

--- a/pages/api/metrics/get.js
+++ b/pages/api/metrics/get.js
@@ -1,16 +1,37 @@
+import { applyRateLimit, setRateLimitHeaders } from '../../../utils/apiRateLimit';
+import { resolveWithCache } from '../../../utils/serverCache';
+
 export default async function handler(req, res) {
   if (req.method !== 'GET') return res.status(405).end();
   const { slug, withSession, start, end } = req.query;
   if (!slug) return res.status(400).json({ error: 'Missing slug' });
 
+  const rate = applyRateLimit(req, `metrics:get:${slug}`, { limit: 300, windowMs: 60_000 });
+  setRateLimitHeaders(res, rate);
+  if (!rate.ok) {
+    return res.status(429).json({ error: '조회 요청이 너무 잦아요. 잠시 후 다시 시도해 주세요.' });
+  }
+
   const sessionRequested = typeof withSession !== 'undefined';
+  const startDate = parseDateParam(start);
+  const endDate = parseDateParam(end);
+
   const { getViewerId, ensureViewerId } = await import('../../../utils/viewerSession');
   const viewerId = sessionRequested ? ensureViewerId(req, res) : getViewerId(req);
 
-  const { getMetrics } = await import('../../../utils/metricsStore');
-  const startDate = parseDateParam(start);
-  const endDate = parseDateParam(end);
-  const data = await getMetrics(slug, { viewerId, startDate, endDate });
+  const cacheKey = JSON.stringify({
+    slug,
+    start: startDate ? startDate.toISOString() : null,
+    end: endDate ? endDate.toISOString() : null,
+    viewer: sessionRequested ? viewerId || null : null,
+  });
+  const ttl = sessionRequested ? 3_000 : startDate || endDate ? 10_000 : 15_000;
+
+  const data = await resolveWithCache('metrics:get', cacheKey, ttl, async () => {
+    const { getMetrics } = await import('../../../utils/metricsStore');
+    return getMetrics(slug, { viewerId, startDate, endDate });
+  });
+
   res.status(200).json({ slug, ...data });
 }
 

--- a/utils/apiRateLimit.js
+++ b/utils/apiRateLimit.js
@@ -1,0 +1,95 @@
+const GLOBAL_KEY = Symbol.for('laffy.apiRateLimit');
+
+function getStore() {
+  const globalObject = globalThis;
+  if (!globalObject[GLOBAL_KEY]) {
+    globalObject[GLOBAL_KEY] = {
+      buckets: new Map(),
+    };
+  }
+  return globalObject[GLOBAL_KEY];
+}
+
+function cleanupBuckets(store, now) {
+  const maxChecks = 50;
+  let checked = 0;
+  for (const [key, bucket] of store.buckets) {
+    if (bucket.resetAt <= now) {
+      store.buckets.delete(key);
+    }
+    checked += 1;
+    if (checked >= maxChecks) break;
+  }
+}
+
+function getClientIp(req) {
+  const xForwardedFor = req.headers['x-forwarded-for'];
+  if (typeof xForwardedFor === 'string' && xForwardedFor) {
+    const parts = xForwardedFor.split(',');
+    if (parts.length) {
+      return parts[0].trim();
+    }
+  }
+  if (Array.isArray(xForwardedFor) && xForwardedFor.length) {
+    return xForwardedFor[0];
+  }
+  if (req.socket?.remoteAddress) {
+    return req.socket.remoteAddress;
+  }
+  return 'unknown';
+}
+
+export function applyRateLimit(req, bucketId, options) {
+  const { limit = 60, windowMs = 60_000 } = options || {};
+  const store = getStore();
+  const now = Date.now();
+  cleanupBuckets(store, now);
+
+  const clientId = getClientIp(req);
+  const key = `${bucketId}:${clientId}`;
+  const bucket = store.buckets.get(key);
+
+  if (!bucket || bucket.resetAt <= now) {
+    const resetAt = now + windowMs;
+    store.buckets.set(key, { count: 1, resetAt });
+    return {
+      ok: true,
+      key,
+      limit,
+      remaining: Math.max(0, limit - 1),
+      resetAt,
+      retryAfter: Math.ceil(windowMs / 1000),
+    };
+  }
+
+  if (bucket.count >= limit) {
+    return {
+      ok: false,
+      key,
+      limit,
+      remaining: 0,
+      resetAt: bucket.resetAt,
+      retryAfter: Math.max(1, Math.ceil((bucket.resetAt - now) / 1000)),
+    };
+  }
+
+  bucket.count += 1;
+  return {
+    ok: true,
+    key,
+    limit,
+    remaining: Math.max(0, limit - bucket.count),
+    resetAt: bucket.resetAt,
+    retryAfter: Math.max(1, Math.ceil((bucket.resetAt - now) / 1000)),
+  };
+}
+
+export function setRateLimitHeaders(res, result) {
+  if (!result || !res?.setHeader) return;
+  res.setHeader('X-RateLimit-Limit', String(result.limit));
+  res.setHeader('X-RateLimit-Remaining', String(Math.max(0, result.remaining)));
+  res.setHeader('X-RateLimit-Reset', String(Math.ceil(result.resetAt / 1000)));
+  if (!result.ok) {
+    res.setHeader('Retry-After', String(result.retryAfter));
+  }
+}

--- a/utils/serverCache.js
+++ b/utils/serverCache.js
@@ -1,0 +1,93 @@
+const GLOBAL_KEY = Symbol.for('laffy.serverCache');
+
+function getGlobalStore() {
+  const globalObject = globalThis;
+  if (!globalObject[GLOBAL_KEY]) {
+    globalObject[GLOBAL_KEY] = {};
+  }
+  return globalObject[GLOBAL_KEY];
+}
+
+function ensureStore(name) {
+  const globalStore = getGlobalStore();
+  if (!globalStore[name]) {
+    globalStore[name] = {
+      entries: new Map(),
+      inFlight: new Map(),
+    };
+  }
+  return globalStore[name];
+}
+
+function cleanupEntries(store, now) {
+  const maxChecks = 50;
+  let checked = 0;
+  for (const [key, entry] of store.entries) {
+    if (entry.expiresAt && entry.expiresAt <= now) {
+      store.entries.delete(key);
+    }
+    checked += 1;
+    if (checked >= maxChecks) break;
+  }
+}
+
+export function getCachedValue(storeName, key) {
+  const store = ensureStore(storeName);
+  const entry = store.entries.get(key);
+  if (!entry) return undefined;
+  if (entry.expiresAt && entry.expiresAt <= Date.now()) {
+    store.entries.delete(key);
+    return undefined;
+  }
+  return entry.value;
+}
+
+export function setCachedValue(storeName, key, value, ttlMs) {
+  const store = ensureStore(storeName);
+  if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+    store.entries.delete(key);
+    return;
+  }
+  const now = Date.now();
+  cleanupEntries(store, now);
+  store.entries.set(key, {
+    value,
+    expiresAt: now + ttlMs,
+  });
+}
+
+export function resolveWithCache(storeName, key, ttlMs, factory) {
+  const store = ensureStore(storeName);
+  const now = Date.now();
+  cleanupEntries(store, now);
+  const cached = store.entries.get(key);
+  if (cached && (!cached.expiresAt || cached.expiresAt > now)) {
+    return Promise.resolve(cached.value);
+  }
+  if (store.inFlight.has(key)) {
+    return store.inFlight.get(key);
+  }
+  const executor = Promise.resolve()
+    .then(() => factory())
+    .then((value) => {
+      if (Number.isFinite(ttlMs) && ttlMs > 0) {
+        store.entries.set(key, { value, expiresAt: Date.now() + ttlMs });
+      }
+      return value;
+    })
+    .catch((error) => {
+      store.entries.delete(key);
+      throw error;
+    })
+    .finally(() => {
+      store.inFlight.delete(key);
+    });
+  store.inFlight.set(key, executor);
+  return executor;
+}
+
+export function clearCache(storeName) {
+  const store = ensureStore(storeName);
+  store.entries.clear();
+  store.inFlight.clear();
+}


### PR DESCRIPTION
## 요약
- 관리자 이벤트 요약, 히트맵, 애드스테라 통계 API에 메모리 캐시와 속도 제한을 추가해 중복 요청을 억제했습니다.
- 조회 지표 API(`/api/metrics/get`, `/api/metrics/batch`)에 공용 캐시와 IP 기반 속도 제한을 적용해 단시간 중복 호출과 남용을 차단했습니다.
- 서버에서 재사용할 수 있는 속도 제한 및 캐시 유틸리티를 도입해 동일 파라미터 요청을 공유하도록 정리했습니다.

## 테스트
- `npm run lint` *(기존 JSX/prop-types 규칙 위반으로 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68d6f371f83c8323b84a2100a045d6c6