### PR TITLE
Redis 이벤트 적재를 Lua 스크립트로 최적화

### DIFF
--- a/utils/redisClient.js
+++ b/utils/redisClient.js
@@ -67,3 +67,15 @@ export async function redisCommand(command, options = {}) {
   const data = await res.json();
   return data.result;
 }
+
+export async function redisEval(script, keys = [], args = [], options = {}) {
+  const keyCount = Array.isArray(keys) ? keys.length : 0;
+  const command = [
+    'EVAL',
+    script,
+    String(keyCount),
+    ...keys,
+    ...args.map((arg) => (typeof arg === 'string' ? arg : String(arg))),
+  ];
+  return redisCommand(command, options);
+}


### PR DESCRIPTION
## Summary
- Redis 배치 Lua 스크립트로 이벤트 집계·TTL 연장을 한 번의 호출로 처리하도록 변경했습니다.
- 값과 세션 존재 여부에 따라 TTL 연장 로직을 분기해 불필요한 EXPIRE 호출을 줄였습니다.
- Upstash REST API에서 Lua 실행을 돕는 `redisEval` 헬퍼를 추가했습니다.

## Testing
- node - <<'NODE' ... (ingestEvents 메모리 폴백 시나리오 확인)


------
https://chatgpt.com/codex/tasks/task_e_68d7000b3d588323ad5e41190f45a559