### PR TITLE
스마트링크 리다이렉트를 포함한 트위터 비디오 카드 개선

### DIFF
--- a/components/x/meta/VideoSocialMeta.jsx
+++ b/components/x/meta/VideoSocialMeta.jsx
@@ -24,6 +24,9 @@ export default function VideoSocialMeta({ seo, title, description, player = {} }
     const streamContentType = typeof player.streamContentType === "string" ? player.streamContentType : null;
     const width = Number.isFinite(player.width) ? String(player.width) : null;
     const height = Number.isFinite(player.height) ? String(player.height) : null;
+    const resolvedStreamContentType = streamContentType || (streamUrl ? "video/mp4" : null);
+    const hasVideo = Boolean(playerUrl || streamUrl);
+    const twitterCardType = hasVideo ? "player" : "summary_large_image";
 
     if (
         !playerUrl &&
@@ -39,21 +42,29 @@ export default function VideoSocialMeta({ seo, title, description, player = {} }
     return (
         <Head>
             {renderCanonicalElements(canonicalGroup)}
+            {canonicalGroup.canonicalUrl ? (
+                <meta property="og:url" content={canonicalGroup.canonicalUrl} />
+            ) : null}
+            <meta property="og:type" content={hasVideo ? "video.other" : "website"} />
             {thumbnailUrl ? <meta property="og:image" content={thumbnailUrl} /> : null}
+            {thumbnailUrl ? <meta property="og:image:secure_url" content={thumbnailUrl} /> : null}
             {streamUrl ? <meta property="og:video" content={streamUrl} /> : null}
+            {streamUrl ? <meta property="og:video:url" content={streamUrl} /> : null}
             {streamUrl ? <meta property="og:video:secure_url" content={streamUrl} /> : null}
-            {streamContentType ? <meta property="og:video:type" content={streamContentType} /> : null}
+            {resolvedStreamContentType ? (
+                <meta property="og:video:type" content={resolvedStreamContentType} />
+            ) : null}
             {width ? <meta property="og:video:width" content={width} /> : null}
             {height ? <meta property="og:video:height" content={height} /> : null}
             {safeTitle ? <meta property="og:title" content={safeTitle} /> : null}
             {safeDescription ? <meta property="og:description" content={safeDescription} /> : null}
-            <meta name="twitter:card" content="player" />
+            <meta name="twitter:card" content={twitterCardType} />
             {playerUrl ? <meta name="twitter:player" content={playerUrl} /> : null}
             {width ? <meta name="twitter:player:width" content={width} /> : null}
             {height ? <meta name="twitter:player:height" content={height} /> : null}
             {streamUrl ? <meta name="twitter:player:stream" content={streamUrl} /> : null}
-            {streamContentType ? (
-                <meta name="twitter:player:stream:content_type" content={streamContentType} />
+            {resolvedStreamContentType ? (
+                <meta name="twitter:player:stream:content_type" content={resolvedStreamContentType} />
             ) : null}
             {thumbnailUrl ? <meta name="twitter:image" content={thumbnailUrl} /> : null}
             {safeTitle ? <meta name="twitter:title" content={safeTitle} /> : null}

--- a/lib/admin/normalizeMeta.js
+++ b/lib/admin/normalizeMeta.js
@@ -16,6 +16,7 @@ const DEFAULT_META = {
   poster: '',
   thumbnail: '',
   src: '',
+  smartLinkUrl: '',
   publishedAt: '',
   updatedAt: '',
   likes: 0,
@@ -48,6 +49,19 @@ function parseChannel(value) {
   const normalized = parseString(value).toLowerCase();
   if (VALID_CHANNELS.has(normalized)) return normalized;
   return 'x';
+}
+
+function pickFirstString(values) {
+  if (!Array.isArray(values)) return '';
+  for (const value of values) {
+    const parsed = parseString(value);
+    if (parsed) return parsed;
+  }
+  return '';
+}
+
+function resolveLinkCandidate(...values) {
+  return pickFirstString(values.flat());
 }
 
 function extractTimeline(meta) {
@@ -133,6 +147,12 @@ export default function normalizeMeta(meta) {
     const thumbUrl = parseString(media.thumbUrl);
     const orientation = parseOrientation(media.orientation ?? meta.orientation);
 
+    const linksBlock = meta && typeof meta.links === 'object' && meta.links ? meta.links : {};
+    const actionsBlock = meta && typeof meta.actions === 'object' && meta.actions ? meta.actions : {};
+    const shareBlock = meta && typeof meta.share === 'object' && meta.share ? meta.share : {};
+    const destinationsBlock =
+      meta && typeof meta.destinations === 'object' && meta.destinations ? meta.destinations : {};
+
     const timestampBlock =
       meta && typeof meta.timestamps === 'object' && !Array.isArray(meta.timestamps)
         ? meta.timestamps
@@ -148,6 +168,28 @@ export default function normalizeMeta(meta) {
     const poster = previewUrl || assetUrl;
     const thumbnail = thumbUrl || previewUrl || assetUrl;
 
+    const smartLinkUrl = resolveLinkCandidate(
+      linksBlock.smartLinkUrl,
+      linksBlock.smartLink,
+      linksBlock.smart,
+      linksBlock.redirectUrl,
+      linksBlock.redirect,
+      linksBlock.landingUrl,
+      linksBlock.externalUrl,
+      linksBlock.outboundUrl,
+      linksBlock.url,
+      actionsBlock.primary && [actionsBlock.primary.url, actionsBlock.primary.href, actionsBlock.primary.link],
+      actionsBlock.secondary && [actionsBlock.secondary.url, actionsBlock.secondary.href, actionsBlock.secondary.link],
+      shareBlock && [shareBlock.url, shareBlock.webUrl, shareBlock.permalink, shareBlock.shareUrl],
+      destinationsBlock && [destinationsBlock.smartLinkUrl, destinationsBlock.landingUrl, destinationsBlock.url],
+      meta.smartLinkUrl,
+      meta.smartlink,
+      meta.redirectUrl,
+      meta.redirect,
+      meta.shareUrl,
+      meta.externalUrl
+    );
+
     normalized.slug = slug;
     normalized.type = type;
     normalized.title = socialTitle || cardTitle || summary || slug;
@@ -160,6 +202,7 @@ export default function normalizeMeta(meta) {
     normalized.poster = poster;
     normalized.thumbnail = thumbnail;
     normalized.src = assetUrl;
+    normalized.smartLinkUrl = smartLinkUrl;
     normalized.publishedAt = publishedAt;
     normalized.updatedAt = updatedAt;
     normalized.likes = likesMetric;
@@ -184,6 +227,20 @@ export default function normalizeMeta(meta) {
     const thumbnail = parseString(meta.thumbnail) || poster;
     const src = parseString(meta.src) || parseString(meta.url);
 
+    const linksBlock = meta && typeof meta.links === 'object' && meta.links ? meta.links : {};
+    const smartLinkUrl = resolveLinkCandidate(
+      meta.smartLinkUrl,
+      meta.smartlink,
+      meta.redirectUrl,
+      meta.redirect,
+      linksBlock.smartLinkUrl,
+      linksBlock.smartLink,
+      linksBlock.redirectUrl,
+      linksBlock.redirect,
+      linksBlock.landingUrl,
+      linksBlock.url
+    );
+
     normalized.slug = slug;
     normalized.type = type;
     normalized.title = title || description || summary || slug;
@@ -196,6 +253,7 @@ export default function normalizeMeta(meta) {
     normalized.poster = poster;
     normalized.thumbnail = thumbnail;
     normalized.src = src;
+    normalized.smartLinkUrl = smartLinkUrl;
     normalized.publishedAt = publishedAtFallback;
     normalized.updatedAt = updatedAtFallback;
     normalized.likes = likes;

--- a/pages/k/[slug].js
+++ b/pages/k/[slug].js
@@ -133,8 +133,11 @@ export async function getStaticProps({ params, locale }) {
     return { notFound: true };
   }
 
-  const redirectUrl = typeof meme.src === 'string' ? meme.src : '';
-  if (!redirectUrl) {
+  const assetUrl = typeof meme.src === 'string' ? meme.src : '';
+  const smartLinkUrl = typeof meme.smartLinkUrl === 'string' ? meme.smartLinkUrl : '';
+  const redirectSource = smartLinkUrl || assetUrl;
+
+  if (!redirectSource) {
     return { notFound: true };
   }
 
@@ -157,7 +160,8 @@ export async function getStaticProps({ params, locale }) {
   const canonicalUrl = origin ? `${origin}/k/${params.slug}` : '';
   const embedUrl = origin ? `${origin}/k/embed/${params.slug}` : '';
   const thumb = toAbs(meme.poster || meme.thumbnail || '');
-  const absoluteRedirect = toAbs(redirectUrl);
+  const absoluteAsset = toAbs(assetUrl);
+  const absoluteRedirect = toAbs(redirectSource);
   const uploadDate = meme.publishedAt || new Date().toISOString();
   const hreflangs = ['ko', 'en'].map((lng) => ({ hrefLang: lng, href: `${origin}/k/${params.slug}?locale=${lng}` }));
   hreflangs.push({ hrefLang: 'x-default', href: `${origin}/k/${params.slug}` });
@@ -168,7 +172,7 @@ export async function getStaticProps({ params, locale }) {
     name: normalizedMeme.title,
     description: normalizedMeme.description,
     thumbnailUrl: thumb || undefined,
-    contentUrl: absoluteRedirect || undefined,
+    contentUrl: absoluteAsset || absoluteRedirect || undefined,
     uploadDate,
   };
 
@@ -184,20 +188,24 @@ export async function getStaticProps({ params, locale }) {
     hreflangs,
     jsonLd,
     metaImage: thumb,
-    player: {
-      playerUrl: embedUrl || undefined,
-      streamUrl: absoluteRedirect || undefined,
-      streamContentType: meme.mimeType || 'video/mp4',
-      thumbnailUrl: thumb || undefined,
-      width: playerDimensions.width,
-      height: playerDimensions.height,
-    },
+    ...(absoluteAsset
+      ? {
+          player: {
+            playerUrl: embedUrl || undefined,
+            streamUrl: absoluteAsset,
+            streamContentType: meme.mimeType || 'video/mp4',
+            thumbnailUrl: thumb || undefined,
+            width: playerDimensions.width,
+            height: playerDimensions.height,
+          },
+        }
+      : {}),
   };
 
   return {
     props: {
       meme: normalizedMeme,
-      redirectUrl,
+      redirectUrl: absoluteRedirect,
       ...(await serverSideTranslations(locale ?? 'en', ['common'])),
     },
     revalidate: 60,

--- a/pages/k/embed/[slug].js
+++ b/pages/k/embed/[slug].js
@@ -76,8 +76,8 @@ export async function getStaticProps({ params, locale }) {
     return { notFound: true };
   }
 
-  const redirectUrl = typeof meme.src === 'string' ? meme.src : '';
-  if (!redirectUrl) {
+  const assetUrl = typeof meme.src === 'string' ? meme.src : '';
+  if (!assetUrl) {
     return { notFound: true };
   }
 
@@ -100,7 +100,7 @@ export async function getStaticProps({ params, locale }) {
   const canonicalUrl = origin ? `${origin}/k/${params.slug}` : '';
   const embedUrl = origin ? `${origin}/k/embed/${params.slug}` : '';
   const thumb = toAbs(meme.poster || meme.thumbnail || '');
-  const absoluteRedirect = toAbs(redirectUrl);
+  const absoluteAsset = toAbs(assetUrl);
   const uploadDate = meme.publishedAt || new Date().toISOString();
   const hreflangs = ['ko', 'en'].map((lng) => ({ hrefLang: lng, href: `${origin}/k/${params.slug}?locale=${lng}` }));
   hreflangs.push({ hrefLang: 'x-default', href: `${origin}/k/${params.slug}` });
@@ -111,7 +111,7 @@ export async function getStaticProps({ params, locale }) {
     name: normalizedMeme.title,
     description: normalizedMeme.description,
     thumbnailUrl: thumb || undefined,
-    contentUrl: absoluteRedirect || undefined,
+    contentUrl: absoluteAsset || undefined,
     uploadDate,
   };
 
@@ -129,7 +129,7 @@ export async function getStaticProps({ params, locale }) {
     metaImage: thumb,
     player: {
       playerUrl: embedUrl || undefined,
-      streamUrl: absoluteRedirect || undefined,
+      streamUrl: absoluteAsset || undefined,
       streamContentType: meme.mimeType || 'video/mp4',
       thumbnailUrl: thumb || undefined,
       width: playerDimensions.width,
@@ -140,7 +140,7 @@ export async function getStaticProps({ params, locale }) {
   return {
     props: {
       meme: normalizedMeme,
-      embedSrc: absoluteRedirect,
+      embedSrc: absoluteAsset,
       ...(await serverSideTranslations(locale ?? 'en', ['common'])),
     },
     revalidate: 60,

--- a/utils/contentSource.js
+++ b/utils/contentSource.js
@@ -81,6 +81,7 @@ function normalize(meta) {
     slug: normalized.slug,
     type: normalized.type || 'video',
     src: normalized.src || '',
+    smartLinkUrl: normalized.smartLinkUrl || '',
     poster,
     title: normalized.title || '',
     description: normalized.description || '',


### PR DESCRIPTION
## 요약
- 메타 파일에서 스마트링크 후보 URL을 파싱해 콘텐츠에 저장하도록 normalize 로직을 확장했습니다.
- K 라우트와 임베드 페이지에서 스마트링크로 리다이렉트하면서도 CDN 동영상으로 트위터 플레이어 카드를 구성하도록 메타 데이터를 정비했습니다.
- 비디오 소셜 메타 태그에 기본 MIME 타입, OG/Twitter 속성 보강 등 안정화를 진행했습니다.

## 테스트
- npm run lint *(현행 ESLint 설정 상 React in scope/prop-types 오류 다수로 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68da57b4ff448323839f75cdc71cc90e