### PR TITLE
feat: 사용자 이벤트 Redis 전송 임시 중단

### DIFF
--- a/utils/eventsStore.js
+++ b/utils/eventsStore.js
@@ -5,6 +5,7 @@ import {
   SUPABASE_EVENTS_ROLLUP_FUNCTION,
   SUPABASE_EVENTS_ROLLUP_TABLE,
 } from './supabaseClient';
+import { isInternalRedisIngestionDisabled } from './internalRedisToggle';
 
 const DEFAULT_RANGE_DAYS = 6;
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -165,6 +166,9 @@ async function redisCommand(command, options) {
 }
 
 async function hasRedis() {
+  if (isInternalRedisIngestionDisabled()) {
+    return false;
+  }
   const { hasUpstash } = await import('./redisClient');
   return hasUpstash();
 }

--- a/utils/heatmapStore.js
+++ b/utils/heatmapStore.js
@@ -9,6 +9,14 @@ const FIELD_DELIMITER = '|';
 const DEFAULT_BUCKET = 'default';
 const MAX_CELLS_PER_BATCH = 30;
 
+async function isRedisAvailable() {
+  if (isInternalRedisIngestionDisabled()) {
+    return false;
+  }
+  const { hasUpstash } = await import('./redisClient');
+  return hasUpstash();
+}
+
 function sanitizeSegment(value, fallback, maxLength = 48) {
   if (typeof value !== 'string') return fallback;
   const trimmed = value.trim();
@@ -216,11 +224,10 @@ export async function recordHeatmapSamples(slug, options = {}) {
 
   const timestamp = Number.isFinite(Number(options.timestamp)) ? Number(options.timestamp) : Date.now();
 
-  const { hasUpstash } = await import('./redisClient');
   let recorded = 0;
   let redisSucceeded = false;
 
-  if (!isInternalRedisIngestionDisabled() && hasUpstash()) {
+  if (await isRedisAvailable()) {
     try {
       recorded = await recordWithRedis(normalizedSlug, bucket, cells);
       redisSucceeded = true;
@@ -242,8 +249,7 @@ export async function getHeatmapSnapshot(slug) {
   const normalizedSlug = typeof slug === 'string' ? slug.trim() : '';
   if (!normalizedSlug) return { slug: '', buckets: [] };
 
-  const { hasUpstash } = await import('./redisClient');
-  if (!isInternalRedisIngestionDisabled() && hasUpstash()) {
+  if (await isRedisAvailable()) {
     try {
       const entries = await loadFromRedis(normalizedSlug);
       return { slug: normalizedSlug, buckets: aggregateEntries(entries) };

--- a/utils/heatmapStore.js
+++ b/utils/heatmapStore.js
@@ -3,6 +3,7 @@ import {
   callSupabaseRpc,
   SUPABASE_HEATMAP_ROLLUP_FUNCTION,
 } from './supabaseClient';
+import { isInternalRedisIngestionDisabled } from './internalRedisToggle';
 
 const FIELD_DELIMITER = '|';
 const DEFAULT_BUCKET = 'default';
@@ -219,7 +220,7 @@ export async function recordHeatmapSamples(slug, options = {}) {
   let recorded = 0;
   let redisSucceeded = false;
 
-  if (hasUpstash()) {
+  if (!isInternalRedisIngestionDisabled() && hasUpstash()) {
     try {
       recorded = await recordWithRedis(normalizedSlug, bucket, cells);
       redisSucceeded = true;
@@ -242,7 +243,7 @@ export async function getHeatmapSnapshot(slug) {
   if (!normalizedSlug) return { slug: '', buckets: [] };
 
   const { hasUpstash } = await import('./redisClient');
-  if (hasUpstash()) {
+  if (!isInternalRedisIngestionDisabled() && hasUpstash()) {
     try {
       const entries = await loadFromRedis(normalizedSlug);
       return { slug: normalizedSlug, buckets: aggregateEntries(entries) };

--- a/utils/internalRedisToggle.js
+++ b/utils/internalRedisToggle.js
@@ -1,4 +1,5 @@
 const TRUTHY = new Set(['1', 'true', 'yes', 'on']);
+const FALSY = new Set(['0', 'false', 'no', 'off']);
 
 function normalize(value) {
   if (typeof value !== 'string') return '';
@@ -6,13 +7,27 @@ function normalize(value) {
 }
 
 export function isInternalRedisIngestionDisabled() {
-  const raw = process.env.DISABLE_INTERNAL_REDIS_EVENTS ?? process.env.DISABLE_INTERNAL_REDIS;
-  if (!raw) return false;
-  const normalized = normalize(raw);
-  if (!normalized) return false;
-  if (TRUTHY.has(normalized)) return true;
-  if (normalized === '0' || normalized === 'false' || normalized === 'off' || normalized === 'no') {
-    return false;
+  const enableRaw = process.env.ENABLE_INTERNAL_REDIS_EVENTS ?? process.env.ENABLE_INTERNAL_REDIS;
+  if (enableRaw) {
+    const normalized = normalize(enableRaw);
+    if (TRUTHY.has(normalized)) {
+      return false;
+    }
+    if (FALSY.has(normalized)) {
+      return true;
+    }
   }
+
+  const disableRaw = process.env.DISABLE_INTERNAL_REDIS_EVENTS ?? process.env.DISABLE_INTERNAL_REDIS;
+  if (disableRaw) {
+    const normalized = normalize(disableRaw);
+    if (TRUTHY.has(normalized)) {
+      return true;
+    }
+    if (FALSY.has(normalized)) {
+      return false;
+    }
+  }
+
   return true;
 }

--- a/utils/internalRedisToggle.js
+++ b/utils/internalRedisToggle.js
@@ -1,0 +1,18 @@
+const TRUTHY = new Set(['1', 'true', 'yes', 'on']);
+
+function normalize(value) {
+  if (typeof value !== 'string') return '';
+  return value.trim().toLowerCase();
+}
+
+export function isInternalRedisIngestionDisabled() {
+  const raw = process.env.DISABLE_INTERNAL_REDIS_EVENTS ?? process.env.DISABLE_INTERNAL_REDIS;
+  if (!raw) return false;
+  const normalized = normalize(raw);
+  if (!normalized) return false;
+  if (TRUTHY.has(normalized)) return true;
+  if (normalized === '0' || normalized === 'false' || normalized === 'off' || normalized === 'no') {
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary
- 환경 변수를 통해 사용자 커스텀 이벤트와 히트맵 전송 시 내부 Redis 사용을 비활성화할 수 있도록 조정했습니다.
- Redis 비활성화 플래그 판별 유틸을 추가해 관련 스토어에서 공통으로 활용하도록 했습니다.

## Testing
- npm run lint *(기존 규칙 위반으로 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68d77530e0e883239902aaab2e641edb