### PR TITLE
feat: l_visit 이벤트 분석 Redis 배치 파이프라인 도입

### DIFF
--- a/components/admin/events/EventKeyMetrics.jsx
+++ b/components/admin/events/EventKeyMetrics.jsx
@@ -1,450 +1,57 @@
-import { useId, useMemo } from 'react';
+const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
 
-function aggregateByEvent(items) {
-  const map = new Map();
-  if (!Array.isArray(items)) return map;
-  items.forEach((item) => {
-    const name = typeof item?.eventName === 'string' ? item.eventName : '';
-    if (!name) return;
-    const prev = map.get(name) || { count: 0, valueSum: 0 };
-    const count = Number(item?.count) || 0;
-    const valueSum = Number(item?.valueSum) || 0;
-    map.set(name, {
-      count: prev.count + count,
-      valueSum: prev.valueSum + valueSum,
-    });
-  });
-  return map;
+function formatKstDateTime(value) {
+  if (!value) return '-';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '-';
+  const kst = new Date(date.getTime() + KST_OFFSET_MS);
+  const iso = kst.toISOString();
+  return `${iso.slice(0, 10)} ${iso.slice(11, 19)}`;
 }
 
-function clampRatio(value) {
-  const num = Number(value);
-  if (!Number.isFinite(num) || num <= 0) return 0;
-  if (num >= 1) return 1;
-  return num;
-}
-
-function formatDuration(seconds) {
-  const value = Number(seconds);
-  if (!Number.isFinite(value) || value <= 0) return '0초';
-  if (value < 60) return `${Math.round(value)}초`;
-  const minutes = Math.floor(value / 60);
-  const remainingSeconds = Math.round(value % 60);
-  if (minutes >= 60) {
-    const hours = Math.floor(minutes / 60);
-    const remainMinutes = minutes % 60;
-    return `${hours}시간 ${remainMinutes}분`;
-  }
-  return `${minutes}분 ${remainingSeconds.toString().padStart(2, '0')}초`;
-}
-
-function CircularGauge({ ratio, label, metric, description, colors = ['#818cf8', '#c084fc'] }) {
-  const normalized = clampRatio(ratio);
-  const size = 148;
-  const strokeWidth = 14;
-  const radius = (size - strokeWidth) / 2;
-  const circumference = 2 * Math.PI * radius;
-  const gradientId = useId();
+export default function EventKeyMetrics({ items, formatNumber }) {
+  const rows = Array.isArray(items)
+    ? items.slice(0, 5).map((item) => ({
+        slug: item.slug || '-',
+        count: Number(item.count) || 0,
+        uniqueSessions: Number(item.uniqueSessions) || 0,
+        lastTimestamp: item.lastTimestamp || item.lastDate || null,
+      }))
+    : [];
 
   return (
-    <div className="flex flex-col items-center gap-3 rounded-xl bg-slate-950/40 p-4">
-      <div className="relative inline-flex">
-        <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
-          <defs>
-            <linearGradient id={gradientId} x1="0%" x2="100%" y1="0%" y2="100%">
-              <stop offset="0%" stopColor={colors[0]} />
-              <stop offset="100%" stopColor={colors[1]} />
-            </linearGradient>
-          </defs>
-          <circle
-            cx={size / 2}
-            cy={size / 2}
-            r={radius}
-            fill="none"
-            stroke="rgba(148, 163, 184, 0.25)"
-            strokeWidth={strokeWidth}
-          />
-          <circle
-            cx={size / 2}
-            cy={size / 2}
-            r={radius}
-            fill="none"
-            stroke={`url(#${gradientId})`}
-            strokeWidth={strokeWidth}
-            strokeLinecap="round"
-            strokeDasharray={circumference}
-            strokeDashoffset={circumference * (1 - normalized)}
-            transform={`rotate(-90 ${size / 2} ${size / 2})`}
-          />
-        </svg>
-        <div className="absolute inset-0 flex flex-col items-center justify-center text-center">
-          <span className="text-sm font-semibold text-white">{metric}</span>
-          <span className="mt-0.5 text-[11px] text-slate-400">{label}</span>
-        </div>
+    <div className="rounded-2xl border border-slate-800/60 bg-slate-950/40 p-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">상위 경로</h3>
+        <span className="text-[11px] text-slate-500">l_visit 기준</span>
       </div>
-      {description ? <p className="text-center text-[11px] text-slate-400">{description}</p> : null}
-    </div>
-  );
-}
-
-function buildRevenueGradient(segments) {
-  if (!Array.isArray(segments) || !segments.length) {
-    return 'conic-gradient(rgba(30, 41, 59, 0.6) 0% 100%)';
-  }
-  let current = 0;
-  const parts = [];
-  segments.forEach((segment) => {
-    const ratio = clampRatio(segment.ratio);
-    if (ratio <= 0) return;
-    const start = current * 100;
-    const end = (current + ratio) * 100;
-    parts.push(`${segment.color} ${start}% ${end}%`);
-    current += ratio;
-  });
-  if (current < 1) {
-    parts.push(`rgba(30, 41, 59, 0.6) ${current * 100}% 100%`);
-  }
-  return `conic-gradient(${parts.join(', ')})`;
-}
-
-function RevenueDonut({ segments, centerLabel }) {
-  if (!Array.isArray(segments) || !segments.length) {
-    return (
-      <div className="mt-6 rounded-xl bg-slate-950/40 p-6 text-center text-xs text-slate-400">
-        수익 기여 이벤트가 아직 충분하지 않아요.
-      </div>
-    );
-  }
-
-  const gradient = buildRevenueGradient(segments);
-
-  return (
-    <div className="relative mx-auto mt-6 h-48 w-48">
-      <div
-        className="h-full w-full rounded-full border border-fuchsia-400/30 bg-slate-950/60"
-        style={{ backgroundImage: gradient }}
-      />
-      <div className="absolute inset-6 flex flex-col items-center justify-center rounded-full bg-slate-900/90 text-center">
-        <span className="text-lg font-semibold text-white">{centerLabel}</span>
-        <span className="mt-1 text-[11px] text-slate-400">총 전환 기여</span>
-      </div>
-    </div>
-  );
-}
-
-function ActivityRadar({ metrics }) {
-  const usable = Array.isArray(metrics) ? metrics.filter((item) => Number.isFinite(item.value)) : [];
-  if (usable.length < 3) {
-    return (
-      <div className="flex h-full items-center justify-center rounded-xl bg-slate-950/40 p-6 text-xs text-slate-400">
-        사용자 활동을 그릴 만큼의 데이터가 부족해요.
-      </div>
-    );
-  }
-
-  const size = 240;
-  const center = size / 2;
-  const radius = size / 2 - 28;
-  const step = (Math.PI * 2) / usable.length;
-  const axes = usable.map((item, index) => {
-    const angle = -Math.PI / 2 + index * step;
-    const x = center + Math.cos(angle) * radius;
-    const y = center + Math.sin(angle) * radius;
-    return { ...item, angle, x, y };
-  });
-
-  const gridLevels = 4;
-  const grid = Array.from({ length: gridLevels }, (_, idx) => {
-    const level = (idx + 1) / gridLevels;
-    const points = axes
-      .map(({ angle }) => {
-        const r = radius * level;
-        const x = center + Math.cos(angle) * r;
-        const y = center + Math.sin(angle) * r;
-        return `${x},${y}`;
-      })
-      .join(' ');
-    return (
-      <polygon
-        key={`grid-${level}`}
-        points={points}
-        fill="none"
-        stroke="rgba(148, 163, 184, 0.15)"
-      />
-    );
-  });
-
-  const dataPoints = axes
-    .map(({ angle, value }) => {
-      const r = radius * clampRatio(value);
-      const x = center + Math.cos(angle) * r;
-      const y = center + Math.sin(angle) * r;
-      return `${x},${y}`;
-    })
-    .join(' ');
-
-  return (
-    <svg viewBox={`0 0 ${size} ${size}`} className="h-64 w-64 max-w-full">
-      <circle cx={center} cy={center} r={radius} fill="rgba(15, 23, 42, 0.45)" />
-      {grid}
-      {axes.map(({ x, y }, index) => (
-        <line
-          key={`axis-${index}`}
-          x1={center}
-          y1={center}
-          x2={x}
-          y2={y}
-          stroke="rgba(148, 163, 184, 0.2)"
-        />
-      ))}
-      <polygon
-        points={dataPoints}
-        fill="rgba(129, 140, 248, 0.35)"
-        stroke="rgba(129, 140, 248, 0.7)"
-        strokeWidth="2"
-      />
-      {axes.map(({ angle, x, y, label, display }, index) => {
-        const labelRadius = radius + 18;
-        const valueRadius = radius + 32;
-        const labelX = center + Math.cos(angle) * labelRadius;
-        const labelY = center + Math.sin(angle) * labelRadius;
-        const valueX = center + Math.cos(angle) * valueRadius;
-        const valueY = center + Math.sin(angle) * valueRadius;
-        const anchor = Math.abs(Math.cos(angle)) < 0.2 ? 'middle' : Math.cos(angle) > 0 ? 'start' : 'end';
-        const baseline = Math.abs(Math.sin(angle)) < 0.2 ? 'middle' : Math.sin(angle) > 0 ? 'hanging' : 'baseline';
-        return (
-          <g key={`label-${index}`}>
-            <text
-              x={labelX}
-              y={labelY}
-              fill="rgba(226, 232, 240, 0.85)"
-              fontSize="11"
-              textAnchor={anchor}
-              dominantBaseline={baseline}
-            >
-              {label}
-            </text>
-            <text
-              x={valueX}
-              y={valueY}
-              fill="rgba(148, 163, 184, 0.85)"
-              fontSize="10"
-              textAnchor={anchor}
-              dominantBaseline={baseline === 'middle' ? 'hanging' : baseline}
-            >
-              {display}
-            </text>
-          </g>
-        );
-      })}
-      {axes.map(({ angle, value }, index) => {
-        const r = radius * clampRatio(value);
-        const pointX = center + Math.cos(angle) * r;
-        const pointY = center + Math.sin(angle) * r;
-        return <circle key={`point-${index}`} cx={pointX} cy={pointY} r={4} fill="rgb(129, 140, 248)" stroke="#1e1b4b" strokeWidth="1" />;
-      })}
-    </svg>
-  );
-}
-
-export default function EventKeyMetrics({ items, formatNumber, formatPercent }) {
-  const stats = useMemo(() => aggregateByEvent(items), [items]);
-
-  const getStat = (name) => stats.get(name) || { count: 0, valueSum: 0 };
-
-  const sponsorImpressions = getStat('x_sponsor_impression');
-  const overlayClicks = getStat('x_overlay_click');
-  const smartOpens = getStat('x_smart_link_open');
-  const repeatClicks = getStat('x_sponsor_repeat_click');
-  const scrollDepth = getStat('x_scroll_depth');
-  const sessionDuration = getStat('x_session_duration_bucket');
-  const multiView = getStat('x_multi_view_session');
-  const visits = getStat('x_visit');
-  const ctaFallback = getStat('x_cta_click_unable_to_play');
-  const feedImpressions = getStat('x_feed_impression');
-  const anyClick = getStat('x_any_click');
-
-  const averageScroll = scrollDepth.count > 0 ? scrollDepth.valueSum / scrollDepth.count : 0;
-  const averageDuration = sessionDuration.count > 0 ? sessionDuration.valueSum / sessionDuration.count : 0;
-  const multiViewRate = visits.count > 0 ? multiView.count / visits.count : 0;
-  const engagedRate = visits.count > 0 ? anyClick.count / visits.count : 0;
-  const conversionRate = sponsorImpressions.count > 0 ? smartOpens.count / sponsorImpressions.count : 0;
-  const overlayRate = sponsorImpressions.count > 0 ? overlayClicks.count / sponsorImpressions.count : 0;
-  const overlayToOpenRate = overlayClicks.count > 0 ? smartOpens.count / overlayClicks.count : 0;
-  const repeatIntensity = repeatClicks.count > 0 ? repeatClicks.valueSum / repeatClicks.count : 0;
-  const fallbackShare = smartOpens.count > 0 ? ctaFallback.count / smartOpens.count : 0;
-  const feedToOpenRate = feedImpressions.count > 0 ? smartOpens.count / feedImpressions.count : 0;
-  const targetDuration = 240; // 4 minutes 기준
-  const durationRatio = averageDuration > 0 ? Math.min(averageDuration, targetDuration) / targetDuration : 0;
-
-  const revenueSegments = useMemo(() => {
-    const raw = [
-      { key: 'open', label: '스마트 링크 오픈', value: smartOpens.count, color: 'rgb(168, 85, 247)' },
-      { key: 'repeat', label: '반복 클릭 지수', value: repeatClicks.valueSum, color: 'rgb(34, 211, 238)' },
-      { key: 'fallback', label: 'CTA 장애 우회', value: ctaFallback.count, color: 'rgb(249, 115, 22)' },
-    ].filter((segment) => Number(segment.value) > 0);
-    const total = raw.reduce((sum, segment) => sum + Number(segment.value || 0), 0);
-    return {
-      total,
-      segments: raw.map((segment) => ({
-        ...segment,
-        ratio: total > 0 ? Number(segment.value || 0) / total : 0,
-      })),
-    };
-  }, [ctaFallback.count, repeatClicks.valueSum, smartOpens.count]);
-
-  const radarMetrics = useMemo(
-    () => [
-      {
-        key: 'multi',
-        label: '다중 열람',
-        value: multiViewRate,
-        display: formatPercent ? formatPercent(multiViewRate || 0) : `${Math.round(multiViewRate * 100)}%`,
-      },
-      {
-        key: 'engaged',
-        label: '참여 세션',
-        value: engagedRate,
-        display: formatPercent ? formatPercent(engagedRate || 0) : `${Math.round(engagedRate * 100)}%`,
-      },
-      {
-        key: 'scroll',
-        label: '스크롤 깊이',
-        value: averageScroll / 100,
-        display: `${Math.round(averageScroll)}%`,
-      },
-      {
-        key: 'duration',
-        label: '체류 (4분 기준)',
-        value: durationRatio,
-        display: formatDuration(averageDuration),
-      },
-    ],
-    [averageDuration, averageScroll, durationRatio, engagedRate, formatPercent, multiViewRate]
-  );
-
-  const engagementScore = radarMetrics.length
-    ? radarMetrics.reduce((sum, metric) => sum + clampRatio(metric.value), 0) / radarMetrics.length
-    : 0;
-
-  if (!stats.size) {
-    return null;
-  }
-
-  return (
-    <div className="space-y-5">
-      <div className="grid gap-4 xl:grid-cols-5">
-        <div className="rounded-2xl border border-indigo-500/40 bg-slate-900/80 p-5 shadow-lg shadow-indigo-900/40 xl:col-span-3">
-          <div className="flex items-start justify-between gap-2">
-            <div>
-              <h3 className="text-base font-semibold text-white">스폰서 전환 지수</h3>
-              <p className="mt-1 text-xs text-slate-400">노출-클릭-오픈 단계별 전환을 한국 시간대 기준으로 확인합니다.</p>
-            </div>
-            <span className="text-xs text-indigo-200/90">총 전환율 {formatPercent(conversionRate || 0)}</span>
-          </div>
-          <div className="mt-6 grid gap-4 md:grid-cols-3">
-            <CircularGauge
-              ratio={overlayRate}
-              metric={formatPercent(overlayRate || 0)}
-              label="노출→오버레이"
-              description={`오버레이 클릭 ${formatNumber(overlayClicks.count || 0)}건`}
-              colors={['#38bdf8', '#6366f1']}
-            />
-            <CircularGauge
-              ratio={overlayToOpenRate}
-              metric={formatPercent(overlayToOpenRate || 0)}
-              label="오버레이→오픈"
-              description={`스마트 링크 오픈 ${formatNumber(smartOpens.count || 0)}건`}
-              colors={['#a855f7', '#f472b6']}
-            />
-            <CircularGauge
-              ratio={conversionRate}
-              metric={formatPercent(conversionRate || 0)}
-              label="노출→오픈"
-              description={`노출 ${formatNumber(sponsorImpressions.count || 0)}건 대비`}
-              colors={['#34d399', '#10b981']}
-            />
-          </div>
-          <div className="mt-6 grid gap-3 text-xs text-slate-300 sm:grid-cols-3">
-            <div className="rounded-lg bg-slate-950/40 p-3">
-              <p className="font-semibold text-white">피드→오픈 전환</p>
-              <p className="mt-1 text-indigo-200/90">{formatPercent(feedToOpenRate || 0)}</p>
-              <p className="mt-1 text-[11px] text-slate-500">피드 노출 {formatNumber(feedImpressions.count || 0)}건 기준</p>
-            </div>
-            <div className="rounded-lg bg-slate-950/40 p-3">
-              <p className="font-semibold text-white">반복 클릭 강도</p>
-              <p className="mt-1 text-emerald-200/90">{repeatIntensity.toFixed(2)}</p>
-              <p className="mt-1 text-[11px] text-slate-500">세션별 평균 누적 클릭</p>
-            </div>
-            <div className="rounded-lg bg-slate-950/40 p-3">
-              <p className="font-semibold text-white">장애 우회 비중</p>
-              <p className="mt-1 text-rose-200/90">{formatPercent(fallbackShare || 0)}</p>
-              <p className="mt-1 text-[11px] text-slate-500">스마트 링크 대비 대체 CTA</p>
-            </div>
-          </div>
-        </div>
-
-        <div className="rounded-2xl border border-fuchsia-500/40 bg-slate-900/80 p-5 shadow-lg shadow-fuchsia-900/40 xl:col-span-2">
-          <h3 className="text-base font-semibold text-white">수익 기여 이벤트 분포</h3>
-          <p className="mt-1 text-xs text-slate-400">스마트 링크 오픈과 반복 클릭, 장애 우회 클릭이 만들어낸 전환 기여도를 원형 차트로 보여줍니다.</p>
-          <RevenueDonut
-            segments={revenueSegments.segments}
-            centerLabel={formatNumber(Math.round(revenueSegments.total) || 0)}
-          />
-          {revenueSegments.segments.length > 0 && (
-            <div className="mt-5 space-y-3 text-xs text-slate-300">
-              {revenueSegments.segments.map((segment) => (
-                <div key={segment.key} className="flex items-center justify-between rounded-lg bg-slate-950/40 px-3 py-2">
-                  <div className="flex items-center gap-2">
-                    <span className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: segment.color }} />
-                    <span className="text-slate-200">{segment.label}</span>
-                  </div>
-                  <div className="text-right">
-                    <p className="font-semibold text-white">{formatNumber(Math.round(segment.value) || 0)}</p>
-                    <p className="text-[11px] text-slate-400">{formatPercent(segment.ratio || 0)}</p>
-                  </div>
+      <div className="mt-4 space-y-3">
+        {rows.length === 0 ? (
+          <p className="text-xs text-slate-500">표시할 방문 경로가 아직 없어요.</p>
+        ) : (
+          rows.map((row) => {
+            const avg = row.uniqueSessions > 0 ? row.count / row.uniqueSessions : 0;
+            return (
+              <div
+                key={row.slug}
+                className="grid gap-2 rounded-xl border border-slate-800/40 bg-slate-950/60 p-3 text-xs text-slate-300 sm:grid-cols-4"
+              >
+                <div className="sm:col-span-2">
+                  <p className="font-semibold text-white">{row.slug}</p>
+                  <p className="mt-1 text-[11px] text-slate-400">최근 방문: {formatKstDateTime(row.lastTimestamp)}</p>
                 </div>
-              ))}
-            </div>
-          )}
-        </div>
-      </div>
-
-      <div className="rounded-2xl border border-emerald-500/40 bg-slate-900/80 p-5 shadow-lg shadow-emerald-900/40">
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-          <div>
-            <h3 className="text-base font-semibold text-white">사용자 활동 레이더</h3>
-            <p className="mt-1 text-xs text-slate-400">다중 열람·참여 세션·스크롤 깊이·체류 시간을 복합적으로 분석해 몰입도를 확인합니다.</p>
-            <div className="mt-4 rounded-lg bg-slate-950/40 px-4 py-3 text-xs text-emerald-200/90">
-              평균 활동 지수 {formatPercent ? formatPercent(engagementScore) : `${Math.round(engagementScore * 100)}%`}
-            </div>
-            <div className="mt-4 grid gap-3 text-xs text-slate-300 sm:grid-cols-2">
-              <div className="rounded-lg bg-slate-950/40 p-3">
-                <p className="font-semibold text-white">다중 열람 세션</p>
-                <p className="mt-1 text-indigo-200/90">{formatPercent(multiViewRate || 0)}</p>
-                <p className="mt-1 text-[11px] text-slate-500">총 방문 {formatNumber(visits.count || 0)}건 중 {formatNumber(multiView.count || 0)}건</p>
+                <div>
+                  <p className="text-[11px] uppercase tracking-[0.2em] text-slate-500">총 방문</p>
+                  <p className="text-base font-semibold text-white">{formatNumber(row.count)}</p>
+                </div>
+                <div>
+                  <p className="text-[11px] uppercase tracking-[0.2em] text-slate-500">평균/세션</p>
+                  <p className="text-base font-semibold text-white">{avg.toFixed(2)}</p>
+                </div>
               </div>
-              <div className="rounded-lg bg-slate-950/40 p-3">
-                <p className="font-semibold text-white">참여 세션 비중</p>
-                <p className="mt-1 text-indigo-200/90">{formatPercent(engagedRate || 0)}</p>
-                <p className="mt-1 text-[11px] text-slate-500">첫 상호작용을 기록한 세션</p>
-              </div>
-              <div className="rounded-lg bg-slate-950/40 p-3">
-                <p className="font-semibold text-white">평균 스크롤 깊이</p>
-                <p className="mt-1 text-indigo-200/90">{Math.round(averageScroll)}%</p>
-                <p className="mt-1 text-[11px] text-slate-500">콘텐츠 소비 깊이</p>
-              </div>
-              <div className="rounded-lg bg-slate-950/40 p-3">
-                <p className="font-semibold text-white">평균 체류 시간</p>
-                <p className="mt-1 text-indigo-200/90">{formatDuration(averageDuration)}</p>
-                <p className="mt-1 text-[11px] text-slate-500">세션 체류 시간 버킷 평균</p>
-              </div>
-            </div>
-          </div>
-          <div className="flex w-full justify-center lg:w-auto">
-            <ActivityRadar metrics={radarMetrics} />
-          </div>
-        </div>
+            );
+          })
+        )}
       </div>
     </div>
   );

--- a/components/admin/events/EventSummaryCards.jsx
+++ b/components/admin/events/EventSummaryCards.jsx
@@ -1,40 +1,35 @@
-export default function EventSummaryCards({ totals, formatNumber, formatPercent }) {
-  const totalCount = Number(totals?.count) || 0;
-  const visitors = Number(totals?.visitors ?? totals?.uniqueSessions) || 0;
-  const pageViews = Number(totals?.pageViews ?? totalCount) || 0;
-  const bounceRateRaw = Number(totals?.bounceRate) || 0;
-  const bounceRate = bounceRateRaw > 0 ? Math.min(1, bounceRateRaw) : 0;
-  const pageViewEvents = Array.isArray(totals?.pageViewEventNames) ? totals.pageViewEventNames : [];
-  const visitorEvents = Array.isArray(totals?.visitorEventNames) ? totals.visitorEventNames : [];
-  const bounceEvents = Array.isArray(totals?.bounceEventNames) ? totals.bounceEventNames : [];
+const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
 
-  const formatEventList = (events, fallback) => {
-    if (!events.length) return fallback;
-    return events.slice(0, 3).join(', ');
-  };
+function formatKstDateTime(value) {
+  if (!value) return '-';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '-';
+  const kst = new Date(date.getTime() + KST_OFFSET_MS);
+  const iso = kst.toISOString();
+  return `${iso.slice(0, 10)} ${iso.slice(11, 19)}`;
+}
+
+export default function EventSummaryCards({ totals, formatNumber }) {
+  const visitCount = Number(totals?.visitCount ?? totals?.count) || 0;
+  const uniqueSessions = Number(totals?.uniqueSessions) || 0;
+  const lastVisit = formatKstDateTime(totals?.lastVisitAt || totals?.lastTimestamp);
 
   return (
     <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-      <div className="rounded-2xl border border-slate-800/70 bg-slate-900/80 p-4 shadow-inner shadow-black/40">
-        <p className="text-xs uppercase tracking-[0.3em] text-slate-400">방문자</p>
-        <p className="mt-2 text-3xl font-bold text-white">{formatNumber(visitors)}</p>
-        <p className="mt-1 text-xs text-slate-500">
-          {formatEventList(visitorEvents, '전체 이벤트')} 고유 세션 수 기반
-        </p>
+      <div className="rounded-2xl border border-violet-500/30 bg-violet-500/10 p-4 shadow-inner shadow-black/30">
+        <p className="text-xs uppercase tracking-[0.3em] text-violet-200">총 방문수</p>
+        <p className="mt-2 text-3xl font-bold text-white">{formatNumber(visitCount)}</p>
+        <p className="mt-1 text-xs text-violet-100/70">l_visit 이벤트 누적 합계</p>
       </div>
-      <div className="rounded-2xl border border-slate-800/70 bg-slate-900/80 p-4 shadow-inner shadow-black/40">
-        <p className="text-xs uppercase tracking-[0.3em] text-slate-400">페이지 뷰</p>
-        <p className="mt-2 text-3xl font-bold text-white">{formatNumber(pageViews)}</p>
-        <p className="mt-1 text-xs text-slate-500">
-          {formatEventList(pageViewEvents, '전체 이벤트')} 이벤트 누적 합계
-        </p>
+      <div className="rounded-2xl border border-emerald-500/30 bg-emerald-500/10 p-4 shadow-inner shadow-black/30">
+        <p className="text-xs uppercase tracking-[0.3em] text-emerald-200">순 방문자수</p>
+        <p className="mt-2 text-3xl font-bold text-white">{formatNumber(uniqueSessions)}</p>
+        <p className="mt-1 text-xs text-emerald-100/70">세션 ID 기준 고유 방문</p>
       </div>
-      <div className="rounded-2xl border border-emerald-500/40 bg-gradient-to-br from-emerald-500/10 via-teal-500/5 to-transparent p-4 shadow-lg shadow-emerald-500/20">
-        <p className="text-xs uppercase tracking-[0.3em] text-emerald-200">이탈률</p>
-        <p className="mt-2 text-3xl font-bold text-emerald-100">{formatPercent(bounceRate)}</p>
-        <p className="mt-1 text-xs text-emerald-200/80">
-          {formatEventList(bounceEvents, '이탈 이벤트')} ÷ {formatEventList(visitorEvents, '방문 이벤트')}
-        </p>
+      <div className="rounded-2xl border border-slate-800/60 bg-slate-950/50 p-4 shadow-inner shadow-black/40">
+        <p className="text-xs uppercase tracking-[0.3em] text-slate-400">최근 방문 시간</p>
+        <p className="mt-2 text-xl font-semibold text-white">{lastVisit}</p>
+        <p className="mt-1 text-xs text-slate-400">KST 기준</p>
       </div>
     </div>
   );

--- a/components/admin/events/EventTrendChart.jsx
+++ b/components/admin/events/EventTrendChart.jsx
@@ -1,5 +1,12 @@
 import { ResponsiveContainer, AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+
+const INTERVALS = [
+  { key: 'tenMinute', label: '10분' },
+  { key: 'daily', label: '일별' },
+  { key: 'weekly', label: '주별' },
+  { key: 'monthly', label: '월별' },
+];
 
 function normalizeSeries(series) {
   if (!Array.isArray(series)) return [];
@@ -17,28 +24,83 @@ function EventTooltip({ active, payload, label, formatNumber }) {
   return (
     <div className="rounded-xl border border-slate-800/60 bg-slate-950/90 px-3 py-2 text-xs text-slate-200 shadow-lg shadow-black/30">
       <p className="font-semibold text-white">{label}</p>
-      <p className="mt-1">이벤트 {formatNumber(first?.value || 0)}회</p>
+      <p className="mt-1">방문 {formatNumber(first?.value || 0)}회</p>
     </div>
   );
 }
 
-export default function EventTrendChart({ series, formatNumber }) {
-  const data = useMemo(() => normalizeSeries(series), [series]);
-  if (!data.length) {
-    return null;
+export default function EventTrendChart({ seriesByGranularity, formatNumber }) {
+  const [activeInterval, setActiveInterval] = useState('daily');
+
+  useEffect(() => {
+    const current = seriesByGranularity?.[activeInterval];
+    if (Array.isArray(current) && current.length > 0) {
+      return;
+    }
+    const fallback = INTERVALS.find(
+      (interval) => Array.isArray(seriesByGranularity?.[interval.key]) && seriesByGranularity[interval.key].length > 0
+    );
+    if (fallback && fallback.key !== activeInterval) {
+      setActiveInterval(fallback.key);
+    }
+  }, [activeInterval, seriesByGranularity]);
+
+  const selectedSeries = useMemo(() => {
+    const raw = seriesByGranularity?.[activeInterval];
+    const normalized = normalizeSeries(raw);
+    if (normalized.length) {
+      return normalized;
+    }
+    const fallback = INTERVALS.find((interval) => Array.isArray(seriesByGranularity?.[interval.key]) && seriesByGranularity[interval.key].length);
+    return normalizeSeries(fallback ? seriesByGranularity[fallback.key] : []);
+  }, [activeInterval, seriesByGranularity]);
+
+  const availableIntervals = useMemo(
+    () =>
+      INTERVALS.map((interval) => ({
+        ...interval,
+        disabled: !Array.isArray(seriesByGranularity?.[interval.key]) || seriesByGranularity[interval.key].length === 0,
+      })),
+    [seriesByGranularity]
+  );
+
+  if (!selectedSeries.length) {
+    return (
+      <div className="rounded-2xl border border-slate-800/70 bg-slate-900/60 p-4 text-center text-xs text-slate-500">
+        아직 집계된 방문 데이터가 없어요.
+      </div>
+    );
   }
 
-  const maxValue = Math.max(...data.map((entry) => entry.count), 0);
+  const maxValue = Math.max(...selectedSeries.map((entry) => entry.count), 0);
 
   return (
     <div className="rounded-2xl border border-slate-800/70 bg-slate-900/80 p-4 shadow-inner shadow-black/40">
-      <div className="mb-4 flex items-center justify-between text-xs uppercase tracking-[0.3em] text-slate-400">
-        <span>기간별 이벤트 추이</span>
-        <span className="text-[11px] text-slate-300">최대 {formatNumber(maxValue)}건</span>
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3 text-xs uppercase tracking-[0.3em] text-slate-400">
+        <span>방문 추이</span>
+        <div className="flex gap-2">
+          {availableIntervals.map((interval) => (
+            <button
+              key={interval.key}
+              type="button"
+              onClick={() => setActiveInterval(interval.key)}
+              disabled={interval.disabled}
+              className={`rounded-full px-3 py-1 text-[11px] tracking-wide transition ${
+                activeInterval === interval.key
+                  ? 'bg-violet-500/30 text-violet-100'
+                  : interval.disabled
+                  ? 'bg-slate-800/40 text-slate-500 cursor-not-allowed'
+                  : 'bg-slate-800/60 text-slate-300 hover:bg-slate-700/60'
+              }`}
+            >
+              {interval.label}
+            </button>
+          ))}
+        </div>
       </div>
       <div className="h-64 w-full">
         <ResponsiveContainer>
-          <AreaChart data={data} margin={{ top: 10, right: 20, bottom: 0, left: 0 }}>
+          <AreaChart data={selectedSeries} margin={{ top: 10, right: 20, bottom: 0, left: 0 }}>
             <defs>
               <linearGradient id="eventTrendFill" x1="0" y1="0" x2="0" y2="1">
                 <stop offset="0%" stopColor="rgba(129, 140, 248, 0.6)" />
@@ -49,10 +111,11 @@ export default function EventTrendChart({ series, formatNumber }) {
             <XAxis dataKey="date" stroke="rgba(148, 163, 184, 0.5)" tick={{ fontSize: 11 }} interval="preserveStartEnd" />
             <YAxis stroke="rgba(148, 163, 184, 0.5)" tickFormatter={(value) => formatNumber(value)} tick={{ fontSize: 11 }} />
             <Tooltip content={<EventTooltip formatNumber={formatNumber} />} />
-            <Area type="monotone" dataKey="count" stroke="#818cf8" fill="url(#eventTrendFill)" strokeWidth={2.5} name="이벤트" />
+            <Area type="monotone" dataKey="count" stroke="#818cf8" fill="url(#eventTrendFill)" strokeWidth={2.5} name="방문" />
           </AreaChart>
         </ResponsiveContainer>
       </div>
+      <div className="mt-2 text-right text-[11px] text-slate-400">최대 {formatNumber(maxValue)}건</div>
     </div>
   );
 }

--- a/hooks/admin/useEventAnalytics.js
+++ b/hooks/admin/useEventAnalytics.js
@@ -3,17 +3,12 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 const EMPTY_SUMMARY = Object.freeze({
   items: [],
   totals: {
-    count: 0,
+    visitCount: 0,
     uniqueSessions: 0,
-    visitors: 0,
-    pageViews: 0,
-    bounceEvents: 0,
-    bounceRate: 0,
-    pageViewEventNames: [],
-    visitorEventNames: [],
-    bounceEventNames: [],
+    lastVisitAt: null,
   },
   timeseries: [],
+  timeseriesByGranularity: {},
   catalog: { events: [], slugsByEvent: {} },
 });
 
@@ -68,8 +63,9 @@ export default function useEventAnalytics({
         }
         setData({
           items: Array.isArray(json.items) ? json.items : [],
-          totals: json.totals || { count: 0, uniqueSessions: 0 },
+          totals: json.totals || { visitCount: 0, uniqueSessions: 0 },
           timeseries: Array.isArray(json.timeseries) ? json.timeseries : [],
+          timeseriesByGranularity: json.timeseriesByGranularity || {},
           catalog: json.catalog || { events: [], slugsByEvent: {} },
         });
       } catch (err) {

--- a/hooks/admin/useVisitEvents.js
+++ b/hooks/admin/useVisitEvents.js
@@ -23,7 +23,7 @@ export default function useVisitEvents({ enabled, slug, token, limit = 50 }) {
     if (token) params.set('token', token);
     if (slug) params.set('slug', slug);
 
-    fetch(`/api/admin/x-visit?${params.toString()}`)
+    fetch(`/api/admin/l-visit?${params.toString()}`)
       .then(async (response) => {
         const payload = await response.json().catch(() => ({}));
         if (!response.ok) {

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -33,7 +33,7 @@ const NAV_ITEMS = [
   { key: 'events', label: '분석', ariaLabel: '커스텀 이벤트 분석', requiresToken: true },
   { key: 'ads', label: '수익', ariaLabel: '수익 분석', requiresToken: true },
   { key: 'insights', label: '인사이트', ariaLabel: '통합 인사이트', requiresToken: true },
-  { key: 'visits', label: '방문 로그', ariaLabel: 'x_visit 원시 로그', requiresToken: true },
+  { key: 'visits', label: '방문 로그', ariaLabel: 'l_visit 원시 로그', requiresToken: true },
 ];
 const DEFAULT_VISIT_LIMIT = 50;
 
@@ -569,8 +569,8 @@ export default function AdminPage() {
               </button>
             </div>
             <RealtimeNotice
-              title="Redis 실시간 이벤트"
-              description="최근 3~5분 사이에 수집된 이벤트만 Redis에서 실시간으로 집계해요. 더 오래된 데이터는 별도 저장소 연결 전까지는 제공되지 않습니다."
+              title="Redis 큐 기반 집계"
+              description="l_visit 이벤트는 먼저 Redis 큐에 적재된 뒤 주기적으로 Postgres에 반영돼요. 실시간 수치는 약간의 지연이 있을 수 있습니다."
             />
             <EventFilters
               startDate={analyticsStartDate}
@@ -582,19 +582,12 @@ export default function AdminPage() {
               loading={eventAnalytics.loading}
               onRefresh={eventAnalytics.refresh}
             />
-            <EventSummaryCards
-              totals={eventAnalytics.data.totals}
+            <EventSummaryCards totals={eventAnalytics.data.totals} formatNumber={formatNumber} />
+            <EventKeyMetrics items={eventAnalytics.data.items} formatNumber={formatNumber} />
+            <EventTrendChart
+              seriesByGranularity={eventAnalytics.data.timeseriesByGranularity}
               formatNumber={formatNumber}
-              formatPercent={formatPercent}
             />
-            <EventKeyMetrics
-              items={eventAnalytics.data.items}
-              formatNumber={formatNumber}
-              formatPercent={formatPercent}
-            />
-            {eventAnalytics.data.timeseries.length > 0 && (
-              <EventTrendChart series={eventAnalytics.data.timeseries} formatNumber={formatNumber} />
-            )}
             <EventTable
               rows={eventAnalytics.data.items}
               loading={eventAnalytics.loading}
@@ -688,7 +681,7 @@ export default function AdminPage() {
           <div className="space-y-6">
             <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
               <div>
-                <h2 className="text-2xl font-bold text-white">방문 로그 (x_visit)</h2>
+                <h2 className="text-2xl font-bold text-white">방문 로그 (l_visit)</h2>
                 <p className="text-sm text-slate-400">콘텐츠별 방문 이벤트를 원시 데이터로 확인할 수 있어요.</p>
               </div>
               <button

--- a/pages/api/admin/events/flush.js
+++ b/pages/api/admin/events/flush.js
@@ -1,0 +1,31 @@
+import { assertAdmin } from '../_auth';
+import { applyRateLimit, setRateLimitHeaders } from '../../../../utils/apiRateLimit';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  if (!assertAdmin(req, res)) {
+    return;
+  }
+
+  const rate = applyRateLimit(req, 'admin:events:flush', { limit: 30, windowMs: 60_000 });
+  setRateLimitHeaders(res, rate);
+  if (!rate.ok) {
+    return res.status(429).json({ error: '요청이 너무 잦아요. 잠시 후 다시 시도해 주세요.' });
+  }
+
+  try {
+    const bodyBatch = req.body && Object.prototype.hasOwnProperty.call(req.body, 'batchSize') ? req.body.batchSize : undefined;
+    const batchSizeRaw = bodyBatch ?? req.query?.batchSize;
+    const batchSize = Number.isFinite(Number(batchSizeRaw)) ? Number(batchSizeRaw) : undefined;
+    const { flushVisitEvents } = await import('../../../../utils/eventsStore');
+    const result = await flushVisitEvents({ batchSize });
+    return res.status(200).json({ ok: true, ...result });
+  } catch (error) {
+    console.error('[admin][events] flush failed', error);
+    return res.status(500).json({ error: '이벤트 큐를 비우지 못했어요.' });
+  }
+}

--- a/pages/api/admin/events/summary.js
+++ b/pages/api/admin/events/summary.js
@@ -37,8 +37,11 @@ export default async function handler(req, res) {
 
     return res.status(200).json({
       items: Array.isArray(summary.items) ? summary.items : [],
-      totals: summary.totals || { count: 0, uniqueSessions: 0 },
-      timeseries: Array.isArray(summary.timeseries) ? summary.timeseries : [],
+      totals: summary.totals || { visitCount: 0, uniqueSessions: 0 },
+      timeseries: Array.isArray(summary.timeseriesByGranularity?.daily)
+        ? summary.timeseriesByGranularity.daily
+        : [],
+      timeseriesByGranularity: summary.timeseriesByGranularity || {},
       catalog: summary.catalog || { events: [], slugsByEvent: {} },
     });
   } catch (error) {

--- a/pages/api/admin/l-visit.js
+++ b/pages/api/admin/l-visit.js
@@ -21,7 +21,7 @@ export default async function handler(req, res) {
     return;
   }
 
-  const rate = applyRateLimit(req, 'admin:x_visit:raw', { limit: 45, windowMs: 60_000 });
+  const rate = applyRateLimit(req, 'admin:l_visit:raw', { limit: 45, windowMs: 60_000 });
   setRateLimitHeaders(res, rate);
   if (!rate.ok) {
     return res.status(429).json({ error: '요청이 너무 잦아요. 잠시 후 다시 시도해 주세요.' });
@@ -32,7 +32,7 @@ export default async function handler(req, res) {
     const limitValue = clampLimit(req.query.limit);
     const params = new URLSearchParams();
     params.set('select', 'id,ts,slug,session_id,payload');
-    params.set('event_name', 'eq.x_visit');
+    params.set('event_name', 'eq.l_visit');
     params.set('order', 'ts.desc');
     params.set('limit', String(limitValue));
     if (slugRaw) {
@@ -58,7 +58,7 @@ export default async function handler(req, res) {
       items,
     });
   } catch (error) {
-    console.error('[admin][x_visit] failed to fetch raw events', error);
+    console.error('[admin][l_visit] failed to fetch raw events', error);
     return res.status(500).json({ error: '방문 로그를 불러오지 못했어요.' });
   }
 }

--- a/pages/x/[slug].js
+++ b/pages/x/[slug].js
@@ -59,7 +59,7 @@ export default function ImageDetail(props) {
     const origin = window.location.origin || undefined;
     const eventUrl = event?.url ? new URL(event.url, origin) : null;
     const path = eventUrl?.pathname || window.location.pathname || '';
-    const storageKey = path ? `x_visit_sent:${path}` : '';
+    const storageKey = path ? `l_visit_sent:${path}` : '';
     const already = storageKey && window.sessionStorage?.getItem(storageKey) === '1';
     if (already) return null;
 
@@ -88,7 +88,7 @@ export default function ImageDetail(props) {
   }, [slug, title]);
 
   usePageviewTracker({
-    eventName: 'x_visit',
+    eventName: 'l_visit',
     match: visitMatch,
     getPayload: visitPayloadBuilder,
     enabled: Boolean(slug || title),
@@ -98,7 +98,7 @@ export default function ImageDetail(props) {
     if (typeof window === 'undefined') return undefined;
     const payload = visitPayloadBuilder({ url: window.location.href });
     if (payload) {
-      vaTrack('x_visit', payload);
+      vaTrack('l_visit', payload);
     }
     return undefined;
   }, [visitPayloadBuilder]);


### PR DESCRIPTION
## 요약
- l_visit 이벤트만을 허용하는 Redis 큐 기반 원시 로그 적재 및 10분 단위 지표 업서트를 구현해 배치 처리 파이프라인을 구성했습니다.
- 관리 콘솔 분석 뷰를 l_visit 전용 지표 카드, 상위 경로, 다중 시간 해상도 트렌드 차트로 개편하고 방문 로그 API를 l-visit 엔드포인트로 교체했습니다.
- 관리용 API에 이벤트 큐 플러시 엔드포인트를 추가하고 요약 응답에 다중 해상도 시계열을 포함하도록 정리했습니다.

## 테스트
- npm run lint (기존 코드의 PropTypes 규칙 미준수로 실패)


------
https://chatgpt.com/codex/tasks/task_e_68da0c2809488323ae90181b042f2fb0