### PR TITLE
feat: 관리자 업로드 대기 게시 흐름 추가

### DIFF
--- a/components/admin/uploads/PendingUploadsPanel.jsx
+++ b/components/admin/uploads/PendingUploadsPanel.jsx
@@ -1,0 +1,167 @@
+import { useEffect } from 'react';
+
+const CHANNEL_LABELS = {
+  l: 'L 채널',
+  k: 'K 채널',
+  x: 'X 채널',
+  g: 'Gofile 채널',
+};
+
+function formatRelativeTime(value) {
+  if (!value) return '';
+  try {
+    const target = new Date(value);
+    if (Number.isNaN(target.getTime())) return '';
+    const now = new Date();
+    const diffMs = now.getTime() - target.getTime();
+    const diffMinutes = Math.floor(diffMs / 60000);
+    if (diffMinutes < 1) return '방금 전';
+    if (diffMinutes < 60) return `${diffMinutes}분 전`;
+    const diffHours = Math.floor(diffMinutes / 60);
+    if (diffHours < 24) return `${diffHours}시간 전`;
+    const diffDays = Math.floor(diffHours / 24);
+    if (diffDays < 7) return `${diffDays}일 전`;
+    return target.toLocaleString('ko-KR', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch (error) {
+    console.error('Failed to format time', value, error);
+    return '';
+  }
+}
+
+export default function PendingUploadsPanel({
+  items = [],
+  isLoading = false,
+  onRefresh = () => {},
+  onPublish = () => {},
+  onDelete = () => {},
+  hasToken = false,
+  publishingSlug = '',
+  publishFeedback,
+}) {
+  const feedback = publishFeedback || { status: 'idle', message: '' };
+
+  useEffect(() => {
+    if (!feedback?.message || feedback.status === 'idle') return undefined;
+    const timer = setTimeout(() => {
+      if (typeof feedback.onClear === 'function') {
+        feedback.onClear();
+      }
+    }, 4000);
+    return () => clearTimeout(timer);
+  }, [feedback]);
+
+  return (
+    <div className="space-y-4 rounded-3xl border border-slate-800/60 bg-slate-950/60 p-6 shadow-inner shadow-cyan-900/20">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="space-y-2">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.38em] text-slate-400">게시 대기중</p>
+          <h3 className="text-xl font-semibold text-slate-50">검토 후 게시를 완료하세요</h3>
+          <p className="text-sm leading-relaxed text-slate-300">
+            새로 업로드한 콘텐츠는 먼저 이곳에 쌓입니다. 검토 후 게시하기 버튼을 눌러 채널 목록으로 이동시켜 주세요.
+          </p>
+          {feedback?.message && (
+            <p
+              className={`rounded-xl px-3 py-2 text-xs ${
+                feedback.status === 'success'
+                  ? 'bg-emerald-500/10 text-emerald-200'
+                  : feedback.status === 'error'
+                    ? 'bg-rose-500/10 text-rose-200'
+                    : 'bg-slate-800/70 text-slate-200'
+              }`}
+            >
+              {feedback.message}
+            </p>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onRefresh}
+            className="rounded-full border border-slate-700/70 px-4 py-2 text-xs font-semibold text-slate-200 transition hover:border-slate-500 hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={isLoading}
+          >
+            대기 목록 새로고침
+          </button>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="rounded-2xl border border-slate-800/60 bg-slate-950/40 p-6 text-sm text-slate-300">
+          대기중인 콘텐츠를 불러오는 중입니다…
+        </div>
+      ) : items.length === 0 ? (
+        <div className="rounded-2xl border border-slate-800/60 bg-slate-950/40 p-6 text-sm text-slate-400">
+          현재 게시 대기중인 콘텐츠가 없습니다.
+        </div>
+      ) : (
+        <div className="grid gap-4">
+          {items.map((item) => {
+            const channelLabel = CHANNEL_LABELS[item.channel] || '기타 채널';
+            const pendingLabel = formatRelativeTime(item.pendingAt || item.uploadedAt);
+            const isPublishing = publishingSlug === item.slug;
+            return (
+              <div
+                key={item.pathname || item.slug}
+                className="flex flex-col gap-4 rounded-2xl border border-slate-800/60 bg-[#060c1d]/80 p-4 shadow-lg shadow-indigo-900/10 md:flex-row"
+              >
+                <div className="w-full max-w-[220px] overflow-hidden rounded-xl border border-slate-800/70 bg-slate-950/70">
+                  {item.preview ? (
+                    <img src={item.preview} alt={item.title || item.slug} className="h-40 w-full object-cover" />
+                  ) : (
+                    <div className="grid h-40 place-items-center text-xs uppercase tracking-[0.32em] text-slate-500">
+                      No Preview
+                    </div>
+                  )}
+                </div>
+                <div className="flex flex-1 flex-col gap-3">
+                  <div className="space-y-2">
+                    <div className="font-mono text-sm font-semibold text-cyan-200">{item.slug}</div>
+                    <h4 className="text-base font-semibold text-slate-100">{item.title || '제목 없음'}</h4>
+                    <div className="flex flex-wrap items-center gap-2 text-xs text-slate-400">
+                      <span className="rounded-full border border-slate-700/70 px-2 py-0.5 text-[11px] text-slate-300">
+                        {channelLabel}
+                      </span>
+                      <span className="rounded-full border border-slate-700/70 px-2 py-0.5 text-[11px] text-slate-400">
+                        {item.type === 'image' ? '이미지' : '영상'}
+                      </span>
+                      {pendingLabel && (
+                        <span className="text-[11px] text-slate-500">{pendingLabel} 대기 시작</span>
+                      )}
+                    </div>
+                    {item.summary && (
+                      <p className="text-sm text-slate-300">{item.summary}</p>
+                    )}
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2 pt-2">
+                    <button
+                      type="button"
+                      onClick={() => onPublish(item)}
+                      disabled={!hasToken || isPublishing}
+                      className="rounded-xl border border-emerald-400/60 bg-emerald-500/20 px-4 py-2 text-sm font-semibold text-emerald-100 transition hover:border-emerald-300/80 hover:text-emerald-50 disabled:cursor-not-allowed disabled:border-emerald-900 disabled:text-emerald-400"
+                    >
+                      {isPublishing ? '게시 중…' : '게시하기'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onDelete(item)}
+                      disabled={!hasToken}
+                      className="rounded-xl border border-rose-500/60 px-4 py-2 text-sm font-semibold text-rose-100 transition hover:border-rose-400/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-200 disabled:cursor-not-allowed disabled:border-rose-900 disabled:text-rose-400"
+                    >
+                      삭제
+                    </button>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/admin/uploads/UploadForm.jsx
+++ b/components/admin/uploads/UploadForm.jsx
@@ -23,8 +23,8 @@ export default function UploadForm({
     : 'image/jpeg,image/png,image/webp,video/mp4';
   const uploadHeading = isKChannel ? '썸네일 이미지 업로드' : '파일 업로드';
   const uploadHint = isKChannel
-    ? '플레이어 카드와 공유 썸네일로 사용할 이미지를 업로드하세요. 동영상은 외부 CDN 주소를 통해 재생됩니다.'
-    : '이미지 또는 영상을 업로드하면 즉시 메타 정보가 저장됩니다.';
+    ? '플레이어 카드와 공유 썸네일로 사용할 이미지를 업로드하세요. 검토 후 게시하기를 눌러 채널에 반영됩니다.'
+    : '이미지 또는 영상을 업로드하면 게시 대기 목록에 먼저 저장된 뒤 게시하기 버튼으로 채널에 반영됩니다.';
   const externalLabel = isGChannel ? '자동 생성됨' : '외부 CDN 동영상 URL';
   const externalPlaceholder = isGChannel
     ? '자동으로 스마트링크가 연결됩니다'
@@ -41,7 +41,7 @@ export default function UploadForm({
         <p className="text-[11px] font-semibold uppercase tracking-[0.38em] text-slate-300">콘텐츠 업로드</p>
         <h3 className="text-xl font-semibold text-slate-50">간편하게 새 콘텐츠를 등록하세요</h3>
         <p className="text-sm leading-relaxed text-slate-300">
-          제목과 채널만 지정하면 파일을 올리는 즉시 메타 정보가 자동으로 저장됩니다.
+          제목과 채널만 지정하면 새 업로드가 게시 대기 영역에 저장됩니다. 검토 후 게시하기 버튼을 눌러 주세요.
         </p>
       </div>
       <div className="space-y-4">

--- a/components/admin/uploads/UploadsSection.jsx
+++ b/components/admin/uploads/UploadsSection.jsx
@@ -3,6 +3,7 @@ import UploadFilters from './UploadFilters';
 import UploadForm from './UploadForm';
 import UploadedItemCard from './UploadedItemCard';
 import buildRegisterPayload from '@/lib/admin/buildRegisterPayload';
+import PendingUploadsPanel from './PendingUploadsPanel';
 
 export default function UploadsSection({
   hasToken,
@@ -23,6 +24,12 @@ export default function UploadsSection({
   filters,
   onFiltersChange,
   tokenQueryString,
+  pendingItems = [],
+  onRefreshPending,
+  onPublishPending,
+  isLoadingPending = false,
+  publishingSlug = '',
+  pendingFeedback = null,
 }) {
   const queryString = typeof tokenQueryString === 'string' ? tokenQueryString : '';
   const [selectedIds, setSelectedIds] = useState(() => new Set());
@@ -32,6 +39,7 @@ export default function UploadsSection({
   const [bulkTagForm, setBulkTagForm] = useState({ type: '' });
   const [isTagSubmitting, setIsTagSubmitting] = useState(false);
   const handleRefresh = onRefresh || (() => {});
+  const handleRefreshPending = onRefreshPending || (() => {});
   const handleLoadMore = onLoadMore || (() => {});
 
   const {
@@ -295,13 +303,25 @@ export default function UploadsSection({
 
   return (
     <section className="space-y-6 animate-fade-slide">
+      {hasToken && (
+        <PendingUploadsPanel
+          items={pendingItems}
+          isLoading={isLoadingPending}
+          onRefresh={handleRefreshPending}
+          onPublish={onPublishPending}
+          onDelete={onDelete}
+          hasToken={hasToken}
+          publishingSlug={publishingSlug}
+          publishFeedback={pendingFeedback}
+        />
+      )}
       <div className="space-y-6 rounded-3xl border border-slate-800/60 bg-gradient-to-r from-[#050916]/90 via-[#060b1c]/80 to-[#0a1124]/90 p-6 shadow-lg shadow-cyan-900/20">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
           <div className="space-y-2">
             <p className="text-[11px] font-semibold uppercase tracking-[0.48em] text-slate-400">콘텐츠 관리</p>
             <h2 className="text-2xl font-semibold text-slate-50">업로드한 자료를 한눈에 살펴보세요</h2>
             <p className="text-sm text-slate-300">
-              {activeChannelLabel} {items.length}개를 손쉽게 정리하고 공유할 수 있어요.
+              {activeChannelLabel} {items.length}개를 손쉽게 정리하고 공유할 수 있어요. 게시된 목록만 집계합니다.
             </p>
           </div>
           <div className="flex flex-wrap items-center gap-2">

--- a/hooks/admin/usePendingUploads.js
+++ b/hooks/admin/usePendingUploads.js
@@ -1,0 +1,57 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+export default function usePendingUploads({ enabled, queryString }) {
+  const [items, setItems] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const qs = useMemo(() => {
+    if (!queryString) return '';
+    return queryString.startsWith('?') || queryString.startsWith('&')
+      ? queryString
+      : `?${queryString}`;
+  }, [queryString]);
+
+  const fetchItems = useCallback(async () => {
+    if (!enabled) {
+      setItems([]);
+      setError(null);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const res = await fetch(`/api/admin/pending/list${qs}`);
+      if (!res.ok) {
+        throw new Error(`request_failed_${res.status}`);
+      }
+      const data = await res.json();
+      setItems(Array.isArray(data?.items) ? data.items : []);
+      setError(null);
+    } catch (err) {
+      console.error('Failed to load pending uploads', err);
+      setItems([]);
+      setError(err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [enabled, qs]);
+
+  useEffect(() => {
+    if (!enabled) {
+      setItems([]);
+      setError(null);
+      return;
+    }
+    fetchItems();
+  }, [enabled, fetchItems]);
+
+  return {
+    items,
+    setItems,
+    refresh: fetchItems,
+    isLoading,
+    error,
+  };
+}

--- a/lib/admin/slug.js
+++ b/lib/admin/slug.js
@@ -1,0 +1,60 @@
+import { randomBytes } from 'crypto';
+import { list } from '@vercel/blob';
+
+const SLUG_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+
+function generateRandomSlugInternal(length = 6) {
+  try {
+    const bytes = randomBytes(length);
+    let result = '';
+    for (let i = 0; i < length; i += 1) {
+      result += SLUG_ALPHABET[bytes[i] % SLUG_ALPHABET.length];
+    }
+    return result;
+  } catch (error) {
+    console.error('Failed to generate random slug via crypto.randomBytes, fallback to Math.random', error);
+    let result = '';
+    for (let i = 0; i < length; i += 1) {
+      result += SLUG_ALPHABET[Math.floor(Math.random() * SLUG_ALPHABET.length)];
+    }
+    return result;
+  }
+}
+
+async function hasBlobAtPrefix(prefix, token) {
+  try {
+    const response = await list({ prefix, token, limit: 1 });
+    return Array.isArray(response?.blobs) && response.blobs.length > 0;
+  } catch (error) {
+    console.error('Failed to verify blob existence', prefix, error);
+    return false;
+  }
+}
+
+export async function isSlugTaken({ folder, slug, includePending = true }) {
+  if (!folder || !slug) return false;
+  const token = process.env.BLOB_READ_WRITE_TOKEN;
+  if (!token) return false;
+  const publishedPrefix = `content/${folder}/${slug}.json`;
+  const pendingPrefix = `content/pending/${slug}.json`;
+  const [publishedExists, pendingExists] = await Promise.all([
+    hasBlobAtPrefix(publishedPrefix, token),
+    includePending ? hasBlobAtPrefix(pendingPrefix, token) : Promise.resolve(false),
+  ]);
+  return publishedExists || pendingExists;
+}
+
+export async function generateUniqueSlug(folder, { includePending = true } = {}, attempt = 0) {
+  if (attempt >= 20) {
+    throw new Error('Unable to allocate unique slug');
+  }
+  const candidate = generateRandomSlugInternal();
+  if (await isSlugTaken({ folder, slug: candidate, includePending })) {
+    return generateUniqueSlug(folder, { includePending }, attempt + 1);
+  }
+  return candidate;
+}
+
+export function generateRandomSlug(length = 6) {
+  return generateRandomSlugInternal(length);
+}

--- a/pages/api/admin/list.js
+++ b/pages/api/admin/list.js
@@ -224,7 +224,10 @@ export default async function handler(req, res) {
       });
 
       const blobs = Array.isArray(response?.blobs)
-        ? response.blobs.filter((blob) => blob?.pathname?.endsWith('.json'))
+        ? response.blobs.filter(
+            (blob) =>
+              blob?.pathname?.endsWith('.json') && !blob.pathname.startsWith('content/pending/')
+          )
         : [];
 
       if (!blobs.length) {

--- a/pages/api/admin/pending/list.js
+++ b/pages/api/admin/pending/list.js
@@ -1,0 +1,142 @@
+import { assertAdmin } from '../_auth';
+import { list } from '@vercel/blob';
+import { getBlobReadToken } from '@/utils/blobTokens';
+import normalizeMeta from '@/lib/admin/normalizeMeta';
+
+const MAX_PENDING_RESULTS = 120;
+const PAGE_LIMIT = 60;
+const MAX_ITERATIONS = 20;
+
+function parseISOString(value) {
+  if (typeof value !== 'string') return '';
+  const trimmed = value.trim();
+  if (!trimmed) return '';
+  const parsed = Date.parse(trimmed);
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : '';
+}
+
+function parseTimestamp(value) {
+  if (!value) return 0;
+  if (value instanceof Date) {
+    const time = value.getTime();
+    return Number.isFinite(time) ? time : 0;
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : 0;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return 0;
+    const parsed = Date.parse(trimmed);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+function buildPendingItem(blob, meta) {
+  const normalized = normalizeMeta(meta);
+  const pendingBlock =
+    meta && typeof meta.timestamps === 'object' && !Array.isArray(meta.timestamps)
+      ? meta.timestamps
+      : {};
+  const pendingAt = parseISOString(pendingBlock.pendingAt || pendingBlock.createdAt || '');
+
+  return {
+    pathname: blob.pathname,
+    url: blob.url,
+    size: blob.size,
+    uploadedAt: blob.uploadedAt,
+    slug: normalized.slug || blob.pathname?.replace(/^content\/pending\//, '').replace(/\.json$/, '') || '',
+    type: normalized.type || 'video',
+    channel: normalized.channel || 'x',
+    title: normalized.title || normalized.slug || '',
+    summary: normalized.summary || '',
+    description: normalized.description || '',
+    preview: normalized.preview || normalized.thumbnail || normalized.poster || '',
+    poster: normalized.poster || '',
+    thumbnail: normalized.thumbnail || '',
+    src: normalized.src || '',
+    orientation: normalized.orientation || 'landscape',
+    durationSeconds: Number.isFinite(normalized.durationSeconds) ? normalized.durationSeconds : 0,
+    likes: Number.isFinite(normalized.likes) ? normalized.likes : 0,
+    views: Number.isFinite(normalized.views) ? normalized.views : 0,
+    timestamps: Array.isArray(normalized.timestamps) ? normalized.timestamps : [],
+    status: typeof meta?.status === 'string' ? meta.status : 'pending',
+    pendingAt,
+  };
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') return res.status(405).end();
+  if (!assertAdmin(req, res)) return;
+
+  try {
+    const token = getBlobReadToken();
+    if (!token) {
+      return res.status(503).json({ error: 'Blob access token unavailable' });
+    }
+
+    let cursor;
+    let iterations = 0;
+    const collected = [];
+
+    while (collected.length < MAX_PENDING_RESULTS && iterations < MAX_ITERATIONS) {
+      const response = await list({
+        prefix: 'content/pending/',
+        token,
+        limit: PAGE_LIMIT,
+        cursor,
+      });
+
+      const blobs = Array.isArray(response?.blobs)
+        ? response.blobs.filter((blob) => blob?.pathname?.endsWith('.json'))
+        : [];
+
+      if (!blobs.length) {
+        break;
+      }
+
+      const metas = await Promise.all(
+        blobs.map(async (blob) => {
+          if (!blob?.url) return null;
+          try {
+            const resp = await fetch(blob.url, { cache: 'no-store' });
+            if (!resp.ok) return null;
+            return await resp.json();
+          } catch (error) {
+            console.error('Failed to fetch pending meta', blob.pathname, error);
+            return null;
+          }
+        })
+      );
+
+      blobs.forEach((blob, index) => {
+        const meta = metas[index];
+        if (!meta) return;
+        collected.push(buildPendingItem(blob, meta));
+      });
+
+      cursor = response?.cursor;
+      if (!cursor) {
+        break;
+      }
+
+      iterations += 1;
+    }
+
+    const sorted = collected.sort((a, b) => {
+      const aTime = parseTimestamp(a.pendingAt) || parseTimestamp(a.uploadedAt);
+      const bTime = parseTimestamp(b.pendingAt) || parseTimestamp(b.uploadedAt);
+      return bTime - aTime;
+    });
+
+    res.status(200).json({ items: sorted });
+  } catch (error) {
+    console.error('Failed to list pending uploads', error);
+    res.status(500).json({ error: 'Failed to list pending uploads' });
+  }
+}
+
+export const config = {
+  runtime: 'nodejs',
+};

--- a/pages/api/admin/pending/publish.js
+++ b/pages/api/admin/pending/publish.js
@@ -1,0 +1,125 @@
+import { assertAdmin } from '../_auth';
+import { del, list, put } from '@vercel/blob';
+import normalizeMeta from '@/lib/admin/normalizeMeta';
+import { generateUniqueSlug, isSlugTaken } from '@/lib/admin/slug';
+
+function parseString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function buildRevalidateTargets(channel, type, slug) {
+  const targets = new Set();
+  if (channel === 'l') {
+    targets.add('/l');
+    if (slug) targets.add(`/l/${slug}`);
+  } else if (channel === 'k') {
+    targets.add('/k');
+    if (slug) targets.add(`/k/${slug}`);
+  } else if (channel === 'g') {
+    targets.add('/gofile.io/d');
+    if (slug) targets.add(`/gofile.io/d/${slug}`);
+  } else if (type === 'image') {
+    targets.add('/x');
+    if (slug) targets.add(`/x/${slug}`);
+  } else {
+    targets.add('/m');
+    if (slug) targets.add(`/m/${slug}`);
+  }
+  return Array.from(targets);
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).end();
+  if (!assertAdmin(req, res)) return;
+
+  const slugInput = parseString(req.body?.slug);
+  if (!slugInput) {
+    return res.status(400).json({ error: 'Missing slug' });
+  }
+
+  const token = process.env.BLOB_READ_WRITE_TOKEN;
+  if (!token) {
+    return res.status(503).json({ error: 'Blob write token unavailable' });
+  }
+
+  try {
+    const { blobs } = await list({
+      prefix: `content/pending/${slugInput}.json`,
+      token,
+      limit: 1,
+    });
+    const blob = Array.isArray(blobs) && blobs.length > 0 ? blobs[0] : null;
+    if (!blob?.url) {
+      return res.status(404).json({ error: 'Pending entry not found' });
+    }
+
+    const pendingMetaRes = await fetch(blob.url, { cache: 'no-store' });
+    if (!pendingMetaRes.ok) {
+      return res.status(500).json({ error: 'Failed to fetch pending meta' });
+    }
+    const pendingMeta = await pendingMetaRes.json();
+    const normalized = normalizeMeta(pendingMeta);
+
+    const folder = normalized.type === 'image' ? 'images' : 'videos';
+    let finalSlug = normalized.slug || slugInput;
+    const channel = parseString(normalized.channel) || 'x';
+    const effectiveChannel = ['x', 'l', 'k', 'g'].includes(channel) ? channel : 'x';
+    const nowIso = new Date().toISOString();
+
+    if (await isSlugTaken({ folder, slug: finalSlug, includePending: false })) {
+      finalSlug = await generateUniqueSlug(folder, { includePending: false });
+    }
+
+    const timestampsBlock =
+      pendingMeta && typeof pendingMeta.timestamps === 'object' && !Array.isArray(pendingMeta.timestamps)
+        ? { ...pendingMeta.timestamps }
+        : {};
+    timestampsBlock.publishedAt = nowIso;
+    timestampsBlock.updatedAt = nowIso;
+
+    const publishedMeta = {
+      ...pendingMeta,
+      schemaVersion: '2024-05',
+      slug: finalSlug,
+      type: normalized.type === 'image' ? 'image' : 'video',
+      channel: effectiveChannel,
+      timestamps: timestampsBlock,
+    };
+    if (publishedMeta.status) {
+      delete publishedMeta.status;
+    }
+
+    const key = `content/${folder}/${finalSlug}.json`;
+    await put(key, JSON.stringify(publishedMeta, null, 2), {
+      token,
+      access: 'public',
+      contentType: 'application/json',
+      addRandomSuffix: false,
+      allowOverwrite: true,
+    });
+
+    await del(blob.url || blob.pathname, { token });
+
+    const revalidateTargets = buildRevalidateTargets(effectiveChannel, publishedMeta.type, finalSlug);
+    if (typeof res.revalidate === 'function') {
+      await Promise.all(
+        revalidateTargets.map(async (path) => {
+          try {
+            await res.revalidate(path);
+          } catch (error) {
+            console.error('Failed to revalidate path', path, error);
+          }
+        })
+      );
+    }
+
+    res.status(200).json({ ok: true, slug: finalSlug, key, revalidated: revalidateTargets });
+  } catch (error) {
+    console.error('Failed to publish pending item', error);
+    res.status(500).json({ error: 'Failed to publish pending item' });
+  }
+}
+
+export const config = {
+  runtime: 'nodejs',
+};


### PR DESCRIPTION
## 요약
- 관리자 업로드 페이지에 `게시 대기중` 패널을 추가하고 게시/삭제 액션을 제공했습니다.
- 신규 업로드가 먼저 대기 상태로 저장되도록 API와 등록 로직을 수정하고, 대기 목록 조회 및 게시 API를 구현했습니다.
- 슬러그 유틸을 공유 모듈로 분리하고 대기 목록 전용 훅과 UI 컴포넌트를 추가했습니다.

## 테스트
- `npm run lint` (Node.js 미설치로 실행 불가)


------
https://chatgpt.com/codex/tasks/task_e_68dccd5c9a64832395ee27473f420f59