### PR TITLE
관리자 업로드 목록 필터 기본값 및 더보기 버튼 개선

### DIFF
--- a/components/admin/uploads/UploadsSection.jsx
+++ b/components/admin/uploads/UploadsSection.jsx
@@ -523,20 +523,20 @@ export default function UploadsSection({
               {isFiltering ? '조건에 맞는 콘텐츠가 없습니다.' : '표시할 콘텐츠가 없습니다.'}
             </div>
           )}
-
-          {canShowLoadMore && (
-            <div className="col-span-full flex justify-center">
-              <button
-                type="button"
-                onClick={handleLoadMore}
-                disabled={isLoadingMore}
-                className="rounded-full bg-slate-800 px-6 py-2 text-sm font-semibold text-slate-200 transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:bg-slate-900 disabled:text-slate-500"
-              >
-                {isLoadingMore ? '불러오는 중…' : '더 보기'}
-              </button>
-            </div>
-          )}
         </div>
+
+        {canShowLoadMore && (
+          <div className="mt-8 flex justify-center">
+            <button
+              type="button"
+              onClick={handleLoadMore}
+              disabled={isLoadingMore}
+              className="inline-flex items-center justify-center rounded-full border border-slate-800/70 bg-slate-900/80 px-6 py-2 text-sm font-semibold text-slate-100 shadow-lg shadow-slate-950/40 transition-transform duration-300 hover:-translate-y-0.5 hover:border-sky-500/50 hover:bg-slate-800/80 hover:text-white focus:outline-none focus:ring-2 focus:ring-sky-500/40 disabled:cursor-not-allowed disabled:border-slate-800 disabled:text-slate-500 disabled:opacity-70"
+            >
+              {isLoadingMore ? '불러오는 중…' : '더 보기'}
+            </button>
+          </div>
+        )}
       </div>
 
       {isUploadModalOpen && (

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -126,7 +126,7 @@ export default function AdminPage() {
     search: '',
     type: '',
     sort: 'recent',
-    channel: 'k',
+    channel: '',
   });
 
   const uploadsQueryString = useMemo(() => {


### PR DESCRIPTION
## 요약
- 업로드 목록 채널 필터의 기본값을 전체로 변경하여 특정 채널에 속한 콘텐츠가 누락되지 않도록 했습니다.
- 업로드 카드 그리드 외부로 더 보기 버튼을 분리하고 스타일을 조정해 세로로 과도하게 늘어나는 문제를 해결했습니다.

## 테스트
- npm run lint *(실패: 기존 코드 전반의 lint 규칙 위반 다수)*

------
https://chatgpt.com/codex/tasks/task_e_68dd1214b730832380ac53c200eb120d