### PR TITLE
트위터 비디오 카드 메타데이터 개선

### DIFF
--- a/components/x/meta/VideoSocialMeta.jsx
+++ b/components/x/meta/VideoSocialMeta.jsx
@@ -18,12 +18,14 @@ export default function VideoSocialMeta({ seo, title, description, player = {} }
     const safeTitle = typeof title === "string" ? title : "";
     const safeDescription = typeof description === "string" ? description : "";
 
-    const playerUrl = typeof player.playerUrl === "string" ? player.playerUrl : null;
-    const streamUrl = typeof player.streamUrl === "string" ? player.streamUrl : null;
-    const thumbnailUrl = typeof player.thumbnailUrl === "string" ? player.thumbnailUrl : null;
-    const streamContentType = typeof player.streamContentType === "string" ? player.streamContentType : null;
+    const playerUrl = typeof player.playerUrl === "string" ? player.playerUrl.trim() : null;
+    const streamUrl = typeof player.streamUrl === "string" ? player.streamUrl.trim() : null;
+    const thumbnailUrl = typeof player.thumbnailUrl === "string" ? player.thumbnailUrl.trim() : null;
+    const streamContentType =
+        typeof player.streamContentType === "string" ? player.streamContentType.trim() : null;
     const width = Number.isFinite(player.width) ? String(player.width) : null;
     const height = Number.isFinite(player.height) ? String(player.height) : null;
+    const canonicalUrl = canonicalGroup.canonicalUrl;
 
     if (
         !playerUrl &&
@@ -39,8 +41,11 @@ export default function VideoSocialMeta({ seo, title, description, player = {} }
     return (
         <Head>
             {renderCanonicalElements(canonicalGroup)}
+            {canonicalUrl ? <meta property="og:url" content={canonicalUrl} /> : null}
+            <meta property="og:type" content="video.other" />
             {thumbnailUrl ? <meta property="og:image" content={thumbnailUrl} /> : null}
             {streamUrl ? <meta property="og:video" content={streamUrl} /> : null}
+            {streamUrl ? <meta property="og:video:url" content={streamUrl} /> : null}
             {streamUrl ? <meta property="og:video:secure_url" content={streamUrl} /> : null}
             {streamContentType ? <meta property="og:video:type" content={streamContentType} /> : null}
             {width ? <meta property="og:video:width" content={width} /> : null}

--- a/pages/k/[slug].js
+++ b/pages/k/[slug].js
@@ -140,11 +140,38 @@ export async function getStaticProps({ params, locale }) {
 
   const normalizedMeme = { ...meme };
 
-  const siteUrl =
-    process.env.NEXT_PUBLIC_SITE_URL
-    || (process.env.VERCEL_PROJECT_PRODUCTION_URL ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}` : '')
-    || (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : '');
-  const origin = siteUrl || '';
+  const resolveOrigin = () => {
+    const candidates = [
+      process.env.NEXT_PUBLIC_SITE_URL,
+      process.env.NEXT_PUBLIC_FALLBACK_SITE_URL,
+      process.env.NEXT_PUBLIC_APP_URL,
+      process.env.VERCEL_PROJECT_PRODUCTION_URL
+        ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
+        : '',
+      process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : '',
+    ];
+
+    for (const candidate of candidates) {
+      if (!candidate || typeof candidate !== 'string') continue;
+      const trimmed = candidate.trim();
+      if (!trimmed) continue;
+      try {
+        const withScheme = trimmed.startsWith('http') ? trimmed : `https://${trimmed}`;
+        const url = new URL(withScheme);
+        return url.origin;
+      } catch {
+        continue;
+      }
+    }
+
+    if (process.env.NODE_ENV === 'development') {
+      return 'http://localhost:3000';
+    }
+
+    return 'https://laffy.ai';
+  };
+
+  const origin = resolveOrigin();
   const toAbs = (u) => {
     if (!u) return '';
     try {


### PR DESCRIPTION
## 요약
- VideoSocialMeta 컴포넌트에 canonical URL 및 Open Graph 비디오 메타 태그를 보강하여 플레이어 카드 인식을 높였습니다.
- K 라우트의 정적/임베드 페이지에서 절대 경로 계산을 개선해 트위터 플레이어가 항상 HTTPS 임베드 주소를 받도록 했습니다.

## 테스트
- `npm run lint` (기존 린트 오류 다수로 실패)


------
https://chatgpt.com/codex/tasks/task_e_68da57b4ff448323839f75cdc71cc90e