### PR TITLE
feat(admin): modernize Adsterra revenue analytics

### DIFF
--- a/components/admin/adsterra/AdsterraChartPanel.jsx
+++ b/components/admin/adsterra/AdsterraChartPanel.jsx
@@ -28,56 +28,173 @@ function buildSeries(rows) {
   return Array.from(map.values()).sort((a, b) => new Date(a.iso || a.label) - new Date(b.iso || b.label));
 }
 
-export default function AdsterraChartPanel({ rows, formatNumber }) {
+export default function AdsterraChartPanel({ rows, formatNumber, formatCurrency }) {
   const series = useMemo(() => buildSeries(rows), [rows]);
-  if (!series.length) {
+  const metrics = useMemo(
+    () =>
+      series.map((value) => {
+        const impressions = value.impressions || 0;
+        const revenue = value.revenue || 0;
+        const cpm = impressions > 0 ? (revenue / impressions) * 1000 : 0;
+        const rpm = impressions > 0 ? revenue / impressions : 0;
+        return { ...value, cpm, rpm };
+      }),
+    [series]
+  );
+
+  if (!metrics.length) {
     return (
-      <div className="rounded-2xl border border-slate-800/70 bg-slate-900/80 p-6 text-sm text-slate-400">
-        통계를 불러오면 추세 그래프가 표시됩니다.
+      <div className="rounded-3xl border border-slate-800/70 bg-slate-900/80 p-6 text-sm text-slate-400">
+        통계를 불러오면 고급형 추세 그래프가 표시됩니다.
       </div>
     );
   }
 
-  const maxImpressions = Math.max(...series.map((value) => value.impressions), 1);
-  const width = 600;
-  const height = 160;
-  const stepX = width / Math.max(series.length - 1, 1);
+  const impressionsMax = Math.max(...metrics.map((value) => value.impressions), 1);
+  const revenueMax = Math.max(...metrics.map((value) => value.revenue), 1);
+  const cpmMax = Math.max(...metrics.map((value) => value.cpm), 1);
+  const baseWidth = Math.max((metrics.length - 1) * 120, 600);
+  const hasMultiplePoints = metrics.length > 1;
+  const stepX = hasMultiplePoints ? baseWidth / (metrics.length - 1) : 0;
+  const height = 240;
 
-  const linePath = series
-    .map((value, index) => {
-      const x = index * stepX;
-      const y = height - (value.impressions / maxImpressions) * height;
-      return `${index === 0 ? 'M' : 'L'}${x},${y}`;
-    })
-    .join(' ');
+  const getX = (index) => (hasMultiplePoints ? index * stepX : baseWidth / 2);
+  const buildPath = (accessor, maxValue) =>
+    metrics
+      .map((value, index) => {
+        const raw = accessor(value);
+        const clamped = Number.isFinite(raw) ? Math.max(raw, 0) : 0;
+        const y = maxValue > 0 ? height - (clamped / maxValue) * height : height;
+        const x = getX(index);
+        return `${index === 0 ? 'M' : 'L'}${x},${y}`;
+      })
+      .join(' ');
+
+  const impressionsLine = buildPath((value) => value.impressions, impressionsMax);
+  const revenueLine = buildPath((value) => value.revenue, revenueMax);
+  const cpmLine = buildPath((value) => value.cpm, cpmMax);
+  const firstX = getX(0);
+  const lastX = getX(metrics.length - 1);
+  const impressionsArea = `${impressionsLine} L${lastX},${height} L${firstX},${height} Z`;
+
+  const scatterWidth = 520;
+  const scatterHeight = 200;
+  const scatterMaxImpressions = Math.max(...metrics.map((value) => value.impressions), 1);
+  const scatterMaxRevenue = Math.max(...metrics.map((value) => value.revenue), 1);
+  const scatterMaxCpm = Math.max(...metrics.map((value) => value.cpm), 1);
 
   return (
-    <div className="rounded-2xl border border-slate-800/70 bg-slate-900/80 p-6">
-      <div className="flex items-center justify-between text-sm">
+    <div className="space-y-6 rounded-3xl border border-slate-800/70 bg-slate-950/80 p-6 shadow-xl shadow-slate-950/40">
+      <div className="flex flex-col gap-2 lg:flex-row lg:items-end lg:justify-between">
         <div>
-          <p className="text-xs uppercase tracking-widest text-slate-500">노출 추세</p>
-          <p className="text-lg font-semibold text-white">최근 {series.length}일</p>
+          <p className="text-[11px] uppercase tracking-[0.35em] text-slate-400">노출 · 수익 추세</p>
+          <h3 className="text-2xl font-semibold text-white">하이브리드 타임라인 분석</h3>
         </div>
         <div className="text-xs text-slate-400">
-          최고 노출 {formatNumber(maxImpressions)}
+          최고 노출 {formatNumber(impressionsMax)} · 최고 수익 {formatCurrency(revenueMax)} · 최고 CPM {formatCurrency(cpmMax, 3)}
         </div>
       </div>
-      <svg viewBox={`0 0 ${width} ${height}`} className="mt-4 h-40 w-full">
-        <defs>
-          <linearGradient id="adsterra-impressions" x1="0" x2="0" y1="0" y2="1">
-            <stop offset="0%" stopColor="#34d399" stopOpacity="0.8" />
-            <stop offset="100%" stopColor="#34d399" stopOpacity="0" />
-          </linearGradient>
-        </defs>
-        <path d={`${linePath} L${width},${height} L0,${height} Z`} fill="url(#adsterra-impressions)" />
-        <path d={linePath} stroke="#34d399" strokeWidth="3" fill="none" strokeLinecap="round" />
-      </svg>
-      <div className="mt-3 grid grid-cols-2 gap-2 text-[11px] text-slate-400 sm:grid-cols-4">
-        {series.map((value) => (
-          <div key={value.iso || value.label} className="rounded-lg bg-slate-900/60 px-3 py-2">
-            <p className="font-semibold text-slate-200">{value.label}</p>
-            <p>노출 {formatNumber(value.impressions)}</p>
-            <p>클릭 {formatNumber(value.clicks)}</p>
+
+      <div className="overflow-hidden rounded-3xl border border-slate-800/70 bg-gradient-to-br from-slate-900 via-slate-950 to-indigo-950 p-6">
+        <svg viewBox={`0 0 ${baseWidth} ${height}`} className="h-64 w-full">
+          <defs>
+            <linearGradient id="adsterra-impression-fill" x1="0" x2="0" y1="0" y2="1">
+              <stop offset="0%" stopColor="rgba(34,211,238,0.45)" />
+              <stop offset="100%" stopColor="rgba(79,70,229,0)" />
+            </linearGradient>
+            <linearGradient id="adsterra-revenue-line" x1="0" x2="1" y1="0" y2="0">
+              <stop offset="0%" stopColor="#f472b6" />
+              <stop offset="100%" stopColor="#c084fc" />
+            </linearGradient>
+            <linearGradient id="adsterra-cpm-line" x1="0" x2="1" y1="0" y2="0">
+              <stop offset="0%" stopColor="#38bdf8" />
+              <stop offset="100%" stopColor="#60a5fa" />
+            </linearGradient>
+          </defs>
+          <path d={impressionsArea} fill="url(#adsterra-impression-fill)" />
+          <path d={impressionsLine} stroke="#22d3ee" strokeWidth="3" fill="none" strokeLinecap="round" />
+          <path d={revenueLine} stroke="url(#adsterra-revenue-line)" strokeWidth="2.5" fill="none" strokeLinecap="round" strokeDasharray="6 4" />
+          <path d={cpmLine} stroke="url(#adsterra-cpm-line)" strokeWidth="2.5" fill="none" strokeLinecap="round" strokeDasharray="2 6" />
+        </svg>
+        <div className="mt-4 flex flex-wrap items-center gap-4 text-[11px] text-slate-400">
+          <span className="inline-flex items-center gap-2"><span className="h-2 w-6 rounded-full bg-cyan-300" />노출</span>
+          <span className="inline-flex items-center gap-2"><span className="h-2 w-6 rounded-full bg-pink-400" />수익</span>
+          <span className="inline-flex items-center gap-2"><span className="h-2 w-6 rounded-full bg-sky-400" />CPM</span>
+        </div>
+      </div>
+
+      <div className="grid gap-4 text-[12px] text-slate-300 lg:grid-cols-2">
+        <div className="rounded-2xl border border-slate-800/60 bg-slate-900/70 p-4">
+          <p className="font-semibold text-slate-100">노출 ↔ CPM 상관 뷰</p>
+          <svg viewBox={`0 0 ${scatterWidth} ${scatterHeight}`} className="mt-3 h-48 w-full">
+            <defs>
+              <linearGradient id="adsterra-scatter-cpm" x1="0" x2="1" y1="0" y2="0">
+                <stop offset="0%" stopColor="rgba(56,189,248,0.35)" />
+                <stop offset="100%" stopColor="rgba(129,140,248,0.35)" />
+              </linearGradient>
+            </defs>
+            <rect width={scatterWidth} height={scatterHeight} fill="url(#adsterra-scatter-cpm)" opacity="0.15" />
+            {metrics.map((value) => {
+              const x = (value.impressions / scatterMaxImpressions) * scatterWidth;
+              const y = scatterHeight - (value.cpm / scatterMaxCpm) * scatterHeight;
+              const radius = Math.max(6, Math.min(14, value.rpm * 1600));
+              return (
+                <circle
+                  key={`cpm-${value.iso || value.label}`}
+                  cx={x}
+                  cy={Number.isFinite(y) ? y : scatterHeight}
+                  r={Number.isFinite(radius) ? radius : 6}
+                  fill="rgba(56,189,248,0.65)"
+                  stroke="rgba(125,211,252,0.9)"
+                  strokeWidth="1.5"
+                />
+              );
+            })}
+          </svg>
+          <p className="mt-2 text-[11px] text-slate-400">
+            점의 크기는 평균 노출당 수익을 의미하며, 우측 상단으로 갈수록 고효율 구간이에요.
+          </p>
+        </div>
+        <div className="rounded-2xl border border-slate-800/60 bg-slate-900/70 p-4">
+          <p className="font-semibold text-slate-100">노출 ↔ 일일 수익 분포</p>
+          <svg viewBox={`0 0 ${scatterWidth} ${scatterHeight}`} className="mt-3 h-48 w-full">
+            <defs>
+              <linearGradient id="adsterra-scatter-revenue" x1="0" x2="1" y1="0" y2="0">
+                <stop offset="0%" stopColor="rgba(244,114,182,0.35)" />
+                <stop offset="100%" stopColor="rgba(192,132,252,0.35)" />
+              </linearGradient>
+            </defs>
+            <rect width={scatterWidth} height={scatterHeight} fill="url(#adsterra-scatter-revenue)" opacity="0.15" />
+            {metrics.map((value) => {
+              const x = (value.impressions / scatterMaxImpressions) * scatterWidth;
+              const y = scatterHeight - (value.revenue / scatterMaxRevenue) * scatterHeight;
+              const radius = Math.max(6, Math.min(16, (value.cpm / Math.max(cpmMax, 1)) * 12));
+              return (
+                <circle
+                  key={`revenue-${value.iso || value.label}`}
+                  cx={x}
+                  cy={Number.isFinite(y) ? y : scatterHeight}
+                  r={Number.isFinite(radius) ? radius : 6}
+                  fill="rgba(244,114,182,0.65)"
+                  stroke="rgba(249,168,212,0.9)"
+                  strokeWidth="1.5"
+                />
+              );
+            })}
+          </svg>
+          <p className="mt-2 text-[11px] text-slate-400">
+            원의 크기는 CPM을 나타내며, 오른쪽 아래 영역은 노출 대비 수익 개선 여지가 있는 지점을 의미합니다.
+          </p>
+        </div>
+      </div>
+
+      <div className="grid gap-3 text-[11px] text-slate-300 md:grid-cols-2 xl:grid-cols-3">
+        {metrics.map((value) => (
+          <div key={value.iso || value.label} className="rounded-2xl border border-slate-800/60 bg-slate-900/70 p-4">
+            <p className="text-sm font-semibold text-white">{value.label}</p>
+            <p className="mt-1 text-slate-400">노출 {formatNumber(value.impressions)}</p>
+            <p className="mt-1 text-slate-400">수익 {formatCurrency(value.revenue)}</p>
+            <p className="mt-1 text-slate-400">CPM {formatCurrency(value.cpm, 3)}</p>
           </div>
         ))}
       </div>

--- a/components/admin/adsterra/AdsterraControls.jsx
+++ b/components/admin/adsterra/AdsterraControls.jsx
@@ -37,29 +37,61 @@ export default function AdsterraControls({
   onSavePreset,
   presets,
 }) {
+  const fieldClass =
+    'w-full rounded-2xl border border-slate-700/70 bg-slate-900/80 px-4 py-2.5 text-sm text-slate-100 shadow-[inset_0_0_0_1px_rgba(148,163,184,0.12)] transition focus:border-cyan-400 focus:outline-none focus:ring-2 focus:ring-cyan-400/30 disabled:opacity-40';
+  const helperClass = 'text-[11px] leading-relaxed text-slate-400';
+  const noPlacements = placements.length === 0;
+
   return (
-    <div className="space-y-4 rounded-2xl bg-slate-900/80 p-5 ring-1 ring-slate-800/70">
-      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+    <div className="space-y-6 rounded-3xl bg-gradient-to-br from-slate-950 via-slate-900/85 to-indigo-950/70 p-6 shadow-2xl shadow-indigo-950/40 ring-1 ring-slate-800/70">
+      <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
         <div>
-          <p className="text-xs uppercase tracking-widest text-slate-400">연결된 도메인</p>
-          <p className="text-sm font-semibold text-white">
-            {domainName}
-            <span className="ml-2 text-xs font-normal text-slate-400">{domainId ? `#${domainId}` : '—'}</span>
+          <p className="text-[11px] uppercase tracking-[0.4em] text-slate-400/80">Adsterra Revenue Mission Control</p>
+          <h2 className="mt-2 text-2xl font-semibold text-white">미래지향 수익 허브</h2>
+          <p className="mt-3 text-sm text-slate-300">
+            연결된 도메인{' '}
+            <span className="font-semibold text-white">{domainName || '—'}</span>
+            {domainId ? (
+              <span className="ml-2 inline-flex items-center rounded-full bg-slate-900/80 px-2 py-0.5 text-[11px] text-cyan-200/80">
+                #{domainId}
+              </span>
+            ) : (
+              <span className="ml-2 inline-flex items-center rounded-full bg-slate-900/80 px-2 py-0.5 text-[11px] text-slate-500">ID 미설정</span>
+            )}
           </p>
-          <p className="mt-1 text-[11px] text-slate-500">환경 변수에 저장된 토큰으로 자동 연결돼요.</p>
+          <p className="mt-1 text-xs text-slate-500">
+            환경 변수에 저장된 토큰으로 인증돼 Smartlink_1과 300x250_1 플레이스먼트를 집중 모니터링합니다.
+          </p>
         </div>
-        <div className="flex flex-col gap-1 text-xs text-slate-400 md:items-end">
+        <div className="flex flex-col items-start gap-2 text-xs text-slate-300 lg:items-end">
           <button
             type="button"
             onClick={onRefreshPlacements}
             disabled={loadingPlacements}
-            className="inline-flex items-center justify-center rounded-full border border-slate-600/60 px-3 py-1 text-[11px] font-semibold text-slate-200 transition hover:bg-slate-800/60 disabled:cursor-not-allowed disabled:opacity-50"
+            className="inline-flex items-center justify-center rounded-full border border-cyan-400/40 bg-slate-900/80 px-4 py-2 text-[12px] font-semibold text-cyan-100 shadow-[0_0_25px_rgba(34,211,238,0.15)] transition hover:border-cyan-300/70 hover:text-white disabled:cursor-not-allowed disabled:opacity-60"
           >
-            플레이스먼트 새로고침
+            {loadingPlacements ? '플레이스먼트 정리 중…' : '플레이스먼트 동기화'}
           </button>
-          {loadingPlacements && <span>플레이스먼트를 불러오는 중입니다…</span>}
+          <span className={helperClass}>
+            전체 보기에서는 Smartlink_1과 300x250_1 데이터를 함께 분석해요.
+          </span>
         </div>
       </div>
+
+      {(status || error) && (
+        <div className="grid gap-3 md:grid-cols-2">
+          {status && (
+            <div className="rounded-2xl border border-emerald-400/30 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-100 shadow-inner shadow-emerald-500/20">
+              {status}
+            </div>
+          )}
+          {error && (
+            <div className="rounded-2xl border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-100 shadow-inner shadow-rose-500/30">
+              {error}
+            </div>
+          )}
+        </div>
+      )}
 
       <AdsterraPresetControls
         placementId={placementId}
@@ -75,17 +107,16 @@ export default function AdsterraControls({
         presets={presets}
       />
 
-      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
         <div className="md:col-span-2 xl:col-span-1">
-          <label className="mb-1 block text-xs uppercase tracking-widest text-slate-400">수익 포맷 (플레이스먼트)</label>
+          <label className="mb-1 block text-xs uppercase tracking-[0.3em] text-slate-400">수익 포맷 (플레이스먼트)</label>
           <select
             value={placementId}
             onChange={(event) => onPlacementChange(event.target.value)}
-            disabled={loadingPlacements}
-            className="w-full rounded-lg bg-slate-800 px-3 py-2 text-sm text-slate-100 disabled:opacity-40"
+            disabled={loadingPlacements || noPlacements}
+            className={fieldClass}
           >
-            <option value={ADSTERRA_ALL_PLACEMENTS_VALUE}>전체 보기 (도메인 전체)</option>
-            <option value="">플레이스먼트를 선택해 주세요</option>
+            <option value={ADSTERRA_ALL_PLACEMENTS_VALUE}>전체 보기 · Smartlink + 300x250</option>
             {placements.map((placement) => {
               const rawId =
                 placement?.id ??
@@ -109,36 +140,48 @@ export default function AdsterraControls({
               );
             })}
           </select>
+          {noPlacements && !loadingPlacements && (
+            <p className="mt-2 text-[11px] text-rose-200/80">
+              Smartlink_1 또는 300x250_1 플레이스먼트를 찾지 못했어요. 도메인 구성을 확인해 주세요.
+            </p>
+          )}
         </div>
         <div>
-          <label className="mb-1 block text-xs uppercase tracking-widest text-slate-400">시작일</label>
+          <label className="mb-1 block text-xs uppercase tracking-[0.3em] text-slate-400">시작일</label>
           <input
             type="date"
             value={startDate}
             onChange={(event) => onStartDateChange(event.target.value)}
             max={endDate || undefined}
-            className="w-full rounded-lg bg-slate-800 px-3 py-2 text-sm text-slate-100"
+            className={fieldClass}
           />
         </div>
         <div>
-          <label className="mb-1 block text-xs uppercase tracking-widest text-slate-400">종료일</label>
+          <label className="mb-1 block text-xs uppercase tracking-[0.3em] text-slate-400">종료일</label>
           <input
             type="date"
             value={endDate}
             onChange={(event) => onEndDateChange(event.target.value)}
             min={startDate || undefined}
-            className="w-full rounded-lg bg-slate-800 px-3 py-2 text-sm text-slate-100"
+            className={fieldClass}
           />
         </div>
       </div>
 
+      <div className="rounded-2xl border border-slate-800/70 bg-slate-900/60 p-4 shadow-inner shadow-slate-950/50">
+        <p className={helperClass}>
+          필터 옵션은 Adsterra 통계 API가 반환한 원시 데이터를 기반으로 자동 완성돼요. 서버가 필터 파라미터를 제공하지 않으므로,
+          이 화면에서 선택한 조건은 모두 클라이언트에서 실시간으로 적용됩니다.
+        </p>
+      </div>
+
       <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
         <div>
-          <label className="mb-1 block text-xs uppercase tracking-widest text-slate-400">국가 필터</label>
+          <label className="mb-1 block text-xs uppercase tracking-[0.3em] text-slate-400">국가 필터</label>
           <select
             value={countryFilter}
             onChange={(event) => onCountryFilterChange(event.target.value)}
-            className="w-full rounded-lg bg-slate-800 px-3 py-2 text-sm text-slate-100"
+            className={fieldClass}
           >
             <option value="">전체</option>
             {countryOptions.map((country) => (
@@ -149,11 +192,11 @@ export default function AdsterraControls({
           </select>
         </div>
         <div>
-          <label className="mb-1 block text-xs uppercase tracking-widest text-slate-400">OS 필터</label>
+          <label className="mb-1 block text-xs uppercase tracking-[0.3em] text-slate-400">OS 필터</label>
           <select
             value={osFilter}
             onChange={(event) => onOsFilterChange(event.target.value)}
-            className="w-full rounded-lg bg-slate-800 px-3 py-2 text-sm text-slate-100"
+            className={fieldClass}
           >
             <option value="">전체</option>
             {osOptions.map((os) => (
@@ -164,11 +207,11 @@ export default function AdsterraControls({
           </select>
         </div>
         <div>
-          <label className="mb-1 block text-xs uppercase tracking-widest text-slate-400">디바이스 필터</label>
+          <label className="mb-1 block text-xs uppercase tracking-[0.3em] text-slate-400">디바이스 필터</label>
           <select
             value={deviceFilter}
             onChange={(event) => onDeviceFilterChange(event.target.value)}
-            className="w-full rounded-lg bg-slate-800 px-3 py-2 text-sm text-slate-100"
+            className={fieldClass}
           >
             <option value="">전체</option>
             {deviceOptions.map((device) => (
@@ -179,11 +222,11 @@ export default function AdsterraControls({
           </select>
         </div>
         <div>
-          <label className="mb-1 block text-xs uppercase tracking-widest text-slate-400">디바이스 포맷</label>
+          <label className="mb-1 block text-xs uppercase tracking-[0.3em] text-slate-400">디바이스 포맷</label>
           <select
             value={deviceFormatFilter}
             onChange={(event) => onDeviceFormatFilterChange(event.target.value)}
-            className="w-full rounded-lg bg-slate-800 px-3 py-2 text-sm text-slate-100"
+            className={fieldClass}
           >
             <option value="">전체</option>
             {deviceFormatOptions.map((format) => (
@@ -211,25 +254,18 @@ export default function AdsterraControls({
           type="button"
           onClick={onFetchStats}
           disabled={!canFetchStats || loadingStats}
-          className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-emerald-400 via-teal-400 to-cyan-400 px-4 py-2 text-sm font-semibold text-slate-950 shadow-lg shadow-emerald-500/30 transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-60"
+          className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-cyan-400 via-sky-400 to-indigo-500 px-5 py-2 text-sm font-semibold text-slate-900 shadow-[0_15px_35px_rgba(14,165,233,0.35)] transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60"
         >
           {loadingStats ? '통계 불러오는 중…' : '통계 다시 불러오기'}
         </button>
         <button
           type="button"
           onClick={onResetDates}
-          className="inline-flex items-center justify-center rounded-full border border-slate-600/60 px-3 py-2 text-xs font-semibold text-slate-200 transition hover:bg-slate-800/60"
+          className="inline-flex items-center justify-center rounded-full border border-slate-600/60 px-3 py-2 text-xs font-semibold text-slate-200 transition hover:border-cyan-300/60 hover:text-white"
         >
           기간 초기화
         </button>
       </div>
-
-      {status && (
-        <div className="rounded-xl border border-emerald-500/40 bg-emerald-500/10 p-3 text-xs text-emerald-100">{status}</div>
-      )}
-      {error && (
-        <div className="rounded-xl border border-rose-500/40 bg-rose-500/10 p-3 text-sm text-rose-100">{error}</div>
-      )}
     </div>
   );
 }

--- a/components/admin/adsterra/AdsterraStatsTable.jsx
+++ b/components/admin/adsterra/AdsterraStatsTable.jsx
@@ -4,29 +4,37 @@ export default function AdsterraStatsTable({
   rows,
   loading,
   formatNumber,
-  formatDecimal,
+  formatCurrency,
   placementLabelMap,
   selectedPlacementId,
+  activeFilters,
 }) {
   const allSelected = selectedPlacementId === ADSTERRA_ALL_PLACEMENTS_VALUE;
+  const hasActiveFilters = Boolean(
+    activeFilters && Object.values(activeFilters).some((value) => Boolean(value))
+  );
+  const showExtendedColumns = hasActiveFilters || !allSelected;
 
   return (
-    <div className="overflow-hidden rounded-2xl bg-slate-900/80 ring-1 ring-slate-800/70">
+    <div className="overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-950/75 shadow-xl shadow-slate-950/40">
       <div className="overflow-x-auto">
         <table className="min-w-full divide-y divide-slate-800/70 text-sm">
-          <thead className="bg-slate-900/60 text-left text-xs uppercase tracking-widest text-slate-400">
+          <thead className="bg-slate-950/70 text-left text-xs uppercase tracking-[0.35em] text-slate-400">
             <tr>
-              <th className="px-4 py-3 font-semibold">날짜</th>
-              <th className="px-4 py-3 font-semibold">국가</th>
-              <th className="px-4 py-3 font-semibold">수익 포맷</th>
-              <th className="px-4 py-3 font-semibold">OS</th>
-              <th className="px-4 py-3 font-semibold">디바이스</th>
-              <th className="px-4 py-3 font-semibold">디바이스 포맷</th>
-              <th className="px-4 py-3 text-right font-semibold">노출수</th>
-              <th className="px-4 py-3 text-right font-semibold">클릭수</th>
-              <th className="px-4 py-3 text-right font-semibold">CTR</th>
-              <th className="px-4 py-3 text-right font-semibold">CPM (USD)</th>
-              <th className="px-4 py-3 text-right font-semibold">수익 (USD)</th>
+              <th className="px-5 py-3 font-semibold">날짜</th>
+              <th className="px-5 py-3 font-semibold">포맷</th>
+              {showExtendedColumns && (
+                <>
+                  <th className="px-5 py-3 font-semibold">국가</th>
+                  <th className="px-5 py-3 font-semibold">OS</th>
+                  <th className="px-5 py-3 font-semibold">디바이스</th>
+                  <th className="px-5 py-3 font-semibold">디바이스 포맷</th>
+                  <th className="px-5 py-3 text-right font-semibold">클릭수</th>
+                </>
+              )}
+              <th className="px-5 py-3 text-right font-semibold">노출 수</th>
+              <th className="px-5 py-3 text-right font-semibold">평균 CPM</th>
+              <th className="px-5 py-3 text-right font-semibold">수익</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-800/60">
@@ -34,11 +42,6 @@ export default function AdsterraStatsTable({
               const impressions = Number(row?.impression ?? row?.impressions ?? 0) || 0;
               const clicks = Number(row?.clicks ?? row?.click ?? 0) || 0;
               const revenue = Number(row?.revenue ?? 0) || 0;
-              const ctrRaw =
-                Number(
-                  row?.ctr ??
-                    (impressions > 0 && clicks >= 0 ? (clicks / impressions) * 100 : 0)
-                ) || 0;
               const cpmRaw =
                 Number(
                   row?.cpm ??
@@ -65,31 +68,34 @@ export default function AdsterraStatsTable({
                   ? placementLabelMap.get(String(placementId)) || ''
                   : '') ||
                 (allSelected
-                  ? '전체 보기'
+                  ? 'Smartlink + 300x250'
                   : placementLabelMap.get(String(selectedPlacementId)) || '—');
               const rowKey = `${row?.localDateIso || dateLabel}-${index}-${placementId ?? ''}-${countryLabel}-${osLabel}-${deviceLabel}-${deviceFormatLabel}`;
               return (
-                <tr key={rowKey} className="hover:bg-slate-800/40">
-                  <td className="px-4 py-3 font-semibold text-slate-100" title={dateDetail}>
+                <tr key={rowKey} className="hover:bg-slate-900/60">
+                  <td className="px-5 py-3 font-semibold text-slate-100" title={dateDetail}>
                     {dateLabel}
                   </td>
-                  <td className="px-4 py-3 text-slate-100">{countryLabel}</td>
-                  <td className="px-4 py-3 text-slate-100">{placementDisplay}</td>
-                  <td className="px-4 py-3 text-slate-100">{osLabel}</td>
-                  <td className="px-4 py-3 text-slate-100">{deviceLabel}</td>
-                  <td className="px-4 py-3 text-slate-100">{deviceFormatLabel}</td>
-                  <td className="px-4 py-3 text-right text-slate-100">{formatNumber(impressions)}</td>
-                  <td className="px-4 py-3 text-right text-slate-100">{formatNumber(clicks)}</td>
-                  <td className="px-4 py-3 text-right text-slate-100">{`${formatDecimal(ctrRaw, 3)}%`}</td>
-                  <td className="px-4 py-3 text-right text-slate-100">{formatDecimal(cpmRaw, 3)}</td>
-                  <td className="px-4 py-3 text-right text-slate-100">{formatDecimal(revenue, 3)}</td>
+                  <td className="px-5 py-3 text-slate-100">{placementDisplay}</td>
+                  {showExtendedColumns && (
+                    <>
+                      <td className="px-5 py-3 text-slate-200">{countryLabel}</td>
+                      <td className="px-5 py-3 text-slate-200">{osLabel}</td>
+                      <td className="px-5 py-3 text-slate-200">{deviceLabel}</td>
+                      <td className="px-5 py-3 text-slate-200">{deviceFormatLabel}</td>
+                      <td className="px-5 py-3 text-right text-slate-100">{formatNumber(clicks)}</td>
+                    </>
+                  )}
+                  <td className="px-5 py-3 text-right text-slate-100">{formatNumber(impressions)}</td>
+                  <td className="px-5 py-3 text-right text-slate-100">{formatCurrency(cpmRaw, 3)}</td>
+                  <td className="px-5 py-3 text-right text-slate-100">{formatCurrency(revenue, 3)}</td>
                 </tr>
               );
             })}
             {!rows.length && !loading && (
               <tr>
-                <td colSpan={11} className="px-4 py-12 text-center text-sm text-slate-400">
-                  통계를 불러오면 여기에 표시됩니다.
+                <td colSpan={showExtendedColumns ? 10 : 5} className="px-5 py-12 text-center text-sm text-slate-400">
+                  통계를 불러오면 기간별 노출 · 수익 지표가 여기에 정렬됩니다.
                 </td>
               </tr>
             )}
@@ -97,8 +103,8 @@ export default function AdsterraStatsTable({
         </table>
       </div>
       {loading && (
-        <div className="border-t border-slate-800/70 bg-slate-900/70 px-4 py-3 text-right text-xs text-slate-400">
-          통계를 불러오는 중입니다…
+        <div className="border-t border-slate-800/70 bg-slate-900/70 px-5 py-3 text-right text-xs text-slate-400">
+          통계를 정리하는 중입니다…
         </div>
       )}
     </div>

--- a/components/admin/adsterra/AdsterraSummaryCards.jsx
+++ b/components/admin/adsterra/AdsterraSummaryCards.jsx
@@ -1,20 +1,134 @@
-export default function AdsterraSummaryCards({ totals, formatNumber, formatDecimal }) {
+import { useMemo } from 'react';
+
+export default function AdsterraSummaryCards({
+  totals,
+  rows,
+  placementLabelMap,
+  formatNumber,
+  formatDecimal,
+  formatCurrency,
+}) {
+  const averageCpm = Number.isFinite(totals.cpm) ? totals.cpm : 0;
+  const averageRevenuePerImpression =
+    totals.impressions > 0 ? totals.revenue / totals.impressions : 0;
+
+  const activeDays = useMemo(() => {
+    if (!Array.isArray(rows)) return 0;
+    const dates = new Set();
+    rows.forEach((row) => {
+      const label = row?.localDate || row?.date || row?.day || row?.Day;
+      if (label) dates.add(String(label));
+    });
+    return dates.size;
+  }, [rows]);
+
+  const formatBreakdown = useMemo(() => {
+    if (!Array.isArray(rows) || !rows.length) return [];
+    const map = new Map();
+    rows.forEach((row) => {
+      if (!row || typeof row !== 'object') return;
+      const placementId =
+        row?.placement_id ??
+        row?.placementId ??
+        row?.placementID ??
+        row?.placementid;
+      const idKey = placementId !== undefined && placementId !== null ? String(placementId) : '';
+      const placementLabel =
+        row?.placement_name ??
+        row?.placement ??
+        row?.placementName ??
+        row?.ad_format ??
+        row?.format ??
+        placementLabelMap.get(idKey) ??
+        (idKey ? `#${idKey}` : '포맷 미지정');
+      const key = placementLabel || placementLabelMap.get(idKey) || '포맷 미지정';
+      const impressions = Number(row?.impression ?? row?.impressions ?? 0) || 0;
+      const revenue = Number(row?.revenue ?? 0) || 0;
+      const current = map.get(key) || { label: key, impressions: 0, revenue: 0 };
+      current.impressions += impressions;
+      current.revenue += revenue;
+      map.set(key, current);
+    });
+    return Array.from(map.values())
+      .map((entry) => ({
+        ...entry,
+        cpm: entry.impressions > 0 ? (entry.revenue / entry.impressions) * 1000 : 0,
+        share: totals.revenue > 0 ? entry.revenue / totals.revenue : 0,
+      }))
+      .sort((a, b) => b.revenue - a.revenue);
+  }, [placementLabelMap, rows, totals.revenue]);
+
+  const breakdownToDisplay = formatBreakdown.length
+    ? formatBreakdown
+    : [
+        {
+          label: '데이터 없음',
+          impressions: 0,
+          revenue: 0,
+          cpm: 0,
+          share: 0,
+        },
+      ];
+
   return (
-    <div className="grid gap-4 md:grid-cols-3">
-      <div className="rounded-2xl border border-white/5 bg-slate-900/80 p-4 shadow-lg shadow-black/20">
-        <p className="text-xs uppercase tracking-[0.25em] text-slate-400">총 노출수</p>
-        <p className="mt-2 text-2xl font-bold text-white">{formatNumber(totals.impressions)}</p>
-        <p className="mt-1 text-xs text-slate-500">선택한 기간 · 필터 기준 합계</p>
+    <div className="grid gap-4 xl:grid-cols-4">
+      <div className="relative overflow-hidden rounded-3xl border border-cyan-400/20 bg-gradient-to-br from-cyan-500/25 via-sky-600/20 to-indigo-800/30 p-6 shadow-lg shadow-cyan-500/25 xl:col-span-2">
+        <div
+          className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(165,243,252,0.2),transparent_60%)]"
+          aria-hidden
+        />
+        <div className="relative space-y-3">
+          <p className="text-xs uppercase tracking-[0.4em] text-cyan-100/80">총 수익</p>
+          <p className="text-3xl font-semibold text-white">{formatCurrency(totals.revenue)}</p>
+          <p className="text-sm text-cyan-100/70">
+            {activeDays > 0 ? `최근 ${activeDays}일 범위` : '기간을 선택해 통계를 확인하세요.'}
+          </p>
+          <p className="text-[11px] text-cyan-100/60">
+            평균 노출당 수익 {formatCurrency(averageRevenuePerImpression, 5)} · 노출 {formatNumber(totals.impressions)}
+          </p>
+        </div>
       </div>
-      <div className="rounded-2xl border border-white/5 bg-slate-900/80 p-4 shadow-lg shadow-black/20">
-        <p className="text-xs uppercase tracking-[0.25em] text-slate-400">총 클릭수</p>
-        <p className="mt-2 text-2xl font-bold text-white">{formatNumber(totals.clicks)}</p>
-        <p className="mt-1 text-xs text-slate-500">필터 기준 평균 CTR {formatDecimal(totals.ctr, 2)}%</p>
+
+      <div className="rounded-3xl border border-slate-800/70 bg-slate-950/60 p-6 shadow-lg shadow-black/40">
+        <p className="text-xs uppercase tracking-[0.35em] text-slate-400">총 노출수</p>
+        <p className="mt-3 text-2xl font-semibold text-white">{formatNumber(totals.impressions)}</p>
+        <p className="mt-2 text-[12px] text-slate-400">
+          필터를 적용한 집계 · Smartlink_1 + 300x250_1 기준
+        </p>
       </div>
-      <div className="rounded-2xl border border-white/5 bg-slate-900/80 p-4 shadow-lg shadow-black/20">
-        <p className="text-xs uppercase tracking-[0.25em] text-slate-400">총 수익 (USD)</p>
-        <p className="mt-2 text-2xl font-bold text-white">{formatDecimal(totals.revenue, 3)}</p>
-        <p className="mt-1 text-xs text-slate-500">필터 기준 평균 CPM {formatDecimal(totals.cpm, 3)}</p>
+
+      <div className="rounded-3xl border border-slate-800/70 bg-slate-950/60 p-6 shadow-lg shadow-black/40">
+        <p className="text-xs uppercase tracking-[0.35em] text-slate-400">평균 CPM</p>
+        <p className="mt-3 text-2xl font-semibold text-white">{formatCurrency(averageCpm, 3)}</p>
+        <p className="mt-2 text-[12px] text-slate-400">
+          선택한 기간 동안 1,000 노출당 예상 수익
+        </p>
+      </div>
+
+      <div className="rounded-3xl border border-slate-800/70 bg-slate-950/60 p-6 shadow-lg shadow-black/40">
+        <p className="text-xs uppercase tracking-[0.35em] text-slate-400">포맷별 수익 비중</p>
+        <div className="mt-4 space-y-4">
+          {breakdownToDisplay.map((entry) => (
+            <div key={entry.label} className="space-y-2">
+              <div className="flex items-center justify-between text-xs text-slate-300">
+                <span className="font-semibold text-slate-100">{entry.label}</span>
+                <span className="font-semibold text-cyan-100">{formatCurrency(entry.revenue)}</span>
+              </div>
+              <div className="h-2 rounded-full bg-slate-800">
+                <div
+                  className="h-full rounded-full bg-gradient-to-r from-cyan-400 to-indigo-500"
+                  style={{ width: `${Math.max(entry.share * 100, entry.revenue > 0 ? 6 : 0)}%` }}
+                />
+              </div>
+              <div className="flex flex-col text-[11px] text-slate-500">
+                <span>노출 {formatNumber(entry.impressions)}</span>
+                <span>
+                  점유 {formatDecimal(entry.share * 100, 2)}% · CPM {formatCurrency(entry.cpm, 3)}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## 요약
- Smartlink_1과 300x250_1만 집계하도록 Adsterra 통계 훅과 API를 정비하고 전체 보기에서도 지정 포맷만 요청하도록 수정했습니다.
- 수익 섹션 UI를 미래지향적인 톤으로 재구성하고 요약 카드·복합 추세 그래프·분포 그래프를 고급 지표 중심으로 업그레이드했습니다.
- 기본 표를 날짜·포맷·노출 수·평균 CPM·수익 중심으로 단순화하고 값에 달러 표기를 붙이도록 개선했습니다.

## 테스트
- `npm run lint` (실패, 기존 React JSX/prop-types 규칙 위반 다수로 인한 프로젝트 수준 오류)


------
https://chatgpt.com/codex/tasks/task_e_68d96e2273288323ad0324469ae17af2