### PR TITLE
업로드 카드 개선 및 목록 뷰 비활성화

### DIFF
--- a/components/admin/analytics/AnalyticsHistoryPanel.unused.jsx
+++ b/components/admin/analytics/AnalyticsHistoryPanel.unused.jsx
@@ -1,3 +1,6 @@
+/**
+ * NOTE: This component is archived and not currently used in the admin UI.
+ */
 import { useMemo } from 'react';
 import ModalPortal from '../modals/ModalPortal';
 

--- a/components/admin/analytics/AnalyticsOverview.unused.jsx
+++ b/components/admin/analytics/AnalyticsOverview.unused.jsx
@@ -1,3 +1,6 @@
+/**
+ * NOTE: This component is archived and not currently used in the admin UI.
+ */
 export default function AnalyticsOverview({ itemCount, totals, averageViews, formatNumber }) {
   return (
     <div className="grid gap-4 md:grid-cols-3">

--- a/components/admin/analytics/AnalyticsTable.unused.jsx
+++ b/components/admin/analytics/AnalyticsTable.unused.jsx
@@ -1,3 +1,6 @@
+/**
+ * NOTE: This component is archived and not currently used in the admin UI.
+ */
 import { useEffect, useMemo, useRef } from 'react';
 import AnalyticsEmptyState from './AnalyticsEmptyState';
 import AnalyticsRow from './AnalyticsRow';

--- a/components/admin/analytics/AnalyticsToolbar.unused.jsx
+++ b/components/admin/analytics/AnalyticsToolbar.unused.jsx
@@ -1,3 +1,6 @@
+/**
+ * NOTE: This component is archived and not currently used in the admin UI.
+ */
 export default function AnalyticsToolbar({
   sortKey,
   sortDirection,

--- a/components/admin/analytics/AnalyticsTrendChart.unused.jsx
+++ b/components/admin/analytics/AnalyticsTrendChart.unused.jsx
@@ -1,4 +1,7 @@
 import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from 'recharts';
+/**
+ * NOTE: This component is archived and not currently used in the admin UI.
+ */
 import { useMemo } from 'react';
 
 function normalizeHistory(history) {

--- a/components/admin/modals/AnalyticsCsvUploadModal.unused.jsx
+++ b/components/admin/modals/AnalyticsCsvUploadModal.unused.jsx
@@ -1,3 +1,6 @@
+/**
+ * NOTE: This component is archived and not currently used in the admin UI.
+ */
 import { useEffect, useMemo, useState } from 'react';
 import ModalPortal from './ModalPortal';
 

--- a/components/admin/modals/EditContentModal.jsx
+++ b/components/admin/modals/EditContentModal.jsx
@@ -69,28 +69,12 @@ export default function EditContentModal({
                 </div>
 
                 <div className="space-y-2">
-                  <label className="text-xs uppercase tracking-widest text-slate-400">Duration (seconds)</label>
-                  <input
-                    type="number"
-                    min="0"
-                    step="1"
-                    inputMode="numeric"
-                    value={editForm.durationSeconds}
-                    onChange={(event) => onFieldChange('durationSeconds', event.target.value)}
-                    className="w-full rounded-2xl border border-slate-700/60 bg-slate-900/80 px-4 py-3 text-sm text-white shadow-inner shadow-black/40 transition focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
-                    placeholder="예: 123"
-                  />
-                  <p className="text-xs text-slate-500">초 단위로 입력해 주세요. 비워두면 기존 값이 유지됩니다.</p>
-                </div>
-
-                <div className="space-y-2">
                   <label className="text-xs uppercase tracking-widest text-slate-400">Channel</label>
                   <select
-                    value={editForm.channel || 'x'}
+                    value={editForm.channel || 'l'}
                     onChange={(event) => onFieldChange('channel', event.target.value)}
                     className="w-full rounded-2xl border border-slate-700/60 bg-slate-900/80 px-4 py-3 text-sm text-white shadow-inner shadow-black/40 transition focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
                   >
-                    <option value="x">x</option>
                     <option value="l">l</option>
                   </select>
                 </div>

--- a/components/admin/uploads/UploadFilters.jsx
+++ b/components/admin/uploads/UploadFilters.jsx
@@ -1,13 +1,6 @@
 const SORT_OPTIONS = [
   { value: 'recent', label: '최신순' },
   { value: 'title', label: '제목순' },
-  { value: 'duration', label: '재생시간' },
-];
-
-const CHANNEL_TABS = [
-  { value: 'l', label: 'L 채널' },
-  { value: 'x', label: 'X 채널' },
-  { value: '', label: '전체 보기' },
 ];
 
 export default function UploadFilters({
@@ -15,31 +8,16 @@ export default function UploadFilters({
   onSearchChange,
   typeFilter,
   onTypeFilterChange,
-  channelFilter,
-  onChannelFilterChange,
   sortOption,
   onSortOptionChange,
 }) {
   return (
     <div className="space-y-4 rounded-3xl border border-slate-800/60 bg-[#050916]/80 p-5 shadow-inner shadow-slate-900/40">
-      <div className="flex flex-wrap items-center gap-2 rounded-full bg-slate-950/40 p-1">
-        {CHANNEL_TABS.map((tab) => {
-          const isActive = channelFilter === tab.value;
-          return (
-            <button
-              key={tab.value || 'all'}
-              type="button"
-              onClick={() => onChannelFilterChange(tab.value)}
-              className={`flex-1 min-w-[96px] rounded-full px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] transition ${
-                isActive
-                  ? 'bg-gradient-to-r from-sky-500/80 via-cyan-400/80 to-indigo-500/80 text-slate-950 shadow-lg shadow-cyan-500/20'
-                  : 'text-slate-400 hover:text-slate-100'
-              }`}
-            >
-              {tab.label}
-            </button>
-          );
-        })}
+      <div className="flex items-center justify-between rounded-2xl border border-slate-900/70 bg-slate-950/40 px-4 py-3 text-[12px] text-slate-300">
+        <span className="font-semibold uppercase tracking-[0.32em] text-slate-400">채널</span>
+        <span className="rounded-full border border-sky-400/40 bg-sky-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.24em] text-sky-200">
+          L 전용 라우트
+        </span>
       </div>
       <div className="grid gap-3 sm:grid-cols-[minmax(200px,1fr)_minmax(140px,200px)_minmax(140px,200px)]">
         <label className="group flex items-center gap-2 rounded-2xl border border-slate-900/60 bg-slate-950/40 px-3 py-2 text-sm text-slate-300 transition hover:border-sky-500/40">

--- a/components/admin/uploads/UploadForm.jsx
+++ b/components/admin/uploads/UploadForm.jsx
@@ -3,64 +3,50 @@ import ClientBlobUploader from '../../ClientBlobUploader';
 export default function UploadForm({
   hasToken,
   title,
-  duration,
   channel,
   onTitleChange,
-  onDurationChange,
   onChannelChange,
   handleUploadUrl,
   onUploaded,
+  onClose,
 }) {
   return (
     <div className="space-y-6 rounded-3xl bg-[#070b1b]/95 p-6 shadow-[0_0_45px_rgba(59,130,246,0.2)] ring-1 ring-slate-800/70 backdrop-blur">
       <div className="space-y-2">
-        <p className="text-[11px] uppercase tracking-[0.4em] text-slate-400">콘텐츠 메타</p>
-        <h3 className="text-lg font-semibold text-slate-50">새로운 L 채널 아카이브</h3>
-        <p className="text-sm text-slate-400">
-          제목과 러닝타임을 입력한 뒤 파일을 업로드하면 메타 정보가 즉시 등록됩니다.
+        <p className="text-[11px] font-semibold uppercase tracking-[0.38em] text-slate-300">콘텐츠 업로드</p>
+        <h3 className="text-xl font-semibold text-slate-50">간편하게 새 콘텐츠를 등록하세요</h3>
+        <p className="text-sm leading-relaxed text-slate-300">
+          제목과 채널만 지정하면 파일을 올리는 즉시 메타 정보가 자동으로 저장됩니다.
         </p>
       </div>
-      <div className="grid gap-4 sm:grid-cols-2">
+      <div className="space-y-4">
         <label className="group flex flex-col gap-2 rounded-2xl border border-slate-800/60 bg-slate-950/40 p-4 transition hover:border-sky-500/40">
-          <span className="text-xs font-medium uppercase tracking-widest text-slate-400">Title</span>
+          <span className="text-xs font-medium text-slate-300">콘텐츠 제목</span>
           <input
             disabled={!hasToken}
             type="text"
-            placeholder="트윗 카드 타이틀"
+            placeholder="예) 6월 1주차 하이라이트"
             value={title}
             onChange={(event) => onTitleChange(event.target.value)}
             className="w-full rounded-lg border border-slate-800/40 bg-black/40 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-sky-500/60 group-hover:border-sky-400/40 disabled:opacity-40"
           />
         </label>
         <label className="group flex flex-col gap-2 rounded-2xl border border-slate-800/60 bg-slate-950/40 p-4 transition hover:border-sky-500/40">
-          <span className="text-xs font-medium uppercase tracking-widest text-slate-400">Duration (sec)</span>
-          <input
-            disabled={!hasToken}
-            type="number"
-            min="0"
-            placeholder="0"
-            value={duration}
-            onChange={(event) => onDurationChange(event.target.value)}
-            className="w-full rounded-lg border border-slate-800/40 bg-black/40 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-sky-500/60 group-hover:border-sky-400/40 disabled:opacity-40"
-          />
-        </label>
-        <label className="group flex flex-col gap-2 rounded-2xl border border-slate-800/60 bg-slate-950/40 p-4 transition hover:border-sky-500/40 sm:col-span-2">
-          <span className="text-xs font-medium uppercase tracking-widest text-slate-400">Channel</span>
+          <span className="text-xs font-medium text-slate-300">채널 선택</span>
           <select
             disabled={!hasToken}
             value={channel}
             onChange={(event) => onChannelChange(event.target.value)}
             className="w-full rounded-lg border border-slate-800/40 bg-black/40 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-sky-500/60 group-hover:border-sky-400/40 disabled:opacity-40"
           >
-            <option value="l">L</option>
-            <option value="x">X</option>
+            <option value="l">L 채널</option>
           </select>
         </label>
       </div>
-      <div className="space-y-3 rounded-2xl border border-slate-800/70 bg-gradient-to-br from-slate-950/80 via-slate-900/60 to-cyan-950/40 p-5">
-        <div className="flex items-center justify-between gap-3">
-          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-sky-300/80">Asset Upload</p>
-          <span className="text-[11px] text-slate-400">최대 200MB · JPG / PNG / WEBP / MP4</span>
+      <div className="space-y-4 rounded-2xl border border-slate-800/70 bg-gradient-to-br from-slate-950/80 via-slate-900/60 to-cyan-950/40 p-5">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-sky-300/80">파일 업로드</p>
+          <span className="text-[11px] text-slate-300">최대 200MB · JPG / PNG / WEBP / MP4</span>
         </div>
         {hasToken ? (
           <ClientBlobUploader
@@ -70,9 +56,20 @@ export default function UploadForm({
             onUploaded={onUploaded}
           />
         ) : (
-          <div className="rounded-xl border border-slate-800/70 bg-black/40 px-4 py-3 text-sm text-slate-400">
-            관리자 토큰이 필요합니다.
+          <div className="rounded-xl border border-slate-800/70 bg-black/40 px-4 py-3 text-sm text-slate-300">
+            관리자 토큰이 있어야 업로드할 수 있어요.
           </div>
+        )}
+      </div>
+      <div className="flex flex-wrap justify-end gap-3">
+        {typeof onClose === 'function' && (
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-xl border border-slate-700/80 px-4 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-500 hover:text-white"
+          >
+            닫기
+          </button>
         )}
       </div>
     </div>

--- a/components/admin/uploads/UploadTagChips.jsx
+++ b/components/admin/uploads/UploadTagChips.jsx
@@ -1,8 +1,6 @@
 export default function UploadTagChips({ item }) {
   const tags = [];
   if (item.channel) tags.push({ label: item.channel.toUpperCase(), tone: 'bg-purple-900/60' });
-  if (item.type) tags.push({ label: item.type.toUpperCase(), tone: 'bg-slate-800' });
-  if (item.durationSeconds) tags.push({ label: `${item.durationSeconds}s`, tone: 'bg-emerald-900/50' });
   if (item.publishedAt) tags.push({ label: item.publishedAt.slice(0, 10), tone: 'bg-slate-800/80' });
 
   if (!tags.length) return null;

--- a/components/admin/uploads/UploadedItemActions.jsx
+++ b/components/admin/uploads/UploadedItemActions.jsx
@@ -6,46 +6,51 @@ export default function UploadedItemActions({
   onEdit,
   onDelete,
 }) {
+  const canCopy = Boolean(item?.routePath);
+  const handleCopy = () => {
+    if (!canCopy) return;
+    onCopy(item);
+  };
+
   return (
-    <div className="flex items-center gap-2 pt-1">
-      {item.routePath && (
-        <>
-          <a
-            href={item.routePath}
-            target="_blank"
-            rel="noreferrer"
-            className="rounded-full bg-indigo-600 px-3 py-1 text-white hover:bg-indigo-500"
-          >
-            Open Route
-          </a>
-          <button
-            onClick={() => onCopy(item)}
-            className={`rounded-full px-3 py-1 text-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 ${
-              copied
-                ? 'bg-gradient-to-r from-emerald-400 via-teal-400 to-cyan-400 text-slate-950 shadow-lg shadow-emerald-500/30'
-                : 'bg-slate-800 text-slate-200 hover:bg-slate-700'
-            }`}
-          >
-            {copied ? 'Copied ✨' : 'Copy'}
-          </button>
-          {copied && <span className="sr-only" aria-live="polite">링크가 복사되었습니다.</span>}
-        </>
-      )}
+    <div className="flex flex-wrap items-center gap-2 pt-1">
+      <button
+        type="button"
+        onClick={handleCopy}
+        disabled={!canCopy}
+        className={`group relative overflow-hidden rounded-xl border px-4 py-1.5 text-sm font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-200 ${
+          copied
+            ? 'border-emerald-400/70 text-emerald-100'
+            : 'border-slate-700/70 text-slate-200 hover:border-sky-400/60 hover:text-white'
+        } ${canCopy ? '' : 'cursor-not-allowed opacity-50'}`}
+      >
+        <span
+          className={`absolute inset-0 -z-10 bg-gradient-to-r from-emerald-400/20 via-teal-400/15 to-cyan-400/25 transition ${
+            copied ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+          }`}
+          aria-hidden="true"
+        />
+        <span className="relative z-10">{copied ? '링크 복사 완료' : '링크 복사'}</span>
+      </button>
+      {copied && <span className="sr-only" aria-live="polite">링크가 복사되었습니다.</span>}
       {hasToken && !item._error && (
         <button
           type="button"
           onClick={() => onEdit(item)}
-          className="rounded-full bg-gradient-to-r from-emerald-400/30 via-teal-400/25 to-cyan-400/25 px-3 py-1 text-sm font-semibold text-emerald-100 shadow-[0_12px_30px_rgba(16,185,129,0.25)] backdrop-blur transition hover:brightness-115 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-200"
+          className="group relative overflow-hidden rounded-xl border border-emerald-400/40 px-4 py-1.5 text-sm font-semibold text-emerald-100 shadow-[0_12px_30px_rgba(16,185,129,0.2)] transition hover:border-emerald-300/70 hover:text-emerald-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-200"
         >
-          Edit
+          <span className="absolute inset-0 -z-10 bg-gradient-to-r from-emerald-400/20 via-teal-400/15 to-cyan-400/20 opacity-70 group-hover:opacity-100" aria-hidden="true" />
+          <span className="relative z-10">메타 수정</span>
         </button>
       )}
       <button
+        type="button"
         disabled={!hasToken}
         onClick={() => onDelete(item)}
-        className="ml-auto rounded-full bg-rose-600 px-3 py-1 hover:bg-rose-500 disabled:opacity-50"
+        className="group relative ml-auto overflow-hidden rounded-xl border border-rose-500/60 px-4 py-1.5 text-sm font-semibold text-rose-100 transition hover:border-rose-400/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-200 disabled:cursor-not-allowed disabled:border-rose-900 disabled:text-rose-400"
       >
-        Delete
+        <span className="absolute inset-0 -z-10 bg-gradient-to-r from-rose-500/30 via-amber-500/20 to-rose-400/30 opacity-70 group-hover:opacity-100" aria-hidden="true" />
+        <span className="relative z-10">삭제</span>
       </button>
     </div>
   );

--- a/components/admin/uploads/UploadedItemCard.jsx
+++ b/components/admin/uploads/UploadedItemCard.jsx
@@ -14,30 +14,38 @@ export default function UploadedItemCard({
 }) {
   const copied = copiedSlug === item.slug;
   const ringClass = item._error
-    ? 'border border-rose-500/60 shadow-[0_0_24px_rgba(244,63,94,0.25)]'
+    ? 'border border-rose-500/60 shadow-[0_0_36px_rgba(244,63,94,0.28)]'
     : selected
-      ? 'border border-emerald-400/70 shadow-[0_0_28px_rgba(16,185,129,0.25)]'
-      : 'border border-slate-800/60';
+      ? 'border border-emerald-400/80 shadow-[0_0_36px_rgba(16,185,129,0.32)]'
+      : 'border border-slate-800/70 shadow-[0_0_55px_rgba(14,23,42,0.55)]';
 
   return (
-    <div className={`relative overflow-hidden rounded-3xl bg-[#050a19]/85 backdrop-blur ${ringClass}`}>
+    <div
+      className={`relative overflow-hidden rounded-3xl bg-[radial-gradient(circle_at_top,_rgba(15,23,42,0.92),_rgba(5,10,25,0.92))] backdrop-blur ${ringClass}`}
+    >
       {selectable && (
-        <label className="absolute left-4 top-4 z-20 flex h-8 w-8 items-center justify-center rounded-full bg-black/70 shadow-lg">
+        <div className="absolute left-5 top-5 z-20 flex items-center gap-2 rounded-lg bg-slate-950/75 px-3 py-1.5 text-[11px] font-medium text-slate-200">
           <input
             type="checkbox"
             className="h-4 w-4 accent-emerald-400"
             onChange={onToggleSelect}
             checked={selected}
           />
-          <span className="sr-only">콘텐츠 선택</span>
-        </label>
+          선택
+        </div>
       )}
-      <div className="grid gap-4 p-4 sm:grid-cols-[140px,1fr]">
-        <div className="relative overflow-hidden rounded-2xl border border-slate-900/60 bg-slate-950/70">
+      <div className="grid gap-5 p-6 lg:grid-cols-[minmax(280px,340px)_1fr]">
+        <div className="relative aspect-[16/9] overflow-hidden rounded-2xl border border-slate-900/70 bg-slate-950/70">
           {item.preview ? (
-            <img src={item.preview} alt={item.title || item.slug} className="h-36 w-full object-cover" />
+            <img
+              src={item.preview}
+              alt={item.title || item.slug}
+              className="h-full w-full object-cover"
+            />
           ) : (
-            <div className="grid h-36 place-items-center text-xs uppercase tracking-[0.3em] text-slate-500">No Preview</div>
+            <div className="grid h-full w-full place-items-center text-xs uppercase tracking-[0.3em] text-slate-500">
+              No Preview
+            </div>
           )}
           {item._error && (
             <span className="absolute right-3 top-3 rounded-full bg-rose-600/80 px-2 py-0.5 text-[11px] font-semibold text-white shadow-lg">
@@ -45,22 +53,28 @@ export default function UploadedItemCard({
             </span>
           )}
         </div>
-        <div className="flex flex-col justify-between gap-3">
-          <div className="space-y-2">
-            <div className="text-sm font-semibold text-slate-100">
-              {item.title || item.slug}
-            </div>
-            <div className="text-[12px] text-slate-400">
-              <span className="rounded bg-slate-900/70 px-2 py-0.5 font-mono text-[11px] tracking-wide text-slate-300">
-                {item.slug}
-              </span>
+        <div className="flex flex-col justify-between gap-4">
+          <div className="space-y-4">
+            <div className="flex flex-col gap-2">
+              <div className="inline-flex max-w-full items-center gap-2">
+                <span className="inline-flex max-w-full items-center gap-2 truncate rounded-xl border border-cyan-400/50 bg-cyan-500/10 px-3 py-1 font-mono text-sm font-semibold uppercase tracking-[0.18em] text-cyan-200 shadow-[0_18px_50px_-30px_rgba(34,211,238,0.75)]">
+                  {item.slug}
+                </span>
+              </div>
+              {item.title && (
+                <div className="truncate text-base font-semibold text-slate-50/90">
+                  {item.title}
+                </div>
+              )}
             </div>
             <UploadTagChips item={item} />
             {item.routePath && (
-              <p className="truncate text-[11px] text-slate-500">{item.routePath}</p>
+              <p className="truncate text-xs text-slate-400">
+                연결 경로 <span className="text-slate-200">{item.routePath}</span>
+              </p>
             )}
             {item._error && (
-              <p className="rounded-xl bg-rose-500/10 px-3 py-2 text-[12px] text-rose-200">
+              <p className="rounded-xl bg-rose-500/15 px-3 py-2 text-[12px] text-rose-200">
                 메타 데이터를 불러오지 못했어요. JSON 파일을 확인해 주세요.
               </p>
             )}

--- a/components/admin/uploads/UploadsSection.jsx
+++ b/components/admin/uploads/UploadsSection.jsx
@@ -37,7 +37,6 @@ export default function UploadsSection({
     search = '',
     type: typeFilter = '',
     sort: sortOption = 'recent',
-    channel: channelFilter = '',
   } =
     filters || {};
 
@@ -53,8 +52,6 @@ export default function UploadsSection({
   const handleSearchChange = useCallback((value) => changeFilters({ search: value }), [changeFilters]);
   const handleTypeFilterChange = useCallback((value) => changeFilters({ type: value }), [changeFilters]);
   const handleSortChange = useCallback((value) => changeFilters({ sort: value }), [changeFilters]);
-  const handleChannelFilterChange = useCallback((value) => changeFilters({ channel: value }), [changeFilters]);
-
   const itemKey = useCallback((item) => item?.pathname || item?.slug || item?.routePath || item?.url || '', []);
 
   useEffect(() => {
@@ -120,12 +117,7 @@ export default function UploadsSection({
     return () => clearTimeout(timer);
   }, [bulkFeedback.status]);
 
-  const isFiltering = Boolean(
-    search ||
-      typeFilter ||
-      channelFilter ||
-      (sortOption && sortOption !== 'recent')
-  );
+  const isFiltering = Boolean(search || typeFilter || (sortOption && sortOption !== 'recent'));
   const showEmptyState = !isLoading && !items.length;
   const canShowLoadMore = hasMore;
   const selectedCount = selectedIds.size;
@@ -267,11 +259,7 @@ export default function UploadsSection({
     [bulkTagForm, handleRefresh, hasToken, queryString, selectedItems]
   );
 
-  const activeChannelLabel = useMemo(() => {
-    if (channelFilter === 'l') return 'L 채널';
-    if (channelFilter === 'x') return 'X 채널';
-    return '전체 채널';
-  }, [channelFilter]);
+  const activeChannelLabel = 'L 채널 콘텐츠';
 
   const handleUploadComplete = useCallback(
     async (blob) => {
@@ -289,13 +277,13 @@ export default function UploadsSection({
 
   return (
     <section className="space-y-6">
-      <div className="space-y-6 rounded-3xl border border-slate-800/60 bg-gradient-to-r from-[#050916]/90 via-[#060b1c]/80 to-[#0a1124]/90 p-6 shadow-lg shadow-cyan-900/20">
+      <div className="space-y-6 rounded-3xl border border-slate-800/70 bg-gradient-to-r from-[#050916]/92 via-[#060b1c]/86 to-[#0a1124]/92 p-6 shadow-[0_45px_140px_-80px_rgba(14,116,144,0.75)]">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
           <div className="space-y-2">
-            <p className="text-[11px] uppercase tracking-[0.48em] text-slate-500">Channel Matrix</p>
-            <h2 className="text-2xl font-semibold text-slate-50">L 라우트 업로드 허브</h2>
-            <p className="text-sm text-slate-400">
-              {activeChannelLabel} 기준으로 정렬된 콘텐츠 {items.length}개를 관리할 수 있어요.
+            <p className="text-[11px] font-semibold uppercase tracking-[0.48em] text-slate-400">콘텐츠 관리</p>
+            <h2 className="text-2xl font-semibold text-slate-50">업로드한 자료를 한눈에 살펴보세요</h2>
+            <p className="text-sm text-slate-300">
+              {activeChannelLabel} {items.length}개를 손쉽게 정리하고 공유할 수 있어요.
             </p>
           </div>
           <div className="flex flex-wrap items-center gap-2">
@@ -305,7 +293,7 @@ export default function UploadsSection({
                 onClick={() => setUploadModalOpen(true)}
                 className="rounded-full bg-gradient-to-r from-sky-500 via-cyan-500 to-indigo-500 px-5 py-2 text-sm font-semibold text-slate-950 shadow-lg shadow-cyan-500/40 transition hover:from-sky-400 hover:via-cyan-400 hover:to-indigo-400"
               >
-                네뷸라 업로드 포털
+                새 콘텐츠 업로드
               </button>
             )}
             <button
@@ -314,7 +302,7 @@ export default function UploadsSection({
               disabled={isLoading}
               className="rounded-full border border-slate-700/70 px-4 py-2 text-sm font-semibold text-slate-200 transition hover:border-slate-500 hover:text-white disabled:cursor-not-allowed disabled:border-slate-900 disabled:text-slate-600"
             >
-              새로고침
+              목록 새로고침
             </button>
           </div>
         </div>
@@ -323,18 +311,16 @@ export default function UploadsSection({
           onSearchChange={handleSearchChange}
           typeFilter={typeFilter}
           onTypeFilterChange={handleTypeFilterChange}
-          channelFilter={channelFilter}
-          onChannelFilterChange={handleChannelFilterChange}
           sortOption={sortOption}
           onSortOptionChange={handleSortChange}
         />
       </div>
 
-      <div className="space-y-4">
+      <div className="space-y-5">
         <div className="space-y-3 rounded-3xl border border-slate-800/60 bg-slate-950/50 p-4">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div className="flex flex-wrap items-center gap-3">
-              <label className="flex items-center gap-2 rounded-full bg-slate-900/70 px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.28em] text-slate-300">
+              <label className="flex items-center gap-2 rounded-lg bg-slate-900/70 px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.28em] text-slate-300">
                 <input
                   ref={selectAllRef}
                   type="checkbox"
@@ -432,7 +418,7 @@ export default function UploadsSection({
           </form>
         )}
 
-        <div className="grid gap-4 lg:grid-cols-2">
+        <div className="grid gap-6 xl:mx-auto xl:max-w-5xl">
           {items.map((item) => (
             <UploadedItemCard
               key={item.pathname || item.slug || item.routePath || item.url}
@@ -495,13 +481,12 @@ export default function UploadsSection({
             <UploadForm
               hasToken={hasToken}
               title={uploadFormState.title}
-              duration={uploadFormState.duration}
               channel={uploadFormState.channel}
               onTitleChange={uploadFormState.setTitle}
-              onDurationChange={uploadFormState.setDuration}
               onChannelChange={uploadFormState.setChannel}
               handleUploadUrl={uploadFormState.handleUploadUrl}
               onUploaded={handleUploadComplete}
+              onClose={handleCloseUploadModal}
             />
           </div>
         </div>


### PR DESCRIPTION
## 요약
- 업로드 카드 레이아웃을 단일 열로 확장하고 슬러그를 강조해 콘텐츠 구분감을 높였습니다.
- 업로드 필터와 폼을 L 채널 전용으로 단순화하고 불필요한 duration 입력을 제거했습니다.
- 관리자 목록 뷰 컴포넌트를 `.unused` 확장자로 보관해 현재 UI에서는 제외했습니다.

## 테스트
- npm run lint *(기존 규칙 미충족으로 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68d9750c1bd88323a9b6b7ad9ea35f7c