### PR TITLE
트위터 플레이어 카드 스트림 메타 태그 추가

### DIFF
--- a/components/x/meta/VideoSocialMeta.jsx
+++ b/components/x/meta/VideoSocialMeta.jsx
@@ -23,6 +23,8 @@ export default function VideoSocialMeta({ seo, title, description, player = {} }
     const thumbnailUrl = typeof player.thumbnailUrl === "string" ? player.thumbnailUrl : null;
     const width = Number.isFinite(player.width) ? String(player.width) : null;
     const height = Number.isFinite(player.height) ? String(player.height) : null;
+    const streamContentType =
+        typeof player.streamContentType === "string" ? player.streamContentType : null;
     const hasStream = Boolean(streamUrl);
     const twitterCardType = playerUrl ? "player" : "summary_large_image";
 
@@ -48,12 +50,22 @@ export default function VideoSocialMeta({ seo, title, description, player = {} }
             {thumbnailUrl ? <meta property="og:image:secure_url" content={thumbnailUrl} /> : null}
             {streamUrl ? <meta property="og:video" content={streamUrl} /> : null}
             {streamUrl ? <meta property="og:video:url" content={streamUrl} /> : null}
+            {streamUrl ? <meta property="og:video:secure_url" content={streamUrl} /> : null}
+            {streamContentType ? (
+                <meta property="og:video:type" content={streamContentType} />
+            ) : null}
+            {width ? <meta property="og:video:width" content={width} /> : null}
+            {height ? <meta property="og:video:height" content={height} /> : null}
             {safeTitle ? <meta property="og:title" content={safeTitle} /> : null}
             {safeDescription ? <meta property="og:description" content={safeDescription} /> : null}
             <meta name="twitter:card" content={twitterCardType} />
             {playerUrl ? <meta name="twitter:player" content={playerUrl} /> : null}
             {width ? <meta name="twitter:player:width" content={width} /> : null}
             {height ? <meta name="twitter:player:height" content={height} /> : null}
+            {streamUrl ? <meta name="twitter:player:stream" content={streamUrl} /> : null}
+            {streamContentType ? (
+                <meta name="twitter:player:stream:content_type" content={streamContentType} />
+            ) : null}
             {thumbnailUrl ? <meta name="twitter:image" content={thumbnailUrl} /> : null}
             {safeTitle ? <meta name="twitter:title" content={safeTitle} /> : null}
             {safeDescription ? <meta name="twitter:description" content={safeDescription} /> : null}


### PR DESCRIPTION
## 요약
- VideoSocialMeta 컴포넌트에 Twitter/OG 스트림 메타 태그를 보강하여 트위터 카드 재생 호환성 향상

## 테스트
- npm run lint (실패, 기존 ESLint 규칙 위반 다수)


------
https://chatgpt.com/codex/tasks/task_e_68da6a57a81883239dd8a266ccbb2e2a