### PR TITLE
feat: l_visit 이벤트 배치 수집 및 분석 고도화

### DIFF
--- a/components/admin/events/EventFilters.jsx
+++ b/components/admin/events/EventFilters.jsx
@@ -7,16 +7,19 @@ export default function EventFilters({
   catalog,
   loading,
   onRefresh,
+  granularity = 'day',
+  onGranularityChange,
 }) {
   const events = Array.isArray(catalog?.events) ? catalog.events : [];
   const slugsByEvent = catalog?.slugsByEvent && typeof catalog.slugsByEvent === 'object' ? catalog.slugsByEvent : {};
   const eventValue = filters?.eventName || '';
   const slugOptions = Array.isArray(slugsByEvent[eventValue]) ? slugsByEvent[eventValue] : [];
   const slugValue = filters?.slug || '';
+  const granularityValue = typeof granularity === 'string' && granularity ? granularity : 'day';
 
   return (
     <div className="flex flex-col gap-4 rounded-2xl bg-slate-900/70 p-4 ring-1 ring-slate-800/60">
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
         <label className="flex flex-col gap-1 text-xs text-slate-300">
           <span className="font-semibold uppercase tracking-[0.3em] text-slate-400">시작일</span>
           <input
@@ -64,6 +67,20 @@ export default function EventFilters({
                 {slug}
               </option>
             ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1 text-xs text-slate-300">
+          <span className="font-semibold uppercase tracking-[0.3em] text-slate-400">시간 단위</span>
+          <select
+            value={granularityValue}
+            onChange={(event) => onGranularityChange?.(event.target.value)}
+            className="rounded-lg border border-slate-700/60 bg-slate-950/70 px-3 py-2 text-sm text-white focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400/60"
+            disabled={loading}
+          >
+            <option value="10m">10분</option>
+            <option value="day">일별</option>
+            <option value="week">주별</option>
+            <option value="month">월별</option>
           </select>
         </label>
       </div>

--- a/components/admin/events/EventKeyMetrics.jsx
+++ b/components/admin/events/EventKeyMetrics.jsx
@@ -259,7 +259,7 @@ export default function EventKeyMetrics({ items, formatNumber, formatPercent }) 
   const scrollDepth = getStat('x_scroll_depth');
   const sessionDuration = getStat('x_session_duration_bucket');
   const multiView = getStat('x_multi_view_session');
-  const visits = getStat('x_visit');
+  const visits = getStat('l_visit');
   const ctaFallback = getStat('x_cta_click_unable_to_play');
   const feedImpressions = getStat('x_feed_impression');
   const anyClick = getStat('x_any_click');

--- a/components/admin/events/EventSummaryCards.jsx
+++ b/components/admin/events/EventSummaryCards.jsx
@@ -1,40 +1,50 @@
-export default function EventSummaryCards({ totals, formatNumber, formatPercent }) {
-  const totalCount = Number(totals?.count) || 0;
-  const visitors = Number(totals?.visitors ?? totals?.uniqueSessions) || 0;
-  const pageViews = Number(totals?.pageViews ?? totalCount) || 0;
-  const bounceRateRaw = Number(totals?.bounceRate) || 0;
-  const bounceRate = bounceRateRaw > 0 ? Math.min(1, bounceRateRaw) : 0;
-  const pageViewEvents = Array.isArray(totals?.pageViewEventNames) ? totals.pageViewEventNames : [];
-  const visitorEvents = Array.isArray(totals?.visitorEventNames) ? totals.visitorEventNames : [];
-  const bounceEvents = Array.isArray(totals?.bounceEventNames) ? totals.bounceEventNames : [];
+const LAST_VISIT_FORMATTER = new Intl.DateTimeFormat('ko-KR', {
+  timeZone: 'Asia/Seoul',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+});
 
-  const formatEventList = (events, fallback) => {
-    if (!events.length) return fallback;
-    return events.slice(0, 3).join(', ');
-  };
+function formatLastVisit(timestamp) {
+  if (!Number.isFinite(timestamp) || timestamp <= 0) return '기록 없음';
+  try {
+    return LAST_VISIT_FORMATTER.format(new Date(timestamp));
+  } catch {
+    return '기록 없음';
+  }
+}
+
+export default function EventSummaryCards({ totals, formatNumber }) {
+  const totalCount = Number(totals?.count) || 0;
+  const uniqueSessions = Number(totals?.uniqueSessions ?? totals?.visitors) || 0;
+  const lastTimestamp = Number(totals?.lastTimestamp) || 0;
+  const granularity = typeof totals?.granularity === 'string' ? totals.granularity : 'day';
+
+  const granularityLabel =
+    {
+      '10m': '10분 간격으로 집계된 방문 수',
+      day: '일별로 집계된 방문 수',
+      week: '주별로 집계된 방문 수',
+      month: '월별로 집계된 방문 수',
+    }[granularity] || '집계된 방문 수';
 
   return (
     <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
       <div className="rounded-2xl border border-slate-800/70 bg-slate-900/80 p-4 shadow-inner shadow-black/40">
-        <p className="text-xs uppercase tracking-[0.3em] text-slate-400">방문자</p>
-        <p className="mt-2 text-3xl font-bold text-white">{formatNumber(visitors)}</p>
-        <p className="mt-1 text-xs text-slate-500">
-          {formatEventList(visitorEvents, '전체 이벤트')} 고유 세션 수 기반
-        </p>
+        <p className="text-xs uppercase tracking-[0.3em] text-slate-400">총 방문수</p>
+        <p className="mt-2 text-3xl font-bold text-white">{formatNumber(totalCount)}</p>
+        <p className="mt-1 text-xs text-slate-500">{granularityLabel}</p>
       </div>
       <div className="rounded-2xl border border-slate-800/70 bg-slate-900/80 p-4 shadow-inner shadow-black/40">
-        <p className="text-xs uppercase tracking-[0.3em] text-slate-400">페이지 뷰</p>
-        <p className="mt-2 text-3xl font-bold text-white">{formatNumber(pageViews)}</p>
-        <p className="mt-1 text-xs text-slate-500">
-          {formatEventList(pageViewEvents, '전체 이벤트')} 이벤트 누적 합계
-        </p>
+        <p className="text-xs uppercase tracking-[0.3em] text-slate-400">순 방문자수</p>
+        <p className="mt-2 text-3xl font-bold text-white">{formatNumber(uniqueSessions)}</p>
+        <p className="mt-1 text-xs text-slate-500">고유 세션 기준</p>
       </div>
-      <div className="rounded-2xl border border-emerald-500/40 bg-gradient-to-br from-emerald-500/10 via-teal-500/5 to-transparent p-4 shadow-lg shadow-emerald-500/20">
-        <p className="text-xs uppercase tracking-[0.3em] text-emerald-200">이탈률</p>
-        <p className="mt-2 text-3xl font-bold text-emerald-100">{formatPercent(bounceRate)}</p>
-        <p className="mt-1 text-xs text-emerald-200/80">
-          {formatEventList(bounceEvents, '이탈 이벤트')} ÷ {formatEventList(visitorEvents, '방문 이벤트')}
-        </p>
+      <div className="rounded-2xl border border-indigo-500/40 bg-gradient-to-br from-indigo-500/10 via-sky-500/5 to-transparent p-4 shadow-lg shadow-indigo-500/20">
+        <p className="text-xs uppercase tracking-[0.3em] text-indigo-200">최근 방문 시간</p>
+        <p className="mt-2 text-lg font-semibold text-indigo-100">{formatLastVisit(lastTimestamp)}</p>
+        <p className="mt-1 text-xs text-indigo-200/70">한국 시간 기준</p>
       </div>
     </div>
   );

--- a/components/admin/events/EventTrendChart.jsx
+++ b/components/admin/events/EventTrendChart.jsx
@@ -22,18 +22,27 @@ function EventTooltip({ active, payload, label, formatNumber }) {
   );
 }
 
-export default function EventTrendChart({ series, formatNumber }) {
+const GRANULARITY_LABELS = {
+  '10m': '10분 단위 이벤트 추이',
+  day: '일별 이벤트 추이',
+  week: '주별 이벤트 추이',
+  month: '월별 이벤트 추이',
+};
+
+export default function EventTrendChart({ series, formatNumber, granularity = 'day' }) {
   const data = useMemo(() => normalizeSeries(series), [series]);
   if (!data.length) {
     return null;
   }
 
   const maxValue = Math.max(...data.map((entry) => entry.count), 0);
+  const normalizedGranularity = typeof granularity === 'string' ? granularity : 'day';
+  const title = GRANULARITY_LABELS[normalizedGranularity] || '기간별 이벤트 추이';
 
   return (
     <div className="rounded-2xl border border-slate-800/70 bg-slate-900/80 p-4 shadow-inner shadow-black/40">
       <div className="mb-4 flex items-center justify-between text-xs uppercase tracking-[0.3em] text-slate-400">
-        <span>기간별 이벤트 추이</span>
+        <span>{title}</span>
         <span className="text-[11px] text-slate-300">최대 {formatNumber(maxValue)}건</span>
       </div>
       <div className="h-64 w-full">

--- a/hooks/admin/useVisitEvents.js
+++ b/hooks/admin/useVisitEvents.js
@@ -23,7 +23,7 @@ export default function useVisitEvents({ enabled, slug, token, limit = 50 }) {
     if (token) params.set('token', token);
     if (slug) params.set('slug', slug);
 
-    fetch(`/api/admin/x-visit?${params.toString()}`)
+    fetch(`/api/admin/l-visit?${params.toString()}`)
       .then(async (response) => {
         const payload = await response.json().catch(() => ({}));
         if (!response.ok) {

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -33,7 +33,7 @@ const NAV_ITEMS = [
   { key: 'events', label: '분석', ariaLabel: '커스텀 이벤트 분석', requiresToken: true },
   { key: 'ads', label: '수익', ariaLabel: '수익 분석', requiresToken: true },
   { key: 'insights', label: '인사이트', ariaLabel: '통합 인사이트', requiresToken: true },
-  { key: 'visits', label: '방문 로그', ariaLabel: 'x_visit 원시 로그', requiresToken: true },
+  { key: 'visits', label: '방문 로그', ariaLabel: 'l_visit 원시 로그', requiresToken: true },
 ];
 const DEFAULT_VISIT_LIMIT = 50;
 
@@ -167,6 +167,7 @@ export default function AdminPage() {
   const [analyticsStartDate, setAnalyticsStartDate] = useState('');
   const [analyticsEndDate, setAnalyticsEndDate] = useState('');
   const [eventFilters, setEventFilters] = useState({ eventName: '', slug: '' });
+  const [analyticsGranularity, setAnalyticsGranularity] = useState('day');
 
   const eventAnalytics = useEventAnalytics({
     enabled: hasToken && view === 'events',
@@ -174,6 +175,7 @@ export default function AdminPage() {
     startDate: analyticsStartDate,
     endDate: analyticsEndDate,
     filters: { ...eventFilters, limit: 200 },
+    granularity: analyticsGranularity,
   });
 
   const visitEvents = useVisitEvents({
@@ -581,11 +583,12 @@ export default function AdminPage() {
               catalog={eventAnalytics.data.catalog}
               loading={eventAnalytics.loading}
               onRefresh={eventAnalytics.refresh}
+              granularity={analyticsGranularity}
+              onGranularityChange={setAnalyticsGranularity}
             />
             <EventSummaryCards
               totals={eventAnalytics.data.totals}
               formatNumber={formatNumber}
-              formatPercent={formatPercent}
             />
             <EventKeyMetrics
               items={eventAnalytics.data.items}
@@ -593,7 +596,11 @@ export default function AdminPage() {
               formatPercent={formatPercent}
             />
             {eventAnalytics.data.timeseries.length > 0 && (
-              <EventTrendChart series={eventAnalytics.data.timeseries} formatNumber={formatNumber} />
+              <EventTrendChart
+                series={eventAnalytics.data.timeseries}
+                formatNumber={formatNumber}
+                granularity={eventAnalytics.data.totals?.granularity || analyticsGranularity}
+              />
             )}
             <EventTable
               rows={eventAnalytics.data.items}
@@ -688,7 +695,7 @@ export default function AdminPage() {
           <div className="space-y-6">
             <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
               <div>
-                <h2 className="text-2xl font-bold text-white">방문 로그 (x_visit)</h2>
+                <h2 className="text-2xl font-bold text-white">방문 로그 (l_visit)</h2>
                 <p className="text-sm text-slate-400">콘텐츠별 방문 이벤트를 원시 데이터로 확인할 수 있어요.</p>
               </div>
               <button

--- a/pages/api/admin/events/flush-queue.js
+++ b/pages/api/admin/events/flush-queue.js
@@ -1,0 +1,37 @@
+import { assertAdmin } from '../_auth';
+import { applyRateLimit, setRateLimitHeaders } from '../../../../utils/apiRateLimit';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  if (!assertAdmin(req, res)) {
+    return;
+  }
+
+  const rate = applyRateLimit(req, 'admin:events:flush', { limit: 30, windowMs: 60_000 });
+  setRateLimitHeaders(res, rate);
+  if (!rate.ok) {
+    return res.status(429).json({ error: '요청이 너무 잦아요. 잠시 후 다시 시도해 주세요.' });
+  }
+
+  try {
+    const limitRaw = typeof req.query.limit === 'string' ? req.query.limit : undefined;
+    const limitValue = (() => {
+      if (!limitRaw) return undefined;
+      const parsed = Number(limitRaw);
+      if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+      return Math.min(2000, Math.round(parsed));
+    })();
+
+    const { flushQueuedEvents } = await import('../../../../utils/eventsStore');
+    const result = await flushQueuedEvents({ limit: limitValue });
+
+    return res.status(200).json({ ok: true, result });
+  } catch (error) {
+    console.error('[admin][events] queue flush failed', error);
+    return res.status(500).json({ error: '이벤트 큐를 비우지 못했어요.' });
+  }
+}

--- a/pages/api/admin/l-visit.js
+++ b/pages/api/admin/l-visit.js
@@ -21,7 +21,7 @@ export default async function handler(req, res) {
     return;
   }
 
-  const rate = applyRateLimit(req, 'admin:x_visit:raw', { limit: 45, windowMs: 60_000 });
+  const rate = applyRateLimit(req, 'admin:l_visit:raw', { limit: 45, windowMs: 60_000 });
   setRateLimitHeaders(res, rate);
   if (!rate.ok) {
     return res.status(429).json({ error: '요청이 너무 잦아요. 잠시 후 다시 시도해 주세요.' });
@@ -32,7 +32,7 @@ export default async function handler(req, res) {
     const limitValue = clampLimit(req.query.limit);
     const params = new URLSearchParams();
     params.set('select', 'id,ts,slug,session_id,payload');
-    params.set('event_name', 'eq.x_visit');
+    params.set('event_name', 'eq.l_visit');
     params.set('order', 'ts.desc');
     params.set('limit', String(limitValue));
     if (slugRaw) {
@@ -58,7 +58,7 @@ export default async function handler(req, res) {
       items,
     });
   } catch (error) {
-    console.error('[admin][x_visit] failed to fetch raw events', error);
+    console.error('[admin][l_visit] failed to fetch raw events', error);
     return res.status(500).json({ error: '방문 로그를 불러오지 못했어요.' });
   }
 }

--- a/supabase/sql/refresh_event_metrics_10m.sql
+++ b/supabase/sql/refresh_event_metrics_10m.sql
@@ -1,0 +1,43 @@
+create or replace function refresh_event_metrics_10m(entries jsonb)
+returns void
+language plpgsql
+as $$
+declare
+  rec record;
+begin
+  if entries is null then
+    return;
+  end if;
+
+  for rec in
+    select
+      (value ->> 'ts_bucket_10m')::timestamptz as ts_bucket_10m,
+      nullif(value ->> 'event_name', '') as event_name,
+      coalesce(value ->> 'slug', '') as slug
+    from jsonb_array_elements(entries) as value
+  loop
+    if rec.ts_bucket_10m is null or rec.event_name is null then
+      continue;
+    end if;
+
+    insert into event_metrics_10m (ts_bucket_10m, event_name, slug, visit_count, unique_sessions, last_ts)
+    select
+      rec.ts_bucket_10m,
+      rec.event_name,
+      rec.slug,
+      count(*) as visit_count,
+      count(distinct session_id) as unique_sessions,
+      max(ts) as last_ts
+    from events_raw
+    where ts_bucket_10m = rec.ts_bucket_10m
+      and event_name = rec.event_name
+      and slug = rec.slug
+    group by rec.ts_bucket_10m, rec.event_name, rec.slug
+    on conflict (ts_bucket_10m, event_name, slug)
+    do update
+      set visit_count = excluded.visit_count,
+          unique_sessions = excluded.unique_sessions,
+          last_ts = greatest(event_metrics_10m.last_ts, excluded.last_ts);
+  end loop;
+end;
+$$;

--- a/utils/supabaseClient.js
+++ b/utils/supabaseClient.js
@@ -71,5 +71,11 @@ export async function supabaseRest(path, { method = 'GET', headers = {}, body } 
   }
 }
 
-export const SUPABASE_EVENTS_ROLLUP_FUNCTION = process.env?.SUPABASE_EVENTS_ROLLUP_FUNCTION?.trim() || 'ingest_events_daily';
-export const SUPABASE_EVENTS_ROLLUP_TABLE = process.env?.SUPABASE_EVENTS_ROLLUP_TABLE?.trim() || 'events_daily_rollups';
+export const SUPABASE_EVENTS_ROLLUP_FUNCTION =
+  process.env?.SUPABASE_EVENTS_ROLLUP_FUNCTION?.trim() || 'ingest_events_daily';
+export const SUPABASE_EVENTS_ROLLUP_TABLE =
+  process.env?.SUPABASE_EVENTS_ROLLUP_TABLE?.trim() || 'events_daily_rollups';
+export const SUPABASE_EVENT_METRICS_REFRESH_FUNCTION =
+  process.env?.SUPABASE_EVENT_METRICS_REFRESH_FUNCTION?.trim() || 'refresh_event_metrics_10m';
+export const SUPABASE_EVENT_METRICS_TABLE =
+  process.env?.SUPABASE_EVENT_METRICS_TABLE?.trim() || 'event_metrics_10m';

--- a/utils/visitAnalytics.js
+++ b/utils/visitAnalytics.js
@@ -1,0 +1,370 @@
+import {
+  hasSupabaseConfig,
+  supabaseRest,
+  SUPABASE_EVENT_METRICS_TABLE,
+} from './supabaseClient';
+
+const EVENT_NAME = 'l_visit';
+const DEFAULT_RANGE_DAYS = 6;
+const DAY_MS = 24 * 60 * 60 * 1000;
+const KST_TIMEZONE = 'Asia/Seoul';
+const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+const TEN_MINUTE_FORMATTER = new Intl.DateTimeFormat('ko-KR', {
+  timeZone: KST_TIMEZONE,
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+});
+
+const DATE_KEY_FORMATTER = new Intl.DateTimeFormat('en-CA', {
+  timeZone: KST_TIMEZONE,
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+});
+
+function pad(value) {
+  return String(value).padStart(2, '0');
+}
+
+function toDate(value) {
+  if (!value) return null;
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return new Date(value.getTime());
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const iso = trimmed.includes('T') ? trimmed : `${trimmed}T00:00:00+09:00`;
+    const parsed = new Date(iso);
+    if (!Number.isNaN(parsed.getTime())) return parsed;
+  }
+  return null;
+}
+
+function formatDateKey(date) {
+  try {
+    return DATE_KEY_FORMATTER.format(date);
+  } catch {
+    return '';
+  }
+}
+
+function startOfKstDay(value) {
+  const parsed = toDate(value);
+  if (!parsed) return null;
+  const key = formatDateKey(parsed);
+  if (!key) return null;
+  const [yearRaw, monthRaw, dayRaw] = key.split('-');
+  const year = Number(yearRaw);
+  const month = Number(monthRaw);
+  const day = Number(dayRaw);
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) {
+    return null;
+  }
+  const utcMillis = Date.UTC(year, month - 1, day);
+  return new Date(utcMillis - KST_OFFSET_MS);
+}
+
+function normalizeRange(startInput, endInput) {
+  const today = startOfKstDay(new Date());
+  const defaultEnd = today || new Date();
+  const defaultStart = new Date((today || new Date()).getTime() - DEFAULT_RANGE_DAYS * DAY_MS);
+
+  const startDate = startOfKstDay(startInput) || defaultStart;
+  const endDate = startOfKstDay(endInput) || defaultEnd;
+
+  if (startDate.getTime() > endDate.getTime()) {
+    return { start: endDate, end: endDate };
+  }
+
+  return { start: startDate, end: endDate };
+}
+
+function toIsoString(date) {
+  return date instanceof Date ? date.toISOString() : new Date(date).toISOString();
+}
+
+function toKstDate(iso) {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return null;
+  return new Date(date.getTime() + KST_OFFSET_MS);
+}
+
+function weekKeyFromBucket(bucketIso) {
+  const kst = toKstDate(bucketIso);
+  if (!kst) return null;
+  const weekday = kst.getUTCDay();
+  const diff = (weekday + 6) % 7; // Monday = 0
+  const startMs = kst.getTime() - diff * DAY_MS;
+  const start = new Date(startMs);
+  const year = start.getUTCFullYear();
+  const month = start.getUTCMonth() + 1;
+  const day = start.getUTCDate();
+  return {
+    label: `${year}-${pad(month)}-${pad(day)} 주`,
+    ts: start.getTime() - KST_OFFSET_MS,
+  };
+}
+
+function monthKeyFromBucket(bucketIso) {
+  const kst = toKstDate(bucketIso);
+  if (!kst) return null;
+  const year = kst.getUTCFullYear();
+  const month = kst.getUTCMonth() + 1;
+  return {
+    label: `${year}-${pad(month)}`,
+    ts: Date.UTC(year, month - 1, 1) - KST_OFFSET_MS,
+  };
+}
+
+function dayKeyFromBucket(bucketIso) {
+  const kst = toKstDate(bucketIso);
+  if (!kst) return null;
+  const year = kst.getUTCFullYear();
+  const month = kst.getUTCMonth() + 1;
+  const day = kst.getUTCDate();
+  return {
+    label: `${year}-${pad(month)}-${pad(day)}`,
+    ts: Date.UTC(year, month - 1, day) - KST_OFFSET_MS,
+  };
+}
+
+function tenMinuteLabel(bucketIso) {
+  const date = new Date(bucketIso);
+  if (Number.isNaN(date.getTime())) return null;
+  return {
+    label: TEN_MINUTE_FORMATTER.format(date),
+    ts: date.getTime(),
+  };
+}
+
+function resolveTimeseriesKey(bucketIso, granularity) {
+  if (granularity === '10m') return tenMinuteLabel(bucketIso);
+  if (granularity === 'week') return weekKeyFromBucket(bucketIso);
+  if (granularity === 'month') return monthKeyFromBucket(bucketIso);
+  return dayKeyFromBucket(bucketIso);
+}
+
+async function fetchMetricRows(range, slug) {
+  if (!hasSupabaseConfig()) return [];
+  const params = new URLSearchParams();
+  params.set('select', 'ts_bucket_10m,slug,visit_count,unique_sessions,last_ts');
+  params.set('event_name', `eq.${EVENT_NAME}`);
+  params.append('order', 'ts_bucket_10m.asc');
+
+  if (slug !== undefined && slug !== null) {
+    const normalized = typeof slug === 'string' ? slug.trim() : '';
+    if (normalized) {
+      params.set('slug', `eq.${normalized}`);
+    } else {
+      params.set('slug', 'eq.');
+    }
+  }
+
+  if (range?.start) {
+    params.append('ts_bucket_10m', `gte.${toIsoString(range.start)}`);
+  }
+  if (range?.end) {
+    const endOfDay = new Date(range.end.getTime() + DAY_MS - 1);
+    params.append('ts_bucket_10m', `lte.${toIsoString(endOfDay)}`);
+  }
+
+  try {
+    const rows = await supabaseRest(`${SUPABASE_EVENT_METRICS_TABLE}?${params.toString()}`);
+    if (!Array.isArray(rows)) return [];
+    return rows.map((row) => ({
+      bucket: row.ts_bucket_10m,
+      slug: typeof row.slug === 'string' ? row.slug : '',
+      visitCount: Number(row.visit_count) || 0,
+      uniqueSessions: Number(row.unique_sessions) || 0,
+      lastTimestamp: row.last_ts ? Date.parse(row.last_ts) || 0 : 0,
+    }));
+  } catch (error) {
+    console.warn('[visitAnalytics] failed to fetch metrics rows', error);
+    return [];
+  }
+}
+
+async function fetchRawSessions(range, slug) {
+  if (!hasSupabaseConfig()) {
+    return { sessionSet: new Set(), slugSessions: new Map(), lastTimestamp: 0 };
+  }
+
+  const params = new URLSearchParams();
+  params.set('select', 'session_id,slug,ts');
+  params.set('event_name', `eq.${EVENT_NAME}`);
+  params.set('session_id', 'not.is.null');
+  params.set('limit', '15000');
+
+  if (slug !== undefined && slug !== null) {
+    const normalized = typeof slug === 'string' ? slug.trim() : '';
+    if (normalized) {
+      params.set('slug', `eq.${normalized}`);
+    } else {
+      params.set('slug', 'eq.');
+    }
+  }
+
+  if (range?.start) {
+    params.append('ts', `gte.${toIsoString(range.start)}`);
+  }
+  if (range?.end) {
+    const endOfDay = new Date(range.end.getTime() + DAY_MS - 1);
+    params.append('ts', `lte.${toIsoString(endOfDay)}`);
+  }
+
+  try {
+    const rows = await supabaseRest(`events_raw?${params.toString()}`);
+    if (!Array.isArray(rows)) {
+      return { sessionSet: new Set(), slugSessions: new Map(), lastTimestamp: 0, slugLastMap: new Map() };
+    }
+
+    const sessionSet = new Set();
+    const slugSessions = new Map();
+    let lastTimestamp = 0;
+    const slugLastMap = new Map();
+
+    rows.forEach((row) => {
+      const sessionId = typeof row.session_id === 'string' ? row.session_id.trim() : '';
+      if (!sessionId) return;
+      sessionSet.add(sessionId);
+      const slugKey = typeof row.slug === 'string' ? row.slug : '';
+      if (!slugSessions.has(slugKey)) {
+        slugSessions.set(slugKey, new Set());
+      }
+      slugSessions.get(slugKey).add(sessionId);
+      const ts = row.ts ? Date.parse(row.ts) : NaN;
+      if (Number.isFinite(ts)) {
+        lastTimestamp = Math.max(lastTimestamp, ts);
+        const prev = slugLastMap.get(slugKey) || 0;
+        if (ts > prev) {
+          slugLastMap.set(slugKey, ts);
+        }
+      }
+    });
+
+    return { sessionSet, slugSessions, lastTimestamp, slugLastMap };
+  } catch (error) {
+    console.warn('[visitAnalytics] failed to fetch raw sessions', error);
+    return { sessionSet: new Set(), slugSessions: new Map(), lastTimestamp: 0, slugLastMap: new Map() };
+  }
+}
+
+function aggregateTimeseries(metrics, granularity) {
+  const normalized = typeof granularity === 'string' ? granularity.toLowerCase() : 'day';
+  const groups = new Map();
+
+  metrics.forEach((row) => {
+    if (!row || !row.bucket) return;
+    const key = resolveTimeseriesKey(row.bucket, normalized);
+    if (!key) return;
+    if (!groups.has(key.label)) {
+      groups.set(key.label, { count: 0, ts: key.ts });
+    }
+    const entry = groups.get(key.label);
+    entry.count += Number(row.visitCount) || 0;
+  });
+
+  return Array.from(groups.entries())
+    .map(([label, value]) => ({ label, ts: value.ts, count: value.count }))
+    .sort((a, b) => (a.ts || 0) - (b.ts || 0))
+    .map((entry) => ({ date: entry.label, count: entry.count }));
+}
+
+function aggregateItems(metrics, rawSessions) {
+  const { slugSessions, slugLastMap } = rawSessions;
+  const map = new Map();
+
+  metrics.forEach((row) => {
+    const slugKey = typeof row.slug === 'string' ? row.slug : '';
+    if (!map.has(slugKey)) {
+      map.set(slugKey, { count: 0, lastTimestamp: 0 });
+    }
+    const entry = map.get(slugKey);
+    entry.count += Number(row.visitCount) || 0;
+    entry.lastTimestamp = Math.max(entry.lastTimestamp, Number(row.lastTimestamp) || 0);
+  });
+
+  const items = Array.from(map.entries()).map(([slugKey, value]) => {
+    const sessionSet = slugSessions.get(slugKey);
+    const rawLast = slugLastMap.get(slugKey) || 0;
+    const lastTimestamp = Math.max(value.lastTimestamp || 0, rawLast || 0);
+    return {
+      eventName: EVENT_NAME,
+      slug: slugKey,
+      count: value.count,
+      uniqueSessions: sessionSet ? sessionSet.size : 0,
+      lastTimestamp: lastTimestamp || null,
+      lastDate: lastTimestamp ? new Date(lastTimestamp).toISOString() : null,
+    };
+  });
+
+  items.sort((a, b) => b.count - a.count);
+  return items;
+}
+
+function buildCatalog(metrics) {
+  const slugs = new Set();
+  metrics.forEach((row) => {
+    if (!row) return;
+    const slug = typeof row.slug === 'string' ? row.slug : '';
+    if (slug) {
+      slugs.add(slug);
+    }
+  });
+  return {
+    events: [EVENT_NAME],
+    slugsByEvent: { [EVENT_NAME]: Array.from(slugs).sort((a, b) => a.localeCompare(b)) },
+  };
+}
+
+export async function getVisitSummary({ startDate, endDate, slug = '', granularity = 'day', limit } = {}) {
+  const range = normalizeRange(startDate, endDate);
+  const metrics = await fetchMetricRows(range, slug);
+  const rawSessions = await fetchRawSessions(range, slug);
+
+  const timeseries = aggregateTimeseries(metrics, granularity);
+  const items = aggregateItems(metrics, rawSessions);
+  const maxItems = Number.isFinite(limit) && limit > 0 ? Math.max(1, Math.floor(limit)) : 0;
+  const limitedItems = maxItems > 0 ? items.slice(0, maxItems) : items;
+
+  const totalVisits = metrics.reduce((sum, row) => sum + (Number(row.visitCount) || 0), 0);
+  const totalUnique = rawSessions.sessionSet.size;
+  const lastTimestamp = Math.max(
+    rawSessions.lastTimestamp || 0,
+    ...metrics.map((row) => Number(row.lastTimestamp) || 0)
+  );
+
+  const catalog = buildCatalog(metrics);
+  if (!catalog.slugsByEvent[EVENT_NAME]?.length && items.length) {
+    catalog.slugsByEvent[EVENT_NAME] = Array.from(new Set(items.map((item) => item.slug).filter(Boolean))).sort((a, b) =>
+      a.localeCompare(b)
+    );
+  }
+
+  return {
+    items: limitedItems,
+    totals: {
+      count: totalVisits,
+      uniqueSessions: totalUnique,
+      visitors: totalUnique,
+      lastTimestamp: lastTimestamp || null,
+      lastDate: lastTimestamp ? new Date(lastTimestamp).toISOString() : null,
+      eventName: EVENT_NAME,
+      slug: typeof slug === 'string' ? slug : '',
+      granularity,
+    },
+    timeseries,
+    catalog,
+  };
+}
+
+export const VISIT_EVENT_NAME = EVENT_NAME;


### PR DESCRIPTION
## 요약
- Redis 큐를 통해 l_visit 원시 이벤트를 적재하고 Supabase RPC를 호출해 10분 단위 집계 테이블을 갱신하도록 ingest 파이프라인을 재구성했습니다.
- l_visit 전용 요약 로직을 추가해 Supabase event_metrics_10m과 events_raw 데이터를 조합하여 총 방문수, 순 방문자수, 최근 방문 시각 및 다양한 시간 단위별 추이를 계산합니다.
- 관리자 이벤트 화면에 시간 단위 선택 기능과 새로운 카드 지표를 도입하고, raw 로그 API 및 훅을 l_visit 기반으로 갱신했습니다.
- Supabase에 배포할 refresh_event_metrics_10m 함수 정의 SQL과 큐 비우기용 관리자 API 엔드포인트를 추가했습니다.

## 테스트
- `npm run lint` (React prop-types, React import 누락 등 기존 ESLint 규칙 미준수로 실패)


------
https://chatgpt.com/codex/tasks/task_e_68da0c2809488323ae90181b042f2fb0